### PR TITLE
Add data-extractor skill for scientific figure digitization

### DIFF
--- a/clawbio.py
+++ b/clawbio.py
@@ -377,6 +377,14 @@ SKILLS = {
         "no_input_required": True,
         "accepts_genotypes": False,
     },
+    "data-extract": {
+        "script": SKILLS_DIR / "data-extractor" / "data_extractor.py",
+        "demo_args": ["--demo"],
+        "description": "Extract numerical data from scientific figure images (Claude vision + OpenCV)",
+        "allowed_extra_flags": {"--web", "--port", "--plot-type"},
+        "api_module": "skills.data-extractor.api",
+        "accepts_genotypes": False,
+    },
 }
 
 # Skills that run in the full-profile pipeline (order matters)

--- a/skills/bio-orchestrator/SKILL.md
+++ b/skills/bio-orchestrator/SKILL.md
@@ -43,6 +43,7 @@ You are the **Bio Orchestrator**, a ClawBio meta-agent for bioinformatics analys
 | Literature query | lit-synthesizer | "Find papers on X", "Summarise recent work on Y" |
 | Ancestry/population CSV | equity-scorer | "Score population diversity", "HEIM equity report" |
 | "Make reproducible" | repro-enforcer | "Export as Nextflow", "Create Singularity container" |
+| Image file (PNG/JPG/TIFF) | data-extractor | "Extract data from this figure", "Digitize this bar chart" |
 | Lab notebook query | labstep | "Show my experiments", "Find protocols", "List reagents" |
 
 ## Decision Process

--- a/skills/bio-orchestrator/orchestrator.py
+++ b/skills/bio-orchestrator/orchestrator.py
@@ -46,6 +46,11 @@ EXTENSION_MAP: dict[str, str] = {
     ".h5ad": "scrna-orchestrator",
     ".csv": "equity-scorer",
     ".tsv": "equity-scorer",
+    ".png": "data-extractor",
+    ".jpg": "data-extractor",
+    ".jpeg": "data-extractor",
+    ".tiff": "data-extractor",
+    ".tif": "data-extractor",
 }
 
 KEYWORD_MAP: dict[str, str] = {
@@ -103,6 +108,14 @@ KEYWORD_MAP: dict[str, str] = {
     "personal profile": "profile-report",
     "my profile": "profile-report",
     "genomic profile": "profile-report",
+    "digitize": "data-extractor",
+    "extract data": "data-extractor",
+    "plot data": "data-extractor",
+    "figure data": "data-extractor",
+    "read chart": "data-extractor",
+    "bar chart": "data-extractor",
+    "scatter plot": "data-extractor",
+    "meta-analysis": "data-extractor",
 }
 
 SKILLS_DIR = Path(__file__).resolve().parent.parent
@@ -219,6 +232,7 @@ SKILL_REGISTRY_MAP: dict[str, str] = {
     "clinpgx": "clinpgx",
     "gwas-lookup": "gwas",
     "profile-report": "profile",
+    "data-extractor": "data-extract",
 }
 
 

--- a/skills/data-extractor/SKILL.md
+++ b/skills/data-extractor/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: data-extractor
+description: Extract numerical data from scientific figure images using Claude vision + OpenCV calibration. Supports 26+ plot types including bar charts, scatter plots, forest plots, Kaplan-Meier curves, box plots, and more.
+version: 0.1.0
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - python3
+      env:
+        - ANTHROPIC_API_KEY
+      config: []
+    always: false
+    emoji: "📊"
+    homepage: https://github.com/ClawBio/ClawBio
+    os: [macos, linux]
+    install:
+      - kind: pip
+        package: anthropic
+        bins: []
+      - kind: pip
+        package: opencv-python-headless
+        bins: []
+      - kind: pip
+        package: numpy
+        bins: []
+      - kind: pip
+        package: Pillow
+        bins: []
+      - kind: pip
+        package: pydantic
+        bins: []
+      - kind: pip
+        package: fastapi
+        bins: []
+      - kind: pip
+        package: uvicorn
+        bins: []
+---
+
+# 📊 Data Extractor
+
+You are the **Data Extractor**, a ClawBio skill for digitizing scientific figures. Your role is to extract numerical data from plot images for meta-analyses and systematic reviews.
+
+## When to Use This Skill
+
+Route to this skill when the user:
+- Provides an image file (PNG, JPG, TIFF) containing a scientific figure
+- Asks to "extract data from a figure", "digitize a plot", "read values from a chart"
+- Mentions "meta-analysis data extraction" or "figure digitization"
+- Wants to convert a bar chart, scatter plot, or other figure to CSV/JSON
+
+## Capabilities
+
+### Supported Plot Types (26)
+scatter, bar, line, box, violin, histogram, heatmap, forest, kaplan_meier,
+dot_strip, stacked_bar, funnel, roc, volcano, waterfall, bland_altman,
+paired, bubble, area, dose_response, manhattan, correlation_matrix,
+error_bar, table, other
+
+### Pipeline (4 phases)
+1. **Panel Detection** — Identify sub-panels in multi-panel figures (Claude vision)
+2. **Pre-Analysis** — Identify axes, scale (linear/log), legend entries, error bars (Claude tool calling)
+3. **CV Calibration + Extraction** — OpenCV detects markers/bars at pixel level, Claude extracts numerical data with calibration context
+4. **Validation** — Heuristic checks for axis range, series count, error bar polarity
+
+### Output Formats
+- **CSV** — One row per data point with series name, x/y values, error bars
+- **JSON** — Structured ExtractedData objects with full metadata
+- **Web UI** — Interactive table + SVG preview with editable cells
+
+## Usage
+
+### CLI
+```bash
+python data_extractor.py --image figure.png --output results/
+python data_extractor.py --web --port 8765
+python data_extractor.py --demo
+```
+
+### API (importable)
+```python
+from api import run
+result = run(options={"image_path": "figure.png", "output_dir": "results/"})
+```
+
+### Web UI
+Launch with `--web` flag. Upload images, draw boxes around plots, extract and edit data interactively.
+
+## Input Formats
+- PNG, JPG, JPEG, TIFF image files
+- Screenshots from papers, posters, slides
+- Multi-panel composite figures (auto-detected and split)
+
+## Notes
+- Requires ANTHROPIC_API_KEY environment variable
+- Uses Claude Sonnet for pre-analysis/detection, Claude Opus for extraction
+- OpenCV calibration improves accuracy for scatter/bar plots with clear markers
+- Error bars are reported as ± extent (delta from mean), not absolute positions

--- a/skills/data-extractor/api.py
+++ b/skills/data-extractor/api.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""ClawBio skill API — data-extractor.
+
+Importable run() interface following ClawBio conventions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+# Ensure skill root is on sys.path for core imports
+_SKILL_DIR = Path(__file__).resolve().parent
+if str(_SKILL_DIR) not in sys.path:
+    sys.path.insert(0, str(_SKILL_DIR))
+
+
+def run(genotypes=None, options=None) -> dict:
+    """Run the data extractor.
+
+    Parameters
+    ----------
+    genotypes : ignored (this skill does not consume genotype data)
+    options : dict with keys:
+        - image_path (str): Path to figure image
+        - image_bytes (bytes): Raw image bytes (alternative to path)
+        - output_dir (str): Where to write CSV/JSON results (default: ./output)
+        - web (bool): If True, launch web UI (default False)
+        - port (int): Web UI port (default 8765)
+        - plot_type (str): Force plot type (optional, auto-detected)
+
+    Returns
+    -------
+    dict with keys:
+        - success (bool)
+        - results (list[dict]): extracted data per panel
+        - summary (dict): {n_panels, n_series, total_points, confidence}
+        - output_files (list[str]): paths to generated files
+        - output_dir (str)
+    """
+    options = options or {}
+
+    # Web UI mode
+    if options.get("web"):
+        from web.server import launch
+        port = options.get("port", 8765)
+        launch(port=port)
+        return {"success": True, "mode": "web", "port": port}
+
+    # Extraction mode
+    image_path = options.get("image_path")
+    image_bytes = options.get("image_bytes")
+    output_dir = options.get("output_dir", str(_SKILL_DIR / "output"))
+    plot_type = options.get("plot_type")
+
+    if not image_path and not image_bytes:
+        return {
+            "success": False,
+            "error": "No image provided. Set image_path or image_bytes in options.",
+            "results": [],
+            "summary": {},
+            "output_files": [],
+            "output_dir": output_dir,
+        }
+
+    try:
+        from core.digitizer import extract_from_image, export_csv, export_json
+        results, _panel_figs = asyncio.run(
+            extract_from_image(
+                image_path=image_path,
+                image_bytes=image_bytes,
+                plot_type=plot_type,
+            )
+        )
+    except Exception as e:
+        return {
+            "success": False,
+            "error": str(e),
+            "results": [],
+            "summary": {},
+            "output_files": [],
+            "output_dir": output_dir,
+        }
+
+    # Export results
+    output_files = []
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    csv_path = export_csv(results, str(out / "extracted_data.csv"))
+    output_files.append(csv_path)
+
+    json_path = export_json(results, str(out / "extracted_data.json"))
+    output_files.append(json_path)
+
+    # Summary
+    total_series = sum(len(r.series) for r in results)
+    total_points = sum(len(s.y_values) for r in results for s in r.series)
+    confidences = [r.confidence.value for r in results]
+
+    return {
+        "success": True,
+        "results": [r.model_dump() for r in results],
+        "summary": {
+            "n_panels": len(results),
+            "n_series": total_series,
+            "total_points": total_points,
+            "confidences": confidences,
+        },
+        "output_files": output_files,
+        "output_dir": output_dir,
+    }

--- a/skills/data-extractor/core/__init__.py
+++ b/skills/data-extractor/core/__init__.py
@@ -1,0 +1,1 @@
+"""Data extractor core modules — plot digitization pipeline."""

--- a/skills/data-extractor/core/cv_calibration.py
+++ b/skills/data-extractor/core/cv_calibration.py
@@ -1,0 +1,396 @@
+"""Computer vision calibration for plot data extraction.
+
+Uses OpenCV to detect:
+1. Plot area boundaries (axis lines)
+2. Colored marker positions (dots, squares, diamonds)
+3. Bar top positions
+
+Returns pixel-level calibration data that gets injected into the
+Claude extraction prompt, so Claude maps pixel positions to axis
+values instead of eyeballing.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+import cv2
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PlotRegion:
+    """Detected plot area boundaries in pixel coordinates."""
+    x_left: int  # left edge of plot area (y-axis line)
+    x_right: int  # right edge of plot area
+    y_top: int  # top edge of plot area
+    y_bottom: int  # bottom edge (x-axis line)
+
+    @property
+    def width(self) -> int:
+        return self.x_right - self.x_left
+
+    @property
+    def height(self) -> int:
+        return self.y_bottom - self.y_top
+
+
+@dataclass
+class DetectedMarker:
+    """A detected data marker with pixel position and color."""
+    px: int  # pixel x
+    py: int  # pixel y
+    color_name: str  # e.g., "red", "blue", "green"
+    color_bgr: tuple[int, int, int]  # average BGR color
+    area: float  # contour area (for size filtering)
+
+
+@dataclass
+class DetectedBar:
+    """A detected bar with position and extent."""
+    px_center: int  # bar center x pixel
+    py_top: int  # bar top y pixel
+    px_left: int
+    px_right: int
+    color_name: str
+    color_bgr: tuple[int, int, int]
+
+
+@dataclass
+class CalibrationResult:
+    """Full calibration data for a plot image."""
+    plot_region: PlotRegion | None = None
+    markers: list[DetectedMarker] = field(default_factory=list)
+    bars: list[DetectedBar] = field(default_factory=list)
+    image_width: int = 0
+    image_height: int = 0
+
+
+# --- Color definitions for common plot markers ---
+# HSV ranges: (H_low, S_low, V_low), (H_high, S_high, V_high)
+# OpenCV HSV: H=0-179, S=0-255, V=0-255
+COLOR_RANGES = {
+    "red": [
+        ((0, 70, 70), (10, 255, 255)),      # red low hue
+        ((170, 70, 70), (179, 255, 255)),    # red high hue (wraps around)
+    ],
+    "blue": [
+        ((100, 70, 50), (130, 255, 255)),
+    ],
+    "green": [
+        ((35, 70, 50), (85, 255, 255)),
+    ],
+    "orange": [
+        ((10, 100, 100), (25, 255, 255)),
+    ],
+    "purple": [
+        ((130, 50, 50), (160, 255, 255)),
+    ],
+    "cyan": [
+        ((80, 70, 50), (100, 255, 255)),
+    ],
+    "yellow": [
+        ((25, 100, 100), (35, 255, 255)),
+    ],
+    "pink": [
+        ((160, 50, 70), (170, 255, 255)),
+    ],
+}
+
+
+def _load_image(image_bytes: bytes) -> np.ndarray:
+    """Load image from bytes into OpenCV BGR array."""
+    arr = np.frombuffer(image_bytes, dtype=np.uint8)
+    img = cv2.imdecode(arr, cv2.IMREAD_COLOR)
+    if img is None:
+        raise ValueError("Failed to decode image")
+    return img
+
+
+def detect_plot_region(img: np.ndarray) -> PlotRegion | None:
+    """Detect the plot area by finding axis lines.
+
+    Looks for the L-shaped axis frame (vertical left line + horizontal bottom line).
+    Uses Hough line detection on edges.
+    """
+    h, w = img.shape[:2]
+    gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+    edges = cv2.Canny(gray, 50, 150, apertureSize=3)
+
+    # Detect lines
+    lines = cv2.HoughLinesP(edges, 1, np.pi / 180, threshold=80,
+                            minLineLength=min(w, h) * 0.2, maxLineGap=10)
+    if lines is None:
+        return None
+
+    # Separate horizontal and vertical lines
+    h_lines = []  # (y, x1, x2)
+    v_lines = []  # (x, y1, y2)
+
+    for line in lines:
+        x1, y1, x2, y2 = line[0]
+        dx = abs(x2 - x1)
+        dy = abs(y2 - y1)
+
+        if dy < 5 and dx > w * 0.15:  # horizontal
+            h_lines.append((min(y1, y2), min(x1, x2), max(x1, x2)))
+        elif dx < 5 and dy > h * 0.15:  # vertical
+            v_lines.append((min(x1, x2), min(y1, y2), max(y1, y2)))
+
+    if not h_lines or not v_lines:
+        # Fallback: estimate plot region as inner 80% of image
+        margin_x = int(w * 0.12)
+        margin_y = int(h * 0.08)
+        return PlotRegion(margin_x, w - int(w * 0.05), margin_y, h - int(h * 0.15))
+
+    # Bottom x-axis: horizontal line with largest y (closest to bottom)
+    h_lines.sort(key=lambda l: l[0], reverse=True)
+    x_axis_y = h_lines[0][0]
+
+    # Left y-axis: vertical line with smallest x (closest to left)
+    v_lines.sort(key=lambda l: l[0])
+    y_axis_x = v_lines[0][0]
+
+    # Right boundary: rightmost extent of horizontal lines near bottom
+    right_x = max(l[2] for l in h_lines if abs(l[0] - x_axis_y) < 20)
+
+    # Top boundary: topmost extent of vertical lines near left axis
+    top_y = min(l[1] for l in v_lines if abs(l[0] - y_axis_x) < 20)
+
+    return PlotRegion(
+        x_left=y_axis_x,
+        x_right=min(right_x, w - 5),
+        y_top=max(top_y, 5),
+        y_bottom=x_axis_y,
+    )
+
+
+def detect_markers(img: np.ndarray, plot_region: PlotRegion | None = None,
+                   min_area: float = 15, max_area: float = 2000) -> list[DetectedMarker]:
+    """Detect colored data point markers using HSV color segmentation.
+
+    Returns centroids of detected markers within the plot region.
+    """
+    hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
+    markers: list[DetectedMarker] = []
+
+    # Define region of interest (with padding to catch edge markers)
+    if plot_region:
+        pad = 10
+        roi_mask = np.zeros(img.shape[:2], dtype=np.uint8)
+        y1 = max(0, plot_region.y_top - pad)
+        y2 = min(img.shape[0], plot_region.y_bottom + pad)
+        x1 = max(0, plot_region.x_left - pad)
+        x2 = min(img.shape[1], plot_region.x_right + pad)
+        roi_mask[y1:y2, x1:x2] = 255
+    else:
+        roi_mask = np.ones(img.shape[:2], dtype=np.uint8) * 255
+
+    for color_name, ranges in COLOR_RANGES.items():
+        # Combine all HSV ranges for this color
+        combined_mask = np.zeros(img.shape[:2], dtype=np.uint8)
+        for (low, high) in ranges:
+            mask = cv2.inRange(hsv, np.array(low), np.array(high))
+            combined_mask = cv2.bitwise_or(combined_mask, mask)
+
+        # Apply ROI and clean up
+        combined_mask = cv2.bitwise_and(combined_mask, roi_mask)
+        kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (3, 3))
+        combined_mask = cv2.morphologyEx(combined_mask, cv2.MORPH_CLOSE, kernel)
+        combined_mask = cv2.morphologyEx(combined_mask, cv2.MORPH_OPEN, kernel)
+
+        # Find contours
+        contours, _ = cv2.findContours(combined_mask, cv2.RETR_EXTERNAL,
+                                       cv2.CHAIN_APPROX_SIMPLE)
+
+        for contour in contours:
+            area = cv2.contourArea(contour)
+            if area < min_area or area > max_area:
+                continue
+
+            M = cv2.moments(contour)
+            if M["m00"] == 0:
+                continue
+
+            cx = int(M["m10"] / M["m00"])
+            cy = int(M["m01"] / M["m00"])
+
+            # Get average color at this point
+            mask_point = np.zeros(img.shape[:2], dtype=np.uint8)
+            cv2.drawContours(mask_point, [contour], -1, 255, -1)
+            mean_color = cv2.mean(img, mask=mask_point)[:3]
+
+            markers.append(DetectedMarker(
+                px=cx, py=cy,
+                color_name=color_name,
+                color_bgr=(int(mean_color[0]), int(mean_color[1]), int(mean_color[2])),
+                area=area,
+            ))
+
+    # Sort by x position
+    markers.sort(key=lambda m: (m.px, m.py))
+    return markers
+
+
+def detect_bars(img: np.ndarray, plot_region: PlotRegion | None = None) -> list[DetectedBar]:
+    """Detect bars in a bar chart by finding colored rectangular regions.
+
+    Returns bar center x, top y, and color for each detected bar.
+    """
+    if plot_region is None:
+        return []
+
+    hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)
+    bars: list[DetectedBar] = []
+
+    for color_name, ranges in COLOR_RANGES.items():
+        combined_mask = np.zeros(img.shape[:2], dtype=np.uint8)
+        for (low, high) in ranges:
+            mask = cv2.inRange(hsv, np.array(low), np.array(high))
+            combined_mask = cv2.bitwise_or(combined_mask, mask)
+
+        # Only look in plot region
+        roi_mask = np.zeros(img.shape[:2], dtype=np.uint8)
+        roi_mask[plot_region.y_top:plot_region.y_bottom,
+                 plot_region.x_left:plot_region.x_right] = 255
+        combined_mask = cv2.bitwise_and(combined_mask, roi_mask)
+
+        # Clean up — use larger kernel for bars
+        kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (5, 5))
+        combined_mask = cv2.morphologyEx(combined_mask, cv2.MORPH_CLOSE, kernel)
+
+        contours, _ = cv2.findContours(combined_mask, cv2.RETR_EXTERNAL,
+                                       cv2.CHAIN_APPROX_SIMPLE)
+
+        for contour in contours:
+            area = cv2.contourArea(contour)
+            if area < 200:  # bars should be sizable
+                continue
+
+            x, y, bw, bh = cv2.boundingRect(contour)
+            aspect = bh / max(bw, 1)
+
+            # Bars are tall rectangles (aspect > 0.5) or wide if horizontal
+            if aspect < 0.3 and bw / max(bh, 1) < 0.3:
+                continue  # not bar-shaped
+
+            # Get average color
+            mask_bar = np.zeros(img.shape[:2], dtype=np.uint8)
+            cv2.drawContours(mask_bar, [contour], -1, 255, -1)
+            mean_color = cv2.mean(img, mask=mask_bar)[:3]
+
+            bars.append(DetectedBar(
+                px_center=x + bw // 2,
+                py_top=y,
+                px_left=x,
+                px_right=x + bw,
+                color_name=color_name,
+                color_bgr=(int(mean_color[0]), int(mean_color[1]), int(mean_color[2])),
+            ))
+
+    # Sort by x position
+    bars.sort(key=lambda b: b.px_center)
+    return bars
+
+
+def calibrate_image(image_bytes: bytes) -> CalibrationResult:
+    """Run full calibration pipeline on a plot image.
+
+    Returns detected plot region, markers, and bars with pixel coordinates.
+    """
+    try:
+        img = _load_image(image_bytes)
+    except Exception as e:
+        logger.warning(f"Failed to load image for calibration: {e}")
+        return CalibrationResult()
+
+    h, w = img.shape[:2]
+    result = CalibrationResult(image_width=w, image_height=h)
+
+    # Step 1: Detect plot region
+    result.plot_region = detect_plot_region(img)
+    if result.plot_region:
+        logger.info(
+            f"Plot region: ({result.plot_region.x_left},{result.plot_region.y_top}) "
+            f"to ({result.plot_region.x_right},{result.plot_region.y_bottom})"
+        )
+
+    # Step 2: Detect markers
+    result.markers = detect_markers(img, result.plot_region)
+    logger.info(f"Detected {len(result.markers)} markers")
+
+    # Step 3: Detect bars
+    result.bars = detect_bars(img, result.plot_region)
+    logger.info(f"Detected {len(result.bars)} bars")
+
+    return result
+
+
+def format_calibration_prompt(cal: CalibrationResult) -> str:
+    """Format calibration data as text to inject into the extraction prompt.
+
+    Tells Claude the exact pixel positions of detected features so it can
+    map them to axis values instead of eyeballing.
+    """
+    if not cal.plot_region and not cal.markers and not cal.bars:
+        return ""
+
+    parts: list[str] = []
+    parts.append("COMPUTER VISION CALIBRATION DATA (use this to improve accuracy):")
+
+    if cal.plot_region:
+        pr = cal.plot_region
+        parts.append(
+            f"Plot area spans pixels: x=[{pr.x_left}..{pr.x_right}] ({pr.width}px wide), "
+            f"y=[{pr.y_top}..{pr.y_bottom}] ({pr.height}px tall). "
+            f"Image size: {cal.image_width}x{cal.image_height}px."
+        )
+        parts.append(
+            "AXIS CALIBRATION INSTRUCTIONS:\n"
+            "Step 1: Read ALL tick labels on the x-axis and y-axis.\n"
+            "Step 2: The leftmost x-axis tick is near pixel x=" + str(pr.x_left) +
+            ", the rightmost near x=" + str(pr.x_right) + ".\n"
+            "Step 3: The bottom y-axis tick is near pixel y=" + str(pr.y_bottom) +
+            ", the top near y=" + str(pr.y_top) + " (y increases downward in pixels).\n"
+            "Step 4: For each data point below, interpolate its value using "
+            "the tick positions as reference."
+        )
+
+    if cal.markers:
+        # Group markers by color
+        by_color: dict[str, list[DetectedMarker]] = {}
+        for m in cal.markers:
+            by_color.setdefault(m.color_name, []).append(m)
+
+        parts.append(f"\nDETECTED DATA POINTS ({len(cal.markers)} total):")
+        for color, mks in sorted(by_color.items()):
+            coords = ", ".join(f"({m.px},{m.py})" for m in mks)
+            parts.append(f"  {color} markers ({len(mks)}): {coords}")
+
+        parts.append(
+            "Each (px,py) is a pixel coordinate. Map each to (x_value, y_value) "
+            "by interpolating between the nearest axis ticks. "
+            "Group markers by color into series using the legend."
+        )
+
+    if cal.bars:
+        parts.append(f"\nDETECTED BARS ({len(cal.bars)} total):")
+        by_color: dict[str, list[DetectedBar]] = {}
+        for b in cal.bars:
+            by_color.setdefault(b.color_name, []).append(b)
+
+        for color, bs in sorted(by_color.items()):
+            coords = ", ".join(
+                f"(center_x={b.px_center}, top_y={b.py_top})" for b in bs
+            )
+            parts.append(f"  {color} bars ({len(bs)}): {coords}")
+
+        parts.append(
+            "Bar top y-pixel tells you the bar height — map to y-axis value. "
+            "Bar center x-pixel tells you which category — map to x-axis label."
+        )
+
+    return "\n".join(parts)

--- a/skills/data-extractor/core/digitizer.py
+++ b/skills/data-extractor/core/digitizer.py
@@ -1,0 +1,2226 @@
+"""Digitize plot data from figure images using Claude vision."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import io
+import json
+import logging
+import re
+
+import anthropic
+from PIL import Image
+
+from .models import Confidence, DataSeries, ExtractedData, Figure, PlotType
+
+logger = logging.getLogger(__name__)
+
+# ── Plot-type-specific prompts ──
+
+BASE_PROMPT = """\
+You are a scientific data extraction specialist performing digitization of \
+figures from published papers for meta-analysis. Your goal is to extract \
+ALL numerical data as accurately as possible.
+
+{legend_context}
+
+{panel_focus}
+
+STEP 1 — IDENTIFY AXES AND SCALE:
+- Read ALL tick mark values on both axes. Write them down mentally.
+- Determine the scale: what is the range? What does each gridline represent?
+- CRITICAL — detect LOG SCALE: If tick marks are spaced like 0.001, 0.01, 0.1, 1, 10 \
+  (powers of 10) or 1, 2, 5, 10, 20, 50, 100 (multiplicative), the axis is LOG-SCALED. \
+  Set x_scale or y_scale to "log" accordingly. Common in dose-response, survival, \
+  forest plots, and any plot with orders-of-magnitude range.
+- Read axis labels and units.
+- Identify all series/groups using the color legend if visible in the image.
+
+STEP 2 — NAMING: Use the REAL names for each series:
+- If a color legend is visible in the image, match each bar/line/point color \
+to its label from the legend. NEVER use generic names like "Bar 1", \
+"red bar", or "Group 1" if a legend is present.
+- If the figure legend text names the series, use those names.
+- If no legend is visible and no names are given, use descriptive colors as a last resort.
+
+STEP 3 — READ VALUES PRECISELY:
+- For EACH data point, anchor your reading to the nearest axis tick marks.
+- Example: if ticks are at 0, 100, 200, 300 and a bar top is halfway between \
+200 and 300, the value is 250 (not "approximately 200" or "around 300").
+- For bars: find the top of each bar, project horizontally to the y-axis, \
+and read the value relative to the closest tick marks above and below.
+- If COMPUTER VISION CALIBRATION DATA is provided below, USE IT:
+  The calibration gives pixel coordinates of detected markers/bars.
+  Map each pixel position to an axis value by interpolating between ticks.
+  This is MORE ACCURATE than visual estimation — trust the pixel coordinates.
+- For line plots: read the y-value at each x-axis tick mark by projecting \
+vertically up to the curve, then horizontally to the y-axis.
+- For scatter points: read both x and y by projecting to the nearest ticks.
+
+ERROR BARS — THIS IS CRITICAL, READ CAREFULLY:
+- error_bars_lower and error_bars_upper are the ± EXTENT (delta), NOT absolute positions.
+- First, read the ABSOLUTE y-position of the top and bottom of the error bar from the axis.
+- Then SUBTRACT the mean to get the extent:
+  error_bars_upper = (top of error bar) − (mean value)
+  error_bars_lower = (mean value) − (bottom of error bar)
+- Both values should be POSITIVE numbers (they are distances from the mean).
+- Example: if a bar height (mean) is 250 and error bar goes from 220 to 280:
+  error_bars_lower = 250 − 220 = 30
+  error_bars_upper = 280 − 250 = 30
+- Example: if mean = 5.2, error bar bottom = 4.1, error bar top = 6.8:
+  error_bars_lower = 5.2 − 4.1 = 1.1
+  error_bars_upper = 6.8 − 5.2 = 1.6
+- For SYMMETRIC error bars (same distance above and below), both values are equal.
+- For ASYMMETRIC error bars (e.g., confidence intervals), read EACH end
+  INDEPENDENTLY from the axis — do NOT assume they are equal.
+- NEVER report the absolute axis position of the error bar tip as the error value.
+- If NO error bars are visible ANYWHERE in the figure, OMIT the \
+"error_bars_lower" and "error_bars_upper" keys entirely from the series. \
+Do NOT include them as empty arrays or arrays of nulls.
+- Only include error bar arrays when error bars are actually visible.
+- If some points have error bars and others don't, use null for the missing ones.
+
+{plot_specific_guidance}
+
+STEP 4 — OUTPUT: Return a JSON object with this exact structure:
+{{
+  "plot_type": "<type>",
+  "title": "<descriptive title from the legend/caption — NEVER just 'Table 1' or 'Figure 3', always describe what the data shows>",
+  "x_label": "<x-axis label>",
+  "y_label": "<y-axis label>",
+  "x_unit": "<x-axis unit if shown, or null>",
+  "y_unit": "<y-axis unit if shown, or null>",
+  "x_min": <first (lowest) tick value on x-axis, or null if categorical>,
+  "x_max": <last (highest) tick value on x-axis, or null if categorical>,
+  "y_min": <first (lowest) tick value on y-axis>,
+  "y_max": <last (highest) tick value on y-axis>,
+  "x_scale": "<MUST be exactly 'linear' or 'log'>",
+  "y_scale": "<MUST be exactly 'linear' or 'log'>",
+  "series": [
+    {{
+      "name": "<series/group name from legend — use real names, not colors>",
+      "x_values": [...],
+      "y_values": [...],
+      "error_bars_lower": [<positive ± extent BELOW mean>],
+      "error_bars_upper": [<positive ± extent ABOVE mean>]
+    }}
+  ],
+  "confidence": "<high|medium|low>",
+  "notes": "<error bar type (SD/SEM/CI), sample sizes if shown, any ambiguity>"
+}}
+
+IMPORTANT — AXIS RANGES: x_min/x_max/y_min/y_max must match the ORIGINAL figure's \
+axis range (the first and last tick marks), NOT the range of your extracted data. \
+This ensures the reproduced plot uses the same scale as the original.
+
+Confidence guide:
+- "high": Clear axes, well-separated points, no ambiguity
+- "medium": Some interpolation needed, minor overlaps
+- "low": Dense overlapping points, unclear axes, or very small figure
+
+Return ONLY the JSON object, no other text."""
+
+PLOT_GUIDANCE = {
+    PlotType.SCATTER: """Scatter plot guidance:
+- Extract EVERY visible data point, even if there are many (hundreds is fine).
+- For each point, report precise (x, y) coordinates.
+- If there are distinct groups/colors, create separate series for each.
+- If a regression/trend line is shown, note its equation and R² in notes but
+  extract the raw data points — do NOT extract points along the trend line.
+- LOG SCALE: If either axis uses log scale (ticks at 1, 10, 100, 1000 or
+  0.01, 0.1, 1, 10), report the ACTUAL values (not log-transformed).
+  E.g., a point halfway between 10 and 100 on a log axis ≈ 30, not 55.
+- For dense clusters where individual points overlap, estimate the count of
+  overlapping points and note it, but still extract representative coordinates.
+- If point sizes vary (bubble-like), note this and see bubble guidance.
+- Significance annotations (* p<0.05 etc.) between groups → note in notes.""",
+
+    PlotType.BAR: """Bar chart guidance:
+- x_values should be category labels (strings), not numbers.
+- HORIZONTAL BARS: If bars are horizontal, swap your reading — the bar length
+  is the value (read from x-axis), categories are on the y-axis. Still report
+  categories in x_values and bar lengths in y_values.
+
+INDIVIDUAL DATA POINTS ON BARS — THIS IS THE MOST IMPORTANT RULE:
+If dots/circles/jitter points are overlaid on the bars, the individual data
+points are the REAL DATA — bars are just summaries (means). Extract the points.
+
+Step 1: IDENTIFY THE GROUPING STRUCTURE.
+  Look at the legend carefully. There are typically TWO layers of grouping:
+  (a) X-axis CATEGORIES: labels under bars (e.g., "TH+M-", "TH+M+", "TH-M+")
+  (b) LEGEND GROUPS: different colors/symbols per bar cluster (e.g., "PD" open
+      circles, "PDD" filled circles). These are shown in the legend box.
+  READ THE LEGEND AND AXIS LABELS VERY CAREFULLY — scientific labels often
+  contain special characters like +, -, superscripts. Copy them exactly.
+
+Step 2: CREATE ONE SERIES PER LEGEND GROUP (not per category).
+  E.g., if legend shows PD and PDD, create series "PD" and series "PDD".
+
+Step 3: FOR EACH SERIES, extract every individual data point.
+  - x_values = repeat the category label for each dot in that category.
+  - y_values = the y-coordinate of each individual dot (read from y-axis).
+  Example for grouped bars with 3 categories and individual dots:
+    Series "PD": x_values=["TH+M-","TH+M-","TH+M-","TH+M-","TH+M-",
+                            "TH+M+","TH+M+","TH+M+","TH+M+","TH+M+",
+                            "TH-M+","TH-M+","TH-M+","TH-M+","TH-M+"],
+                 y_values=[128,48,25,15,12, 95,30,25,20,15, 120,115,25,18,15]
+    Series "PDD": x_values=[...same categories...], y_values=[...dots...]
+
+Step 4: PUT SUMMARY STATS IN NOTES (not as separate series).
+  Format: "Bar heights (means): PD TH+M-=48, PD TH+M+=30, ...; Error bars: SEM"
+  Also note n per group and significance annotations (* ** ns).
+
+DISTINGUISHING OPEN vs FILLED CIRCLES:
+  - Open circles (○) and filled circles (●) usually represent different groups
+    (check the legend). Assign each dot to the correct series.
+  - Dots that are horizontally jittered (spread left-right) within a bar are
+    still the SAME x-category — the jitter is just for visibility.
+
+- If NO individual dots are visible (just bars + error bars), then:
+  y_values = [bar height], error_bars = [error bar extent], one entry per category.
+- If grouped bars (multiple bars per category), create one series per legend group.
+- NEGATIVE BARS: Report negative values as negative numbers.
+- Report error bars if present (usually SEM or SD — note which in notes).
+- LOG SCALE y-axis: read actual values from axis, not visual bar height.
+- Significance annotations (* ** *** ns) → note in notes with group comparisons.""",
+
+    PlotType.LINE: """Line plot guidance:
+- Extract the value at each tick mark AND at each visible data point marker.
+- If lines have no markers, sample at each x-axis tick mark AND at any
+  inflection points where the curve changes direction or slope significantly.
+- For curves that are steep in one region and flat in another, sample more
+  densely in the steep region (e.g., every half tick interval).
+- Create separate series for each line (use legend labels from the color key).
+- DUAL Y-AXES: If the plot has two y-axes (left and right), each line uses
+  its own axis. Check which axis each series belongs to by matching colors
+  or by reading the legend. Report y_values using the correct axis scale.
+  Note "dual y-axis: [left series] use left axis, [right series] use right axis".
+- Report error bands/ribbons if present — use error_bars_lower and
+  error_bars_upper for the band boundaries at each x-point.
+- Report error bars (vertical bars at each point) the same way.
+- LOG SCALE: If an axis is log-scaled, read actual values (see scatter guidance).
+- Include at least 10 points per series for smooth curves.
+- TIME SERIES: If x-axis is dates/time, use consistent format (e.g., "2020-01").""",
+
+    PlotType.BOX: """Box and whisker plot guidance:
+YOU MUST report plot_type as "box" in your output — not "bar".
+
+For EACH group/category, create ONE series with:
+  - name = the group label
+  - x_values = [group_label]  (single entry)
+  - y_values = [median]       (the middle line of the box)
+  - error_bars_lower = [median − whisker_min]  (distance from median to bottom whisker)
+  - error_bars_upper = [whisker_max − median]   (distance from median to top whisker)
+
+In notes, report the FULL box statistics for each group:
+  "GroupName: min=X, Q1=X, median=X, Q3=X, max=X"
+If Q1 and Q3 are visible (the box edges), always include them.
+
+OUTLIERS/FLIERS: If individual outlier points are shown beyond the whiskers,
+  list them in notes: "GroupName outliers: [val1, val2, ...]"
+
+- If individual points are overlaid (jittered/beeswarm), ALSO extract
+  the raw data points as additional series named "GroupName (points)" with
+  x_values = repeat the group label for each dot,
+  y_values = individual y-axis values. Keep the box summary series too.
+- x_values should be group/category labels.
+- If boxes are horizontal, the same logic applies but read from x-axis.
+- Significance annotations → note in notes with comparisons.""",
+
+    PlotType.VIOLIN: """Violin plot guidance:
+- If individual points are overlaid (jittered, beeswarm, or strip),
+  PRIORITIZE the raw data points. Create ONE series per group with:
+  x_values = repeat the group label for each dot,
+  y_values = the individual y-axis values of each dot.
+  Report violin summary stats in notes: "Control: median=12.5, Q1=10.2, Q3=14.8"
+- If NO individual points are overlaid, extract summary statistics:
+  - One series per group: y_values = [median]
+  - error_bars_lower = [Q1], error_bars_upper = [Q3]
+- If a box plot is drawn inside the violin, read values from that box.
+- If only the median line is shown (no inner box), estimate Q1/Q3 from
+  the violin shape where the width starts to narrow significantly.
+- Note the approximate distribution shape (unimodal, bimodal, skewed) in notes.
+- HALF-VIOLIN / RAINCLOUD plots: treat the dot strip and violin halves
+  as a combined figure — extract individual points AND summary stats.
+- x_values should be group/category labels.""",
+
+    PlotType.FOREST: """Forest plot guidance:
+- Each row is a study/subgroup. Use study names as x_values (strings).
+- y_values = effect size (OR, HR, RR, SMD, ROM, or MD — note which in notes).
+- ASYMMETRIC CI BOUNDS — read both ends of EACH horizontal line:
+  Step 1: Read the position of the point/square/diamond on the x-axis (= estimate).
+  Step 2: Read where the LEFT end of the CI line falls on the x-axis (= lower bound).
+  Step 3: Read where the RIGHT end of the CI line falls on the x-axis (= upper bound).
+  Step 4: error_bars_lower = estimate − lower_bound (always positive)
+  Step 5: error_bars_upper = upper_bound − estimate (always positive)
+  Example: estimate at 0.5, CI line goes from 0.2 to 0.85 →
+    error_bars_lower = 0.5 − 0.2 = 0.3
+    error_bars_upper = 0.85 − 0.5 = 0.35
+- Include the overall/pooled estimate as the LAST entry (usually a diamond shape).
+  For diamonds: y_value = center, error_bars = diamond left/right edges as deltas.
+- SUBGROUP ANALYSES: If the forest plot has subgroup headings with their own
+  subtotals, create separate series per subgroup. Name each series by the
+  subgroup heading. Include subtotal rows within each series.
+- Note heterogeneity statistics (I², τ², Q, p-value) if shown — per subgroup
+  and overall.
+- Note the number of events and total N per study if shown in columns.
+- WEIGHT: If study weights (%) are shown, note them in notes.
+- The x-axis label tells you the effect measure — report it in notes.
+- If the scale is logarithmic (common for OR/HR/RR), read ACTUAL values
+  from the axis (e.g., 0.5, 1, 2), not distances.
+- Reference line: note the position of the dashed vertical line (usually at
+  1.0 for ratios or 0 for differences).""",
+
+    PlotType.KAPLAN_MEIER: """Kaplan-Meier survival curve guidance:
+- The curve is a STEP FUNCTION — it drops vertically at event times and stays
+  flat between events. Sample at EVERY visible step (drop point), not just ticks.
+- x_values = time points, y_values = survival probability (0-1 or 0-100%).
+- At minimum, extract: start point, every visible step, and the last point.
+- Create separate series for each group/arm.
+- CENSORING MARKS: Small vertical ticks on the curve indicate censored
+  observations. Note approximate censoring times in notes if visible.
+- NUMBER-AT-RISK TABLE: If shown below the plot, extract it in notes as
+  a formatted table (group: time1=N1, time2=N2, ...).
+- Note median survival time per group if marked (where curve crosses 0.5).
+- If confidence bands (shading) are shown, create error_bars_lower and
+  error_bars_upper series with the band boundaries at each time point.
+- Note the log-rank p-value or HR with CI if displayed on the figure.
+- If x-axis goes beyond the last event, don't extrapolate.""",
+
+    PlotType.HISTOGRAM: """Histogram guidance:
+- x_values = bin centers (or left edges if centers unclear), y_values = counts/frequencies.
+- DENSITY PLOTS: If the y-axis shows density (area = 1) rather than counts,
+  note "density" in notes. Sample the curve at each tick and inflection point.
+- If a kernel density estimate (smooth curve) is overlaid, extract it as a
+  separate series with dense sampling (15+ points).
+- If multiple histograms overlap (semi-transparent), create separate series.
+  Read the height of each group's bar carefully at each bin.
+- Note bin width and total N in notes.
+- CUMULATIVE: If the histogram is cumulative, note this in notes.
+- FREQUENCY POLYGON: If shown as connected points instead of bars, treat
+  like a line plot with x = bin centers, y = frequency.""",
+
+    PlotType.HEATMAP: """Heatmap guidance:
+- Extract the matrix of values if numbers are shown in cells.
+- x_values = column labels, y_values = cell values (row by row).
+- Create one series per row, with the row label as series name.
+- If no numbers shown, estimate values from the color scale bar.
+  Map each cell's color to the nearest value on the scale and note
+  "values estimated from color scale" in notes.
+- CLUSTERED HEATMAPS: If rows/columns are reordered by a dendrogram,
+  use the reordered labels (as displayed), not the original order.
+- CORRELATION HEATMAPS: If the matrix is symmetric (correlation matrix),
+  you can extract just the lower triangle — note this in notes.
+- Note the color scale range (e.g., -2 to 2, 0 to 100) in notes.""",
+
+    PlotType.DOT_STRIP: """Dot/strip plot guidance:
+- This shows individual data points for each group/condition (no bars).
+- Create ONE series per group (use the group name from the legend or axis).
+- For each series: x_values = repeat the group label for each dot,
+  y_values = the individual y-axis values of each dot in that group.
+  E.g., "Control" with 6 dots: x_values = ["Control"]*6, y_values = [12.3, 14.1, ...]
+- If points are color-coded by a second variable (not the x-axis groups),
+  create separate series per color instead, named by the color legend.
+- BEESWARM: If points are spread horizontally to avoid overlap (beeswarm),
+  still read the y-value — the x-jitter is just for visibility.
+- If a horizontal line marks the mean or median for each group, report it
+  in notes: "Group means: Control=12.9, Treatment=8.5" (NOT as a separate series).
+- If error bars extend from the mean line, note those too in notes.
+- Note the number of data points (n) per group in notes.
+- Read each point carefully relative to y-axis ticks — do not cluster points
+  at round numbers if they are actually spread between ticks.
+- Significance annotations → note in notes.""",
+
+    PlotType.STACKED_BAR: """Stacked bar chart guidance:
+- x_values = category labels (strings).
+- Create one series per stack segment (use legend labels for names).
+- y_values = the ABSOLUTE value of each segment (not cumulative top).
+  E.g., if a bar has segments 0-30, 30-55, 55-100, the values are 30, 25, 45.
+- If the y-axis shows percentages (0-100%), note "proportions" in notes.
+- Read segment boundaries carefully by projecting to y-axis ticks.
+- If the chart shows counts, report raw counts; if percentages, report percentages.
+- 100% STACKED: If all bars reach 100%, values are proportions. Check that
+  segments within each bar sum to ~100%.
+- DIVERGING STACKED: If bars extend in both directions from a center line
+  (e.g., Likert scale), report negative segments as negative values.
+- Note total bar height per category if visible.""",
+
+    PlotType.FUNNEL: """Funnel plot guidance:
+- This is a meta-analysis funnel plot (effect size vs. precision/SE).
+- x_values = effect size (OR, RR, HR, SMD, or MD — note which in notes).
+- y_values = standard error, precision, or sample size (note which on y-axis).
+- Extract EVERY visible data point as (x, y).
+- If the y-axis is inverted (0 at top, larger SE at bottom), preserve the
+  actual values — do NOT flip them.
+- Note any visible asymmetry or outliers.
+- If trim-and-fill imputed studies are shown (often open/hollow circles),
+  create a separate series "Imputed studies".
+- CONTOUR FUNNEL: If shaded regions show significance contours (e.g.,
+  p < 0.01, p < 0.05, p < 0.1), note the contour boundaries in notes.
+- If a vertical line marks the pooled estimate, note its value.
+- If Egger's regression line is shown, note its slope/intercept.""",
+
+    PlotType.ROC: """ROC curve guidance:
+- x_values = false positive rate (1 - specificity), typically 0 to 1.
+- y_values = true positive rate (sensitivity), typically 0 to 1.
+- Sample the curve densely: at EVERY visible data point marker, plus at
+  each axis tick mark, plus at any inflection points. Aim for 15-20+ points.
+- Create separate series for each classifier/model if multiple curves shown.
+- Note the AUC (area under curve) value if displayed on the figure.
+- If a diagonal reference line (chance line) is shown, do NOT extract it.
+- If confidence bands are shown, use error_bars for the bounds.
+- OPTIMAL CUTOFF: If a specific operating point is marked (e.g., Youden's J),
+  note its coordinates and the corresponding threshold value.
+- PRECISION-RECALL: If this is actually a precision-recall curve (y = precision,
+  x = recall), note this and adjust axis labels accordingly.""",
+
+    PlotType.VOLCANO: """Volcano plot guidance:
+- x_values = log2 fold change (or similar effect size).
+- y_values = -log10(p-value) or -log10(adjusted p-value). Check the axis label.
+- There may be hundreds or thousands of points. Prioritize extraction:
+  1. ALL labeled/annotated points (genes, proteins, etc.) — these are most
+     important. Create a series per label or a single "Labeled" series.
+  2. All points in the significant regions (colored differently).
+  3. Representative non-significant points if feasible.
+- If points are colored by significance threshold, create series:
+  "Significant up", "Significant down", "Non-significant".
+- Note the significance thresholds (fold-change cutoff lines, p-value
+  cutoff line) and their values.
+- If specific genes/proteins are labeled with text annotations, include
+  each labeled point's name, x, and y in the notes or as a named series.
+- MA PLOTS: If the x-axis is average expression (not fold change), this
+  is an MA plot — note this and label axes accordingly.""",
+
+    PlotType.WATERFALL: """Waterfall plot guidance:
+- This shows ordered response values (e.g., % tumor change per patient).
+- x_values = patient/sample identifiers or sequential indices (1, 2, 3...).
+- y_values = response value (e.g., % change from baseline).
+- Extract EVERY bar from left to right in order.
+- If bars are colored by response category (e.g., responder vs non-responder,
+  or by mutation status), create separate series per category.
+- Note the response threshold lines if shown (e.g., -30% for partial response,
+  +20% for progressive disease in RECIST criteria).
+- Values above 0 = growth/increase; below 0 = shrinkage/decrease.
+- If individual patient IDs are labeled, use those as x_values.
+- Note total number of patients and % in each response category.""",
+
+    PlotType.BLAND_ALTMAN: """Bland-Altman (difference) plot guidance:
+- x_values = mean of the two measurements ((Method A + Method B) / 2).
+- y_values = difference between methods (Method A - Method B).
+- Extract EVERY visible data point as (x, y).
+- Note the mean difference (bias) line value if shown (usually a solid
+  horizontal line).
+- Note the limits of agreement (mean ± 1.96 SD) if shown as dashed
+  horizontal lines — report both upper and lower limit values.
+- If confidence intervals around the bias or limits are shown (shaded
+  bands), note those boundary values.
+- Create separate series if points are grouped by a variable (e.g., color).
+- PROPORTIONAL BIAS: If the scatter shows a trend (difference increasing
+  with mean), note this.
+- If a regression line through the points is shown, note its slope.""",
+
+    PlotType.PAIRED: """Paired/spaghetti plot guidance:
+- This shows before-after or repeated measurements connected by lines.
+- x_values = condition/time-point labels (e.g., "Pre", "Post" or time points).
+- Create one series per subject/sample if lines are individually identifiable
+  and there are ≤15 subjects. Name them "Subject 1", "Subject 2", etc.
+  (or use labels if shown). Each series has 2+ values (one per time point).
+- If there are too many individual lines to distinguish (>15), instead:
+  1. Create a "Mean" series with the mean at each time point.
+  2. Note the approximate range (min, max at each time point) in notes.
+  3. Note n (number of lines).
+- If a bold/thick line shows the group mean, extract it as a "Mean" series.
+- If individual points are also shown at each time point (dots on lines),
+  read the values from the dots, not the connecting lines.
+- Note whether most lines go up, down, or mixed.
+- Significance annotations between time points → note in notes.""",
+
+    PlotType.BUBBLE: """Bubble/balloon plot guidance:
+- This is a scatter plot where point SIZE encodes a third variable.
+- x_values = x-axis coordinates, y_values = y-axis coordinates.
+- Create one series per group/color if groups are present.
+- SIZE ENCODING: If a size legend is shown, estimate each bubble's value
+  from the legend. Add a note "bubble_sizes: [v1, v2, ...]" in notes,
+  matching the order of points in the series.
+- If bubble sizes represent sample size, p-value, or another metric, note which.
+- If no size legend is visible, estimate relative sizes (small/medium/large)
+  and note this in notes.
+- COLOR ENCODING: If bubble color represents a continuous variable (not just
+  groups), note the color scale range and estimate values.
+- Read bubble positions from their CENTER, not their edges.""",
+
+    PlotType.AREA: """Area chart / filled line plot guidance:
+- This is like a line plot but the area under the curve is filled.
+- Extract the same way as line plots: x = tick marks/time points,
+  y = values at each point.
+- STACKED AREA: If multiple filled areas are stacked on top of each other,
+  extract the ABSOLUTE value for each series (subtract the cumulative
+  baseline). E.g., if bottom series goes 0-30 and top series 30-50,
+  the top series value is 20.
+- Create one series per colored area (use legend labels).
+- 100% STACKED AREA: If y-axis is percentage (0-100%), the values are
+  proportions. Check that all series sum to ~100% at each x-point.
+- If confidence bands are shown as shaded areas around a line, extract
+  the center line as y_values and band edges as error_bars.
+- Sample at each x-axis tick mark plus any visible inflection points.""",
+
+    PlotType.DOSE_RESPONSE: """Dose-response / sigmoidal curve guidance:
+- This shows a sigmoidal (S-shaped) or log-linear relationship between
+  dose/concentration (x-axis) and response (y-axis).
+- x_values = dose or concentration values. The x-axis is often LOG-SCALED —
+  read the actual values (e.g., 0.01, 0.1, 1, 10 µM), not log-distances.
+- y_values = response (% inhibition, % viability, fold-change, etc.).
+- Sample densely, especially in the transition region (steep part of the
+  sigmoid). Aim for 15+ points per curve.
+- If data points with error bars are shown (not just the fitted curve),
+  extract THOSE points — they are the actual data. Report the fitted curve
+  parameters in notes instead.
+- Create separate series for each drug/compound/condition.
+- EC50/IC50: Note the EC50/IC50 value if marked on the figure or annotated.
+- Note Hill slope, top/bottom plateaus if shown in an inset or annotation.
+- If the y-axis is normalized (0-100% or 0-1), note what 100% represents.""",
+
+    PlotType.MANHATTAN: """Manhattan plot guidance:
+- This shows -log10(p-value) across genomic positions, typically by chromosome.
+- x_values = chromosomal position or SNP/gene identifiers.
+- y_values = -log10(p-value).
+- There are usually thousands of points — prioritize:
+  1. ALL points ABOVE the genome-wide significance threshold line
+     (typically -log10(5e-8) ≈ 7.3). These are the key findings.
+  2. Points above the suggestive significance line if shown.
+  3. Any specifically labeled/annotated SNPs or genes.
+- Create one series for "Genome-wide significant" with labeled SNPs.
+- Create a second series "Suggestive" for points between thresholds.
+- For labeled peaks, x_value = gene/SNP name, y_value = -log10(p).
+- Note the significance thresholds used (p-value and -log10 equivalent).
+- Note chromosome numbers for the significant hits in notes.
+- Do NOT try to extract every point — focus on significant findings.""",
+
+    PlotType.CORRELATION_MATRIX: """Correlation matrix / correlogram guidance:
+- This is a matrix showing pairwise correlations (typically -1 to +1).
+- Create one series per ROW of the matrix, named by the row label.
+- x_values = column labels, y_values = correlation coefficients.
+- If numbers are shown in cells, extract those exact values.
+- If only colors are shown, estimate from the color scale bar.
+- SYMMETRIC MATRIX: If the matrix is symmetric (same variables on both axes),
+  you can extract just the lower triangle — note this in notes.
+- SIGNIFICANCE MARKERS: If cells are marked with * or × for significance,
+  note which correlations are significant in notes.
+- If cells are blank or crossed out (non-significant after correction),
+  report null for those and note the correction method.
+- Note the correlation method (Pearson, Spearman) if stated.""",
+
+    PlotType.ERROR_BAR: """Error bar plot (means with error bars only) guidance:
+- This shows group means as points/markers with error bars (confidence intervals),
+  but WITHOUT bars underneath (unlike a bar chart).
+- x_values = group/category labels or time points.
+- y_values = mean/estimate values (the center point/marker).
+- ASYMMETRIC ERROR BARS — read BOTH ends of each error bar INDEPENDENTLY:
+  Step 1: Read the y-position of the point/marker (= mean).
+  Step 2: Read where the BOTTOM of the error bar ends on the y-axis.
+  Step 3: Read where the TOP of the error bar ends on the y-axis.
+  Step 4: error_bars_lower = mean − bottom_end  (always positive)
+  Step 5: error_bars_upper = top_end − mean  (always positive)
+  These are often NOT equal! CIs from meta-analyses, ratios, and log-scale
+  data are frequently asymmetric.
+  Example: point at 0.5, CI bottom at 0.2, CI top at 0.85 →
+    error_bars_lower = 0.5 − 0.2 = 0.3
+    error_bars_upper = 0.85 − 0.5 = 0.35
+- IMPORTANT: Read whether the error bars represent SD, SEM, 95% CI, or
+  range — this is usually stated in the legend or y-axis label. Note it.
+- If multiple groups are shown (different colors/markers), create one
+  series per group.
+- If this is a meta-analysis summary (ratio of means, odds ratio, etc.),
+  note the dashed reference line value (often at 1.0 or 0) in notes.
+- If lines connect the points (making it look like a line plot), it may
+  overlap with the line plot type — treat as error_bar if the emphasis
+  is on discrete group comparisons rather than continuous trends.
+- If individual data points are overlaid, extract those as a separate series.
+- Significance annotations (p-values, brackets) → note in notes.""",
+
+    PlotType.TABLE: """Table guidance:
+- TITLE: The "title" field must be a DESCRIPTIVE title derived from the figure
+  legend or table caption — e.g., "Proteasomal subunit levels in substantia
+  nigra". NEVER use generic identifiers like "Table 1", "Table 17", or
+  "Data table". If the legend says "Table 3. Demographic and clinical
+  characteristics", the title should be "Demographic and clinical characteristics".
+- This is a data table from a scientific paper. Extract ALL numerical data.
+- Create one series per data column that contains numerical values.
+- x_values = row labels (first column, or row identifiers like group names,
+  brain regions, etc.).
+- y_values = the numerical values in that column.
+- If a column contains mean ± SD/SEM, split into y_values (mean) and
+  error_bars (the ± value). Note whether it's SD, SEM, or CI.
+- Use the column header as the series name.
+- If the table has sub-headers or grouped rows, note the grouping in notes.
+- For p-values, sample sizes (n), or statistical columns, include them in
+  notes rather than as series (e.g., "p-values: Group A vs B = 0.003").
+- MERGED CELLS: If cells span multiple rows/columns, repeat the value for
+  each row/column it covers.
+- Extract EVERY row and column — do not skip any data.""",
+}
+
+DEFAULT_GUIDANCE = """General guidance:
+- First IDENTIFY the plot type from the image. Set plot_type accurately.
+- Extract all visible numerical data systematically.
+- Use your best judgment for the data structure.
+- LOG SCALE: If any axis is log-scaled, report actual values (not log-transformed).
+  A point halfway between 10 and 100 on a log axis ≈ 30, not 55.
+- DUAL Y-AXES: If two y-axes exist, match each series to its correct axis.
+- Note any unusual features, significance annotations, or ambiguities.
+
+BOX AND WHISKER PLOTS — if you see a box plot, you MUST:
+  - Set plot_type to "box" (NOT "bar").
+  - Create ONE series per group/category with:
+    name = group label, x_values = [group_label], y_values = [median].
+    error_bars_lower = [median − whisker_min], error_bars_upper = [whisker_max − median].
+  - In notes, report: "GroupName: min=X, Q1=X, median=X, Q3=X, max=X" for each group.
+  - Outliers beyond whiskers: "GroupName outliers: [val1, val2, ...]" in notes.
+
+VIOLIN PLOTS — if you see a violin plot with overlaid points:
+  - Set plot_type to "violin". Prioritize extracting the individual data points.
+
+BAR CHARTS WITH INDIVIDUAL DATA POINTS — if you see bars with dots/circles overlaid:
+  - The individual data points (dots) are the REAL DATA — extract those, not bar heights.
+  - Check the legend: open circles (○) vs filled circles (●) usually = different groups.
+  - Create ONE series per LEGEND GROUP (e.g., "PD", "PDD"), not per category.
+  - x_values = repeat category label for each dot; y_values = each dot's y-coordinate.
+  - Put bar heights (means) and error bar type in notes.
+  - only use plot_type "bar" for actual rectangular bars, never for box plots."""
+
+
+def _extract_panel_legend(full_legend: str, panel_label: str) -> str | None:
+    """Try to extract a panel-specific description from the full figure legend.
+
+    E.g., from "Fig 3. (a) Precision across replicates. (b) Significant associations."
+    extract "Precision across replicates" for panel "a".
+    """
+    if not full_legend or not panel_label or panel_label == "main":
+        return None
+
+    # Match patterns like "(a) ...", "(a,b) ...", "a, ...", "a: ..."
+    label = re.escape(panel_label.lower())
+    pattern = rf"\({label}[,\)][^)]*\)\s*(.+?)(?=\([a-z](?:[,\)])|$)"
+    match = re.search(pattern, full_legend, re.IGNORECASE | re.DOTALL)
+    if match:
+        return match.group(1).strip().rstrip(".")
+
+    # Simpler pattern: "a, Description" or "a: Description"
+    pattern2 = rf"(?:^|\s){label}[,:]\s*(.+?)(?=\s+[b-z][,:]|\Z)"
+    match2 = re.search(pattern2, full_legend, re.IGNORECASE | re.DOTALL)
+    if match2:
+        return match2.group(1).strip().rstrip(".")
+
+    return None
+
+
+def _get_prompt(figure: Figure, panel_label: str | None = None, pre_analysis: dict | None = None) -> str:
+    legend_context = ""
+    if figure.legend:
+        legend_context = f"Figure legend: {figure.legend}"
+        if panel_label:
+            panel_desc = _extract_panel_legend(figure.legend, panel_label)
+            if panel_desc:
+                legend_context += f"\n\nThis is panel ({panel_label}): {panel_desc}"
+            else:
+                legend_context += f"\n\nThis is panel ({panel_label}) of the figure."
+
+    panel_focus = ""
+    if panel_label and panel_label != "main":
+        panel_focus = (
+            "CONTEXT: This is a CROPPED sub-panel (panel " + panel_label + ") from a larger "
+            "multi-panel figure. A full-figure context image was provided above.\n"
+            "- Use the FULL FIGURE to read: color legend labels, axis scales from adjacent "
+            "panels that share the same y-axis, and any shared legends.\n"
+            "- Extract data ONLY from panel " + panel_label + " in the cropped image.\n"
+            "- If the y-axis tick marks are not visible in the crop, look at the full figure "
+            "to find the axis scale for this panel's row.\n"
+            "- The crop may show edges of adjacent panels — ignore those completely."
+        )
+
+    guidance = PLOT_GUIDANCE.get(figure.plot_type, DEFAULT_GUIDANCE)
+
+    # If pre-analysis was done, inject its findings as context
+    pre_analysis_context = ""
+    if pre_analysis:
+        parts = ["PRE-ANALYSIS RESULTS (use these to guide your extraction):"]
+        pt = pre_analysis.get("plot_type")
+        if pt:
+            parts.append(f"- Plot type identified as: {pt}")
+        x_ax = pre_analysis.get("x_axis", {})
+        y_ax = pre_analysis.get("y_axis", {})
+        if x_ax.get("scale") == "log":
+            parts.append(f"- X-axis is LOG SCALED (ticks: {x_ax.get('tick_values', [])})")
+        if y_ax.get("scale") == "log":
+            parts.append(f"- Y-axis is LOG SCALED (ticks: {y_ax.get('tick_values', [])})")
+        if x_ax.get("label"):
+            parts.append(f"- X-axis label: {x_ax['label']}" + (f" ({x_ax['unit']})" if x_ax.get("unit") else ""))
+        if y_ax.get("label"):
+            parts.append(f"- Y-axis label: {y_ax['label']}" + (f" ({y_ax['unit']})" if y_ax.get("unit") else ""))
+        legend_entries = pre_analysis.get("legend_entries", [])
+        if legend_entries:
+            parts.append(f"- Legend entries: {', '.join(legend_entries)}")
+        desc = pre_analysis.get("description")
+        if desc:
+            parts.append(f"- Description: {desc}")
+        if pre_analysis.get("has_error_bars"):
+            parts.append("- Error bars are PRESENT — extract them carefully")
+        else:
+            parts.append("- No error bars detected — OMIT error_bars_lower/upper keys")
+        pre_analysis_context = "\n".join(parts)
+
+    return BASE_PROMPT.format(
+        legend_context=legend_context,
+        plot_specific_guidance=guidance,
+        panel_focus=panel_focus,
+    ) + ("\n\n" + pre_analysis_context if pre_analysis_context else "")
+
+
+def _parse_response(raw_text: str, figure_id: str) -> ExtractedData:
+    """Parse Claude's JSON response into ExtractedData."""
+    # Strip markdown code fences
+    text = raw_text.strip()
+    if text.startswith("```"):
+        text = text.split("\n", 1)[1]
+    if text.endswith("```"):
+        text = text[:-3]
+    text = text.strip()
+
+    data = json.loads(text)
+
+    series = []
+    for s in data.get("series", []):
+        y_vals = s.get("y_values") or []
+        x_vals = s.get("x_values") or []
+        err_lo = s.get("error_bars_lower") or []
+        err_hi = s.get("error_bars_upper") or []
+
+        # Pad error arrays to match y length
+        while len(err_lo) < len(y_vals):
+            err_lo.append(None)
+        while len(err_hi) < len(y_vals):
+            err_hi.append(None)
+
+        series.append(DataSeries(
+            name=s.get("name", "Series"),
+            x_values=x_vals,
+            y_values=y_vals,
+            error_bars_lower=err_lo,
+            error_bars_upper=err_hi,
+        ))
+
+    try:
+        plot_type = PlotType(data.get("plot_type", "other"))
+    except ValueError:
+        plot_type = PlotType.OTHER
+
+    try:
+        confidence = Confidence(data.get("confidence", "medium"))
+    except ValueError:
+        confidence = Confidence.MEDIUM
+
+    return ExtractedData(
+        figure_id=figure_id,
+        plot_type=plot_type,
+        title=data.get("title"),
+        x_label=data.get("x_label"),
+        y_label=data.get("y_label"),
+        x_unit=data.get("x_unit"),
+        y_unit=data.get("y_unit"),
+        x_min=data.get("x_min"),
+        x_max=data.get("x_max"),
+        y_min=data.get("y_min"),
+        y_max=data.get("y_max"),
+        x_scale=data.get("x_scale"),
+        y_scale=data.get("y_scale"),
+        series=series,
+        confidence=confidence,
+        notes=data.get("notes"),
+    )
+
+
+PANEL_DETECT_PROMPT = """\
+This scientific figure may contain multiple sub-panels (a, b, c, d...) arranged in a grid.
+
+Your task: describe the GRID LAYOUT, then assign each panel to a grid cell.
+
+STEP 1 — Determine the grid:
+- How many rows and columns of panels are there?
+- A 2×2 figure has 2 rows and 2 columns. A figure with 3 panels on top and 1 wide \
+panel on the bottom is 2 rows × 3 columns (bottom panel spans all 3 columns).
+- Count rows by distinct vertical positions of panels. Count columns by distinct \
+horizontal positions.
+
+STEP 2 — Assign each panel to its grid cell(s):
+- row and col are 1-indexed (top-left = row 1, col 1).
+- If a panel spans multiple cells, use rowspan/colspan.
+
+Return a JSON object:
+{{
+  "rows": 2,
+  "cols": 2,
+  "panels": [
+    {{"label": "a", "plot_type": "bar", "row": 1, "col": 1, "rowspan": 1, "colspan": 1}},
+    {{"label": "b", "plot_type": "scatter", "row": 1, "col": 2, "rowspan": 1, "colspan": 1}},
+    {{"label": "c", "plot_type": "line", "row": 2, "col": 1, "rowspan": 1, "colspan": 2}}
+  ]
+}}
+
+If the figure is a single panel (not multi-panel), return:
+{{"rows": 1, "cols": 1, "panels": [{{"label": "main", "plot_type": "<type>", "row": 1, "col": 1, "rowspan": 1, "colspan": 1}}]}}
+
+Plot type must be one of: scatter, bar, line, box, violin, histogram, heatmap, \
+forest, kaplan_meier, dot_strip, stacked_bar, funnel, roc, volcano, waterfall, \
+bland_altman, paired, bubble, area, dose_response, manhattan, correlation_matrix, \
+error_bar, table, other.
+Return ONLY the JSON object, no other text."""
+
+
+_PLOT_TYPE_ENUM = [
+    "scatter", "bar", "line", "box", "violin", "histogram", "heatmap",
+    "forest", "kaplan_meier", "dot_strip", "stacked_bar", "funnel", "roc",
+    "volcano", "waterfall", "bland_altman", "paired", "bubble", "area",
+    "dose_response", "manhattan", "correlation_matrix", "error_bar", "table", "other",
+]
+
+# ── Tool definitions for structured Claude API calls ──
+
+PRE_ANALYSIS_TOOL = {
+    "name": "report_figure_structure",
+    "description": (
+        "Report the structure of a scientific figure: plot type, axis info, "
+        "scale (linear/log), legend entries, and whether error bars are present."
+    ),
+    "input_schema": {
+        "type": "object",
+        "required": ["plot_type", "x_axis", "y_axis", "legend_entries", "num_series",
+                      "has_error_bars", "description"],
+        "properties": {
+            "plot_type": {
+                "type": "string",
+                "enum": _PLOT_TYPE_ENUM,
+                "description": "The type of plot shown in the figure.",
+            },
+            "x_axis": {
+                "type": "object",
+                "required": ["label", "scale", "is_categorical"],
+                "properties": {
+                    "label": {"type": "string", "description": "X-axis label text"},
+                    "unit": {"type": ["string", "null"], "description": "X-axis unit if shown"},
+                    "scale": {"type": "string", "enum": ["linear", "log"],
+                              "description": "linear or log. Ticks like 0.01,0.1,1,10,100 = log."},
+                    "tick_values": {
+                        "type": "array",
+                        "items": {"type": ["number", "string"]},
+                        "description": "Visible tick mark values on the x-axis",
+                    },
+                    "is_categorical": {"type": "boolean", "description": "True if x-axis shows categories/labels"},
+                },
+            },
+            "y_axis": {
+                "type": "object",
+                "required": ["label", "scale"],
+                "properties": {
+                    "label": {"type": "string", "description": "Y-axis label text"},
+                    "unit": {"type": ["string", "null"], "description": "Y-axis unit if shown"},
+                    "scale": {"type": "string", "enum": ["linear", "log"],
+                              "description": "linear or log. Ticks like 0.01,0.1,1,10,100 = log."},
+                    "tick_values": {
+                        "type": "array",
+                        "items": {"type": ["number", "string"]},
+                        "description": "Visible tick mark values on the y-axis",
+                    },
+                },
+            },
+            "legend_entries": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Series/group names from the color/shape legend. Empty if no legend visible.",
+            },
+            "num_series": {
+                "type": "integer",
+                "description": "Number of distinct data series/groups in the figure",
+            },
+            "has_error_bars": {
+                "type": "boolean",
+                "description": "True if any error bars, confidence intervals, or uncertainty indicators are visible",
+            },
+            "description": {
+                "type": "string",
+                "description": "One sentence describing what this plot shows",
+            },
+        },
+    },
+}
+
+EXTRACT_DATA_TOOL = {
+    "name": "report_extracted_data",
+    "description": "Report all numerical data extracted from a scientific figure.",
+    "input_schema": {
+        "type": "object",
+        "required": ["plot_type", "title", "x_label", "y_label", "x_scale", "y_scale",
+                      "series", "confidence"],
+        "properties": {
+            "plot_type": {"type": "string", "enum": _PLOT_TYPE_ENUM},
+            "title": {
+                "type": "string",
+                "description": "Descriptive title from the legend/caption — never just 'Figure 1' or 'Table 2'.",
+            },
+            "x_label": {"type": ["string", "null"]},
+            "y_label": {"type": ["string", "null"]},
+            "x_unit": {"type": ["string", "null"]},
+            "y_unit": {"type": ["string", "null"]},
+            "x_min": {"type": ["number", "null"], "description": "First tick value on x-axis, null if categorical"},
+            "x_max": {"type": ["number", "null"], "description": "Last tick value on x-axis, null if categorical"},
+            "y_min": {"type": ["number", "null"], "description": "First tick value on y-axis"},
+            "y_max": {"type": ["number", "null"], "description": "Last tick value on y-axis"},
+            "x_scale": {"type": "string", "enum": ["linear", "log"]},
+            "y_scale": {"type": "string", "enum": ["linear", "log"]},
+            "series": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["name", "x_values", "y_values"],
+                    "properties": {
+                        "name": {"type": "string", "description": "Series/group name from legend — use real names"},
+                        "x_values": {"type": "array", "items": {"type": ["number", "string"]}},
+                        "y_values": {"type": "array", "items": {"type": ["number", "null"]}},
+                        "error_bars_lower": {
+                            "type": "array",
+                            "items": {"type": ["number", "null"]},
+                            "description": "Positive distance BELOW mean. Omit entirely if no error bars.",
+                        },
+                        "error_bars_upper": {
+                            "type": "array",
+                            "items": {"type": ["number", "null"]},
+                            "description": "Positive distance ABOVE mean. Omit entirely if no error bars.",
+                        },
+                    },
+                },
+            },
+            "confidence": {"type": "string", "enum": ["high", "medium", "low"]},
+            "notes": {
+                "type": ["string", "null"],
+                "description": (
+                    "Error bar type (SD/SEM/CI), sample sizes, box plot stats "
+                    "(GroupName: min=X, Q1=X, median=X, Q3=X, max=X), outliers, ambiguities."
+                ),
+            },
+        },
+    },
+}
+
+PRE_ANALYSIS_SYSTEM = """\
+You are analyzing a scientific figure BEFORE extracting numerical data.
+Your job is to identify the structure so the extraction step knows exactly what to do.
+
+You MUST call the report_figure_structure tool with your analysis.
+
+CRITICAL for axis scale detection:
+- If tick values increase multiplicatively (0.01, 0.1, 1, 10, 100) → "log"
+- If tick values increase additively (0, 20, 40, 60, 80) → "linear"
+- Forest plots with OR/HR often have log x-axis
+- Dose-response curves often have log x-axis
+- Box-and-whisker plots have plot_type "box" — NOT "bar"
+
+Read every tick mark, every legend entry, and every axis label carefully."""
+
+
+def _image_from_base64(b64: str) -> Image.Image:
+    return Image.open(io.BytesIO(base64.b64decode(b64)))
+
+
+def _image_to_base64(img: Image.Image) -> str:
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode()
+
+
+def _extract_tool_input(response, tool_name: str) -> dict | None:
+    """Extract the input dict from a tool_use content block in a Claude response."""
+    for block in response.content:
+        if block.type == "tool_use" and block.name == tool_name:
+            return block.input
+    return None
+
+
+async def pre_analyze(figure: Figure) -> dict:
+    """Phase 2: Analyze figure structure before data extraction.
+
+    Uses Claude tool calling for structured, reliable output.
+    Returns a dict with plot_type, axis info, scale, legend entries, etc.
+    """
+    client = anthropic.AsyncAnthropic()
+
+    response = await client.messages.create(
+        model="claude-sonnet-4-20250514",
+        max_tokens=2048,
+        system=PRE_ANALYSIS_SYSTEM,
+        tools=[PRE_ANALYSIS_TOOL],
+        tool_choice={"type": "tool", "name": "report_figure_structure"},
+        messages=[{
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": figure.image_base64,
+                    },
+                },
+                {"type": "text", "text": (
+                    "Analyze this scientific figure and report its structure. "
+                    "Pay close attention to:\n"
+                    "- The EXACT plot type (box vs bar, scatter vs dot_strip, etc.)\n"
+                    "- Whether axes are LOG-scaled (look for exponential tick spacing: 1, 10, 100, 1000)\n"
+                    "- All legend entries and their visual encoding (color, shape, fill)\n"
+                    "- Whether individual data points are overlaid on bars/boxes\n"
+                    "- Whether error bars are present and what kind they appear to be"
+                )},
+            ],
+        }],
+    )
+
+    analysis = _extract_tool_input(response, "report_figure_structure") or {}
+
+    logger.info(
+        f"Pre-analysis for {figure.figure_id}: "
+        f"type={analysis.get('plot_type', '?')}, "
+        f"x_scale={analysis.get('x_axis', {}).get('scale', '?')}, "
+        f"y_scale={analysis.get('y_axis', {}).get('scale', '?')}, "
+        f"series={analysis.get('num_series', '?')}, "
+        f"legend={analysis.get('legend_entries', [])}"
+    )
+
+    return analysis
+
+
+async def detect_panels(figure: Figure) -> list[dict]:
+    """Ask Claude to identify sub-panels via grid layout, then compute bboxes.
+
+    Uses a grid-based approach: Claude reports rows/cols and each panel's cell
+    position, then bboxes are computed mathematically from the grid. This is
+    far more reliable than asking Claude to estimate pixel coordinates or
+    percentages, which it consistently gets wrong.
+    """
+    client = anthropic.AsyncAnthropic()
+
+    # Use actual image dimensions (may differ from figure.width/height if resized)
+    img = _image_from_base64(figure.image_base64)
+    actual_w, actual_h = img.width, img.height
+
+    response = await client.messages.create(
+        model="claude-opus-4-6",
+        max_tokens=2048,
+        messages=[{
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "image/png",
+                        "data": figure.image_base64,
+                    },
+                },
+                {"type": "text", "text": PANEL_DETECT_PROMPT},
+            ],
+        }],
+    )
+
+    raw = response.content[0].text.strip()
+    if raw.startswith("```"):
+        raw = raw.split("\n", 1)[1]
+    if raw.endswith("```"):
+        raw = raw[:-3]
+    raw = raw.strip()
+
+    data = json.loads(raw)
+    panels_info = data["panels"]
+    nrows = data.get("rows", 1)
+    ncols = data.get("cols", 1)
+
+    logger.info(
+        f"Detected {len(panels_info)} panels in {figure.figure_id} "
+        f"(grid: {nrows}×{ncols})"
+    )
+
+    # Compute bboxes mathematically from grid positions
+    cell_w = actual_w / ncols
+    cell_h = actual_h / nrows
+
+    panels = []
+    for p in panels_info:
+        row = p.get("row", 1)
+        col = p.get("col", 1)
+        rowspan = p.get("rowspan", 1)
+        colspan = p.get("colspan", 1)
+
+        # Grid cell to pixel bbox (0-indexed internally)
+        x_min = int((col - 1) * cell_w)
+        y_min = int((row - 1) * cell_h)
+        x_max = int((col - 1 + colspan) * cell_w)
+        y_max = int((row - 1 + rowspan) * cell_h)
+
+        bbox = [x_min, y_min, x_max, y_max]
+        panels.append({
+            "label": p["label"],
+            "plot_type": p["plot_type"],
+            "bbox": bbox,
+        })
+
+    return panels
+
+
+def _crop_panel(figure: Figure, bbox: list[int], label: str, plot_type_str: str, padding: int = 40) -> Figure:
+    """Crop a sub-panel from the full figure image and return as a new Figure."""
+    img = _image_from_base64(figure.image_base64)
+    x_min, y_min, x_max, y_max = bbox
+
+    # Scale bbox if figure dimensions don't match actual image
+    # (can happen if width/height fields weren't updated after resizing)
+    if figure.width != img.width or figure.height != img.height:
+        sx = img.width / max(figure.width, 1)
+        sy = img.height / max(figure.height, 1)
+        x_min = int(x_min * sx)
+        y_min = int(y_min * sy)
+        x_max = int(x_max * sx)
+        y_max = int(y_max * sy)
+        logger.info(f"Scaled bbox for {label}: figure={figure.width}x{figure.height} img={img.width}x{img.height}")
+
+    # Add padding and clamp to image bounds
+    x_min = max(0, x_min - padding)
+    y_min = max(0, y_min - padding)
+    x_max = min(img.width, x_max + padding)
+    y_max = min(img.height, y_max + padding)
+
+    cropped = img.crop((x_min, y_min, x_max, y_max))
+    b64 = _image_to_base64(cropped)
+
+    try:
+        pt = PlotType(plot_type_str)
+    except ValueError:
+        pt = PlotType.OTHER
+
+    panel_id = f"{figure.figure_id}_{label}"
+    return Figure(
+        figure_id=panel_id,
+        paper_id=figure.paper_id,
+        page_number=figure.page_number,
+        image_index=figure.image_index,
+        width=cropped.width,
+        height=cropped.height,
+        image_base64=b64,
+        legend=figure.legend,
+        plot_type=pt,
+        plot_type_confidence=Confidence.MEDIUM,
+    )
+
+
+async def _digitize_single(
+    figure: Figure,
+    panel_label: str | None = None,
+    full_figure_b64: str | None = None,
+    pre_analysis_result: dict | None = None,
+) -> tuple[ExtractedData, dict]:
+    """Phase 2+3: Pre-analyze then extract data from a single-panel figure image.
+
+    Returns (result, pre_analysis_dict) so validation can cross-check.
+
+    If full_figure_b64 is provided (for multi-panel splits), it is sent as
+    a context image so the model can reference the full figure's axes, legends,
+    and labels even when the cropped panel is missing them.
+    """
+    client = anthropic.AsyncAnthropic()
+
+    # Phase 2: Pre-analyze if not already done
+    if pre_analysis_result is None:
+        try:
+            pre_analysis_result = await pre_analyze(figure)
+        except Exception as e:
+            logger.warning(f"Pre-analysis failed for {figure.figure_id}: {e}")
+            pre_analysis_result = {}
+
+    # Update figure's plot_type from pre-analysis if it was OTHER
+    if figure.plot_type == PlotType.OTHER and pre_analysis_result.get("plot_type"):
+        try:
+            detected_type = PlotType(pre_analysis_result["plot_type"])
+            figure = figure.model_copy(update={"plot_type": detected_type})
+            logger.info(f"Updated {figure.figure_id} plot_type to {detected_type.value} from pre-analysis")
+        except ValueError:
+            pass
+
+    prompt = _get_prompt(figure, panel_label=panel_label, pre_analysis=pre_analysis_result)
+
+    # Phase 2b: CV calibration — detect markers/bars at pixel level
+    cv_context = ""
+    try:
+        from .cv_calibration import calibrate_image, format_calibration_prompt
+        img_bytes = base64.b64decode(figure.image_base64)
+        cal = calibrate_image(img_bytes)
+        cv_context = format_calibration_prompt(cal)
+        if cv_context:
+            logger.info(
+                f"CV calibration for {figure.figure_id}: "
+                f"{len(cal.markers)} markers, {len(cal.bars)} bars"
+            )
+    except Exception as e:
+        logger.warning(f"CV calibration failed for {figure.figure_id}: {e}")
+
+    content: list[dict] = []
+
+    # For multi-panel: send full figure first as context, then the cropped panel
+    if full_figure_b64:
+        content.append({"type": "text", "text": (
+            "Here is the FULL multi-panel figure for context. "
+            "Use it to read axis scales, tick values, color legends, "
+            "and series labels. Then extract data ONLY from the cropped "
+            "panel shown in the second image."
+        )})
+        content.append({
+            "type": "image",
+            "source": {
+                "type": "base64",
+                "media_type": "image/png",
+                "data": full_figure_b64,
+            },
+        })
+        content.append({"type": "text", "text": "Now extract data from THIS cropped panel:"})
+
+    content.append({
+        "type": "image",
+        "source": {
+            "type": "base64",
+            "media_type": "image/png",
+            "data": figure.image_base64,
+        },
+    })
+    full_prompt = prompt
+    if cv_context:
+        full_prompt += "\n\n" + cv_context
+    content.append({"type": "text", "text": full_prompt + "\n\nYou MUST call the report_extracted_data tool with your results."})
+
+    response = await client.messages.create(
+        model="claude-opus-4-6",
+        max_tokens=8192,
+        tools=[EXTRACT_DATA_TOOL],
+        tool_choice={"type": "tool", "name": "report_extracted_data"},
+        messages=[{"role": "user", "content": content}],
+    )
+
+    # Extract data from tool call (structured, no JSON parsing needed)
+    data = _extract_tool_input(response, "report_extracted_data")
+
+    if data:
+        result = _parse_tool_result(data, figure.figure_id)
+    else:
+        # Fallback: try parsing raw text (shouldn't happen with tool_choice=tool)
+        raw_text = ""
+        for block in response.content:
+            if hasattr(block, "text"):
+                raw_text = block.text
+                break
+        logger.warning(f"Tool call not found for {figure.figure_id}, falling back to text parse")
+        result = _parse_response(raw_text, figure.figure_id)
+
+    # Attach legend and context metadata
+    result.legend_text = figure.legend
+    # text_mentions are attached by the caller (needs PDF access)
+
+    return result, pre_analysis_result
+
+
+def _parse_tool_result(data: dict, figure_id: str) -> ExtractedData:
+    """Parse structured tool call output into ExtractedData.
+
+    Unlike _parse_response which deals with raw JSON text, this receives
+    already-parsed dict from Claude's tool_use response — no string parsing needed.
+    """
+    series = []
+    for s in data.get("series", []):
+        y_vals = s.get("y_values") or []
+        x_vals = s.get("x_values") or []
+        err_lo = s.get("error_bars_lower") or []
+        err_hi = s.get("error_bars_upper") or []
+
+        while len(err_lo) < len(y_vals):
+            err_lo.append(None)
+        while len(err_hi) < len(y_vals):
+            err_hi.append(None)
+
+        series.append(DataSeries(
+            name=s.get("name", "Series"),
+            x_values=x_vals,
+            y_values=[v if v is not None else 0.0 for v in y_vals],
+            error_bars_lower=err_lo,
+            error_bars_upper=err_hi,
+        ))
+
+    try:
+        plot_type = PlotType(data.get("plot_type", "other"))
+    except ValueError:
+        plot_type = PlotType.OTHER
+
+    try:
+        confidence = Confidence(data.get("confidence", "medium"))
+    except ValueError:
+        confidence = Confidence.MEDIUM
+
+    return ExtractedData(
+        figure_id=figure_id,
+        plot_type=plot_type,
+        title=data.get("title"),
+        x_label=data.get("x_label"),
+        y_label=data.get("y_label"),
+        x_unit=data.get("x_unit"),
+        y_unit=data.get("y_unit"),
+        x_min=data.get("x_min"),
+        x_max=data.get("x_max"),
+        y_min=data.get("y_min"),
+        y_max=data.get("y_max"),
+        x_scale=data.get("x_scale"),
+        y_scale=data.get("y_scale"),
+        series=series,
+        confidence=confidence,
+        notes=data.get("notes"),
+    )
+
+
+def validate_extraction(result: ExtractedData, pre_analysis: dict | None = None) -> ExtractedData:
+    """Lightweight heuristic validation — no API calls, no cost, instant.
+
+    Checks for common extraction errors and flags them in notes.
+    Returns the result with warnings appended to notes.
+    """
+    warnings: list[str] = []
+
+    # 1. Empty series check
+    if not result.series:
+        warnings.append("No series extracted")
+    else:
+        for s in result.series:
+            if not s.y_values:
+                warnings.append(f"Series '{s.name}' has no y_values")
+            if s.x_values and s.y_values and len(s.x_values) != len(s.y_values):
+                warnings.append(f"Series '{s.name}': x_values ({len(s.x_values)}) and y_values ({len(s.y_values)}) length mismatch")
+
+    # 2. Values within axis range
+    if result.y_min is not None and result.y_max is not None:
+        y_range = result.y_max - result.y_min
+        tolerance = y_range * 0.15  # 15% tolerance for points near edges
+        for s in result.series:
+            for i, y in enumerate(s.y_values):
+                if y is not None:
+                    if y < result.y_min - tolerance or y > result.y_max + tolerance:
+                        warnings.append(f"Series '{s.name}' point {i}: y={y} outside axis range [{result.y_min}, {result.y_max}]")
+                        break  # one warning per series is enough
+
+    # 3. Plot type consistency with pre-analysis
+    if pre_analysis:
+        pa_type = pre_analysis.get("plot_type")
+        if pa_type and pa_type != "other" and pa_type != result.plot_type.value:
+            warnings.append(f"Plot type mismatch: pre-analysis={pa_type}, extraction={result.plot_type.value}")
+
+        # Series count check
+        pa_n = pre_analysis.get("num_series")
+        if pa_n and isinstance(pa_n, int) and len(result.series) > 0:
+            if abs(len(result.series) - pa_n) > pa_n:  # more than 2x off
+                warnings.append(f"Series count: pre-analysis expected ~{pa_n}, got {len(result.series)}")
+
+        # Legend entry check
+        pa_legend = pre_analysis.get("legend_entries", [])
+        if pa_legend and len(pa_legend) > 0 and len(result.series) > 0:
+            extracted_names = {s.name.lower().strip() for s in result.series}
+            legend_names = {str(e).lower().strip() for e in pa_legend}
+            missing = legend_names - extracted_names
+            if missing and len(missing) <= 3:  # don't warn if totally different (may be subgroups)
+                warnings.append(f"Legend entries not found in series: {', '.join(missing)}")
+
+    # 4. Box plot sanity
+    if result.plot_type == PlotType.BOX:
+        for s in result.series:
+            if s.y_values and len(s.y_values) == 1:
+                # Check notes for box stats
+                if result.notes:
+                    import re
+                    pat = re.escape(s.name) + r".*?min\s*=\s*([\d.\-]+).*?Q1\s*=\s*([\d.\-]+).*?median\s*=\s*([\d.\-]+).*?Q3\s*=\s*([\d.\-]+).*?max\s*=\s*([\d.\-]+)"
+                    m = re.search(pat, result.notes, re.IGNORECASE)
+                    if m:
+                        mn, q1, med, q3, mx = [float(x) for x in m.groups()]
+                        if not (mn <= q1 <= med <= q3 <= mx):
+                            warnings.append(f"Box '{s.name}': stats not monotonic (min={mn} Q1={q1} median={med} Q3={q3} max={mx})")
+
+    # 5. Error bar sanity (should be positive extents)
+    for s in result.series:
+        for i, v in enumerate(s.error_bars_lower):
+            if v is not None and v < 0:
+                warnings.append(f"Series '{s.name}': negative error_bars_lower at index {i} (should be positive extent)")
+                break
+        for i, v in enumerate(s.error_bars_upper):
+            if v is not None and v < 0:
+                warnings.append(f"Series '{s.name}': negative error_bars_upper at index {i} (should be positive extent)")
+                break
+
+    # 6. Duplicate series names
+    names = [s.name for s in result.series]
+    if len(names) != len(set(names)):
+        from collections import Counter
+        dupes = [n for n, c in Counter(names).items() if c > 1]
+        warnings.append(f"Duplicate series names: {', '.join(dupes)}")
+
+    # 7. Confidence downgrade if warnings found
+    if warnings:
+        note_text = "[Validation] " + "; ".join(warnings)
+        existing_notes = result.notes or ""
+        updates: dict = {"notes": existing_notes + "\n" + note_text if existing_notes else note_text}
+
+        # Downgrade confidence if many warnings
+        if len(warnings) >= 3 and result.confidence != Confidence.LOW:
+            updates["confidence"] = Confidence.LOW
+        elif len(warnings) >= 1 and result.confidence == Confidence.HIGH:
+            updates["confidence"] = Confidence.MEDIUM
+
+        result = result.model_copy(update=updates)
+        logger.info(f"Validation for {result.figure_id}: {len(warnings)} warning(s): {'; '.join(warnings)}")
+
+    return result
+
+
+def _render_result_to_png(result: ExtractedData) -> str:
+    """Render ExtractedData to a matplotlib PNG, return base64.
+
+    This creates a plot that can be visually compared to the original figure.
+    Handles all major plot types: box, bar, stacked_bar, histogram, violin,
+    forest, kaplan_meier, scatter, line, dot_strip, paired, error_bar,
+    waterfall, roc, heatmap, volcano, funnel, dose_response, area, bland_altman.
+    """
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        import matplotlib.patches as mpatches
+        from matplotlib.patches import FancyBboxPatch
+        import numpy as np
+    except ImportError:
+        logger.warning("matplotlib not available for verification rendering")
+        return ""
+
+    try:
+        fig, ax = plt.subplots(figsize=(8, 6))
+        colors = ["#3b82f6", "#ef4444", "#10b981", "#f59e0b", "#8b5cf6",
+                  "#ec4899", "#14b8a6", "#f97316", "#6366f1", "#84cc16"]
+        pt = result.plot_type
+
+        # --- Helper: get unique ordered categories across all series ---
+        def _unique_cats() -> list[str]:
+            cats: list[str] = []
+            seen: set[str] = set()
+            for s in result.series:
+                for v in s.x_values:
+                    k = str(v)
+                    if k not in seen:
+                        seen.add(k)
+                        cats.append(k)
+            return cats
+
+        # --- Helper: safe numeric x/y pairs (skips non-numeric x_values) ---
+        def _xy_numeric(s):
+            x, y = [], []
+            for i, xv in enumerate(s.x_values):
+                if xv is None:
+                    continue
+                try:
+                    xf = float(xv)
+                except (ValueError, TypeError):
+                    continue
+                if i < len(s.y_values) and s.y_values[i] is not None:
+                    x.append(xf)
+                    y.append(s.y_values[i])
+            return x, y
+
+        # --- Helper: build error arrays for a series against a category list ---
+        def _err_arrays(s, unique_cats):
+            vals, elo, ehi = [], [], []
+            for cat in unique_cats:
+                idx = next((i for i, x in enumerate(s.x_values) if str(x) == cat), None)
+                vals.append(s.y_values[idx] if idx is not None and idx < len(s.y_values) else 0)
+                elo.append(s.error_bars_lower[idx] if idx is not None and idx < len(s.error_bars_lower) and s.error_bars_lower[idx] else 0)
+                ehi.append(s.error_bars_upper[idx] if idx is not None and idx < len(s.error_bars_upper) and s.error_bars_upper[idx] else 0)
+            return vals, elo, ehi
+
+        # ================================================================
+        # 1. BOX
+        # ================================================================
+        if pt == PlotType.BOX:
+            # Try to parse structured box stats from notes
+            parsed_boxes = []
+            outlier_map: dict[str, list[float]] = {}
+            if result.notes:
+                # Parse "GroupName: min=X, Q1=X, median=X, Q3=X, max=X"
+                box_pat = re.compile(
+                    r"(.+?):\s*min\s*=\s*([\d.\-eE+]+)\s*,\s*Q1\s*=\s*([\d.\-eE+]+)\s*,"
+                    r"\s*median\s*=\s*([\d.\-eE+]+)\s*,\s*Q3\s*=\s*([\d.\-eE+]+)\s*,"
+                    r"\s*max\s*=\s*([\d.\-eE+]+)",
+                    re.IGNORECASE,
+                )
+                for m in box_pat.finditer(result.notes):
+                    parsed_boxes.append({
+                        "label": m.group(1).strip(),
+                        "min": float(m.group(2)),
+                        "q1": float(m.group(3)),
+                        "med": float(m.group(4)),
+                        "q3": float(m.group(5)),
+                        "max": float(m.group(6)),
+                    })
+                # Parse "GroupName outliers: [val1, val2]"
+                out_pat = re.compile(r"(.+?)\s+outliers:\s*\[([\d.,\s\-eE+]*)\]", re.IGNORECASE)
+                for m in out_pat.finditer(result.notes):
+                    name = m.group(1).strip()
+                    vals_str = m.group(2).strip()
+                    if vals_str:
+                        outlier_map[name] = [float(v.strip()) for v in vals_str.split(",") if v.strip()]
+
+            if parsed_boxes:
+                positions = list(range(1, len(parsed_boxes) + 1))
+                for i, b in enumerate(parsed_boxes):
+                    bp = ax.bxp(
+                        [{"whislo": b["min"], "q1": b["q1"], "med": b["med"],
+                          "q3": b["q3"], "whishi": b["max"],
+                          "fliers": outlier_map.get(b["label"], [])}],
+                        positions=[positions[i]],
+                        widths=0.5,
+                        showfliers=True,
+                        patch_artist=True,
+                    )
+                    for patch in bp.get("boxes", []):
+                        patch.set_facecolor(colors[i % len(colors)])
+                        patch.set_alpha(0.7)
+                ax.set_xticks(positions)
+                ax.set_xticklabels([b["label"] for b in parsed_boxes],
+                                   rotation=35 if any(len(b["label"]) > 5 for b in parsed_boxes) else 0,
+                                   ha="right")
+            else:
+                # Fallback: simple boxplot from y_values
+                box_data = []
+                labels = []
+                for s in result.series:
+                    labels.append(s.name)
+                    box_data.append(s.y_values if s.y_values else [0])
+                if box_data:
+                    bp = ax.boxplot(box_data, labels=labels, patch_artist=True)
+                    for i, patch in enumerate(bp["boxes"]):
+                        patch.set_facecolor(colors[i % len(colors)])
+                        patch.set_alpha(0.7)
+
+        # ================================================================
+        # 2. BAR (with jittered-dot detection)
+        # ================================================================
+        elif pt == PlotType.BAR:
+            unique_cats = _unique_cats()
+            has_repeated = (
+                unique_cats
+                and any(len(s.y_values) > len(unique_cats) * 1.5 for s in result.series)
+            )
+
+            if has_repeated:
+                # Jittered dot plot (individual observations)
+                for si, s in enumerate(result.series):
+                    col = colors[si % len(colors)]
+                    by_cat: dict[str, list[float]] = {}
+                    for i, y in enumerate(s.y_values):
+                        cat = str(s.x_values[i]) if i < len(s.x_values) else ""
+                        by_cat.setdefault(cat, []).append(y)
+                    for ci, cat in enumerate(unique_cats):
+                        pts = by_cat.get(cat, [])
+                        if not pts:
+                            continue
+                        jitter = np.random.normal(0, 0.08, len(pts))
+                        x_pos = ci + (si - len(result.series) / 2 + 0.5) * 0.25
+                        ax.scatter([x_pos + j for j in jitter], pts, color=col, s=20,
+                                   alpha=0.7, label=s.name if ci == 0 else None, zorder=3)
+                ax.set_xticks(range(len(unique_cats)))
+                ax.set_xticklabels(unique_cats,
+                                   rotation=35 if unique_cats and max(len(c) for c in unique_cats) > 5 else 0,
+                                   ha="right")
+            else:
+                # Standard grouped bar chart with error bars
+                if unique_cats:
+                    x_pos = np.arange(len(unique_cats))
+                    width = 0.8 / max(1, len(result.series))
+                    for si, s in enumerate(result.series):
+                        col = colors[si % len(colors)]
+                        offset = (si - len(result.series) / 2 + 0.5) * width
+                        vals, elo, ehi = _err_arrays(s, unique_cats)
+                        has_err = any(e for e in elo + ehi)
+                        ax.bar(x_pos + offset, vals, width, color=col, alpha=0.8,
+                               label=s.name,
+                               yerr=[elo, ehi] if has_err else None, capsize=2)
+                    ax.set_xticks(x_pos)
+                    ax.set_xticklabels(unique_cats,
+                                       rotation=35 if max(len(c) for c in unique_cats) > 5 else 0,
+                                       ha="right")
+                else:
+                    # Numeric x-axis bar
+                    for si, s in enumerate(result.series):
+                        col = colors[si % len(colors)]
+                        xv, yv = _xy_numeric(s)
+                        if xv:
+                            ax.bar(xv, yv, color=col, alpha=0.8, label=s.name)
+
+        # ================================================================
+        # 3. STACKED_BAR
+        # ================================================================
+        elif pt == PlotType.STACKED_BAR:
+            unique_cats = _unique_cats()
+            if unique_cats:
+                x_pos = np.arange(len(unique_cats))
+                bottoms = np.zeros(len(unique_cats))
+                width = 0.6
+                for si, s in enumerate(result.series):
+                    col = colors[si % len(colors)]
+                    vals, _, _ = _err_arrays(s, unique_cats)
+                    vals_arr = np.array(vals, dtype=float)
+                    ax.bar(x_pos, vals_arr, width, bottom=bottoms, color=col,
+                           alpha=0.85, label=s.name)
+                    bottoms += vals_arr
+                ax.set_xticks(x_pos)
+                ax.set_xticklabels(unique_cats,
+                                   rotation=35 if max(len(c) for c in unique_cats) > 5 else 0,
+                                   ha="right")
+
+        # ================================================================
+        # 4. HISTOGRAM
+        # ================================================================
+        elif pt == PlotType.HISTOGRAM:
+            for si, s in enumerate(result.series):
+                col = colors[si % len(colors)]
+                xv, yv = _xy_numeric(s)
+                if xv and yv:
+                    # x = bin centers, y = counts/frequencies
+                    if len(xv) >= 2:
+                        bar_width = abs(xv[1] - xv[0]) * 0.9
+                    else:
+                        bar_width = 1.0
+                    ax.bar(xv, yv, width=bar_width, color=col, alpha=0.7,
+                           edgecolor="white", label=s.name)
+                elif yv:
+                    # Only y-values: treat as raw data for histogram
+                    ax.hist(yv, bins="auto", color=col, alpha=0.7, label=s.name)
+
+        # ================================================================
+        # 5. VIOLIN
+        # ================================================================
+        elif pt == PlotType.VIOLIN:
+            # Attempt proper violin; fallback to box-like
+            data_list = []
+            labels = []
+            for s in result.series:
+                labels.append(s.name)
+                data_list.append(s.y_values if s.y_values else [0])
+            if data_list:
+                # Violin needs at least 2 points per group for KDE
+                can_violin = all(len(d) >= 2 for d in data_list)
+                if can_violin:
+                    parts = ax.violinplot(data_list, showmeans=True, showmedians=True)
+                    for i, pc in enumerate(parts.get("bodies", [])):
+                        pc.set_facecolor(colors[i % len(colors)])
+                        pc.set_alpha(0.7)
+                    ax.set_xticks(range(1, len(labels) + 1))
+                    ax.set_xticklabels(labels,
+                                       rotation=35 if any(len(l) > 5 for l in labels) else 0,
+                                       ha="right")
+                else:
+                    bp = ax.boxplot(data_list, labels=labels, patch_artist=True)
+                    for i, patch in enumerate(bp["boxes"]):
+                        patch.set_facecolor(colors[i % len(colors)])
+                        patch.set_alpha(0.7)
+
+        # ================================================================
+        # 6. FOREST
+        # ================================================================
+        elif pt == PlotType.FOREST:
+            y_positions = []
+            labels_list = []
+            for si, s in enumerate(result.series):
+                col = colors[si % len(colors)]
+                xv, yv = _xy_numeric(s)
+                if not xv and s.x_values:
+                    # x_values are study names, y_values are effect sizes
+                    names = [str(v) for v in s.x_values]
+                    n = min(len(names), len(s.y_values))
+                    positions = list(range(n))
+                    effects = s.y_values[:n]
+                    elo = [abs(s.error_bars_lower[i]) if i < len(s.error_bars_lower) and s.error_bars_lower[i] is not None else 0 for i in range(n)]
+                    ehi = [abs(s.error_bars_upper[i]) if i < len(s.error_bars_upper) and s.error_bars_upper[i] is not None else 0 for i in range(n)]
+                    ax.errorbar(effects, positions, xerr=[elo, ehi],
+                                fmt="o" if si == 0 else "s", color=col, capsize=3,
+                                markersize=6, label=s.name, zorder=3)
+                    if not labels_list:
+                        labels_list = names[:n]
+                        y_positions = positions
+                elif xv and yv:
+                    # x = effect size, y used for positioning
+                    n = len(xv)
+                    positions = list(range(len(y_positions), len(y_positions) + n))
+                    elo = [abs(s.error_bars_lower[i]) if i < len(s.error_bars_lower) and s.error_bars_lower[i] is not None else 0 for i in range(n)]
+                    ehi = [abs(s.error_bars_upper[i]) if i < len(s.error_bars_upper) and s.error_bars_upper[i] is not None else 0 for i in range(n)]
+                    ax.errorbar(xv, positions, xerr=[elo, ehi],
+                                fmt="o", color=col, capsize=3, markersize=6,
+                                label=s.name, zorder=3)
+                    y_positions = positions
+            # Vertical reference line
+            ax.axvline(x=0, color="gray", linestyle="--", linewidth=0.8, zorder=1)
+            # If mostly positive values (e.g., OR/RR), also add line at 1
+            all_y = [v for s in result.series for v in s.y_values if v is not None]
+            if all_y and min(all_y) > 0:
+                ax.axvline(x=1, color="gray", linestyle="--", linewidth=0.8, zorder=1)
+            if labels_list:
+                ax.set_yticks(y_positions)
+                ax.set_yticklabels(labels_list, fontsize=7)
+            ax.invert_yaxis()
+
+        # ================================================================
+        # 7. KAPLAN_MEIER
+        # ================================================================
+        elif pt == PlotType.KAPLAN_MEIER:
+            for si, s in enumerate(result.series):
+                col = colors[si % len(colors)]
+                xv, yv = _xy_numeric(s)
+                if xv and yv:
+                    ax.step(xv, yv, where="post", color=col, linewidth=1.5,
+                            label=s.name)
+            ax.set_ylim(-0.05, 1.05)
+
+        # ================================================================
+        # 8. SCATTER
+        # ================================================================
+        elif pt == PlotType.SCATTER:
+            markers = ["o", "s", "^", "D", "v", "P", "*", "X", "p", "h"]
+            for si, s in enumerate(result.series):
+                col = colors[si % len(colors)]
+                mk = markers[si % len(markers)]
+                xv, yv = _xy_numeric(s)
+                if xv and yv:
+                    ax.scatter(xv, yv, color=col, s=20, alpha=0.8,
+                               marker=mk, label=s.name)
+
+        # ================================================================
+        # 9. LINE
+        # ================================================================
+        elif pt == PlotType.LINE:
+            markers = ["o", "s", "^", "D", "v", "P", "*", "X"]
+            for si, s in enumerate(result.series):
+                col = colors[si % len(colors)]
+                mk = markers[si % len(markers)]
+                xv, yv = _xy_numeric(s)
+                if xv and yv:
+                    # Add error bands if available
+                    elo = [s.error_bars_lower[i] if i < len(s.error_bars_lower) and s.error_bars_lower[i] is not None else 0 for i in range(len(yv))]
+                    ehi = [s.error_bars_upper[i] if i < len(s.error_bars_upper) and s.error_bars_upper[i] is not None else 0 for i in range(len(yv))]
+                    ax.plot(xv, yv, color=col, marker=mk, markersize=4,
+                            linewidth=1.5, label=s.name)
+                    if any(e for e in elo + ehi):
+                        lower = [y - e for y, e in zip(yv, elo)]
+                        upper = [y + e for y, e in zip(yv, ehi)]
+                        ax.fill_between(xv, lower, upper, color=col, alpha=0.15)
+
+        # ================================================================
+        # 10. DOT_STRIP
+        # ================================================================
+        elif pt == PlotType.DOT_STRIP:
+            unique_cats = _unique_cats()
+            for si, s in enumerate(result.series):
+                col = colors[si % len(colors)]
+                by_cat: dict[str, list[float]] = {}
+                for i, y in enumerate(s.y_values):
+                    cat = str(s.x_values[i]) if i < len(s.x_values) else s.name
+                    by_cat.setdefault(cat, []).append(y)
+                for ci, cat in enumerate(unique_cats):
+                    pts = by_cat.get(cat, [])
+                    if not pts:
+                        continue
+                    jitter = np.random.normal(0, 0.1, len(pts))
+                    x_pos = ci + (si - len(result.series) / 2 + 0.5) * 0.3
+                    ax.scatter([x_pos + j for j in jitter], pts, color=col, s=18,
+                               alpha=0.7, label=s.name if ci == 0 else None, zorder=3)
+            if unique_cats:
+                ax.set_xticks(range(len(unique_cats)))
+                ax.set_xticklabels(unique_cats,
+                                   rotation=35 if max(len(c) for c in unique_cats) > 5 else 0,
+                                   ha="right")
+
+        # ================================================================
+        # 11. PAIRED
+        # ================================================================
+        elif pt == PlotType.PAIRED:
+            for si, s in enumerate(result.series):
+                col = colors[si % len(colors)]
+                xv, yv = _xy_numeric(s)
+                if len(xv) >= 2 and len(yv) >= 2:
+                    # Assume pairs: (x[0],y[0]) connected to (x[1],y[1]), etc.
+                    # Or two timepoints per subject
+                    ax.plot(xv, yv, "o-", color=col, alpha=0.5, markersize=5,
+                            label=s.name)
+                elif yv and len(yv) % 2 == 0:
+                    # Before-after pairs with x=0,1
+                    half = len(yv) // 2
+                    for i in range(half):
+                        ax.plot([0, 1], [yv[i], yv[half + i]], "o-", color=col,
+                                alpha=0.4, markersize=5)
+                    ax.plot([], [], "o-", color=col, label=s.name)  # legend entry
+                    ax.set_xticks([0, 1])
+                    ax.set_xticklabels(["Before", "After"])
+
+        # ================================================================
+        # 12. ERROR_BAR
+        # ================================================================
+        elif pt == PlotType.ERROR_BAR:
+            unique_cats = _unique_cats()
+            is_cat = unique_cats and any(isinstance(s.x_values[0], str) for s in result.series if s.x_values)
+            for si, s in enumerate(result.series):
+                col = colors[si % len(colors)]
+                if is_cat and unique_cats:
+                    x_pos = np.arange(len(unique_cats))
+                    offset = (si - len(result.series) / 2 + 0.5) * 0.2
+                    vals, elo, ehi = _err_arrays(s, unique_cats)
+                    has_err = any(e for e in elo + ehi)
+                    ax.errorbar(x_pos + offset, vals,
+                                yerr=[elo, ehi] if has_err else None,
+                                fmt="o", color=col, capsize=4, markersize=6,
+                                label=s.name)
+                    ax.set_xticks(x_pos)
+                    ax.set_xticklabels(unique_cats,
+                                       rotation=35 if max(len(c) for c in unique_cats) > 5 else 0,
+                                       ha="right")
+                else:
+                    xv, yv = _xy_numeric(s)
+                    n = len(yv)
+                    elo = [abs(s.error_bars_lower[i]) if i < len(s.error_bars_lower) and s.error_bars_lower[i] is not None else 0 for i in range(n)]
+                    ehi = [abs(s.error_bars_upper[i]) if i < len(s.error_bars_upper) and s.error_bars_upper[i] is not None else 0 for i in range(n)]
+                    has_err = any(e for e in elo + ehi)
+                    ax.errorbar(xv, yv,
+                                yerr=[elo, ehi] if has_err else None,
+                                fmt="o", color=col, capsize=4, markersize=6,
+                                label=s.name)
+
+        # ================================================================
+        # 13. WATERFALL
+        # ================================================================
+        elif pt == PlotType.WATERFALL:
+            # Typically one series: ordered bars going up/down from baseline
+            for si, s in enumerate(result.series):
+                yv = [v for v in s.y_values if v is not None]
+                if not yv:
+                    continue
+                x_indices = np.arange(len(yv))
+                bar_colors = ["#ef4444" if v >= 0 else "#10b981" for v in yv]
+                ax.bar(x_indices, yv, color=bar_colors, edgecolor="white",
+                       linewidth=0.3, label=s.name)
+                ax.axhline(y=0, color="black", linewidth=0.5)
+            # Reference lines common in waterfall (e.g., +20%, -30%)
+            if result.notes and "20" in result.notes:
+                ax.axhline(y=20, color="gray", linestyle="--", linewidth=0.5)
+                ax.axhline(y=-30, color="gray", linestyle="--", linewidth=0.5)
+
+        # ================================================================
+        # 14. ROC
+        # ================================================================
+        elif pt == PlotType.ROC:
+            for si, s in enumerate(result.series):
+                col = colors[si % len(colors)]
+                xv, yv = _xy_numeric(s)
+                if xv and yv:
+                    ax.plot(xv, yv, color=col, linewidth=1.5, label=s.name)
+            ax.plot([0, 1], [0, 1], "k--", linewidth=0.8, alpha=0.5, label="Reference")
+            ax.set_xlim(-0.02, 1.02)
+            ax.set_ylim(-0.02, 1.02)
+            ax.set_aspect("equal", adjustable="box")
+
+        # ================================================================
+        # 15. HEATMAP
+        # ================================================================
+        elif pt == PlotType.HEATMAP:
+            # Build matrix from series: each series = one row
+            if result.series:
+                matrix = []
+                row_labels = []
+                col_labels = []
+                for s in result.series:
+                    row_labels.append(s.name)
+                    matrix.append(s.y_values if s.y_values else [])
+                    if not col_labels and s.x_values:
+                        col_labels = [str(v) for v in s.x_values]
+                if matrix:
+                    # Pad rows to same length
+                    max_len = max(len(r) for r in matrix)
+                    padded = [r + [0.0] * (max_len - len(r)) for r in matrix]
+                    data = np.array(padded, dtype=float)
+                    im = ax.imshow(data, cmap="RdBu_r", aspect="auto")
+                    fig.colorbar(im, ax=ax, shrink=0.8)
+                    if col_labels:
+                        ax.set_xticks(range(min(len(col_labels), max_len)))
+                        ax.set_xticklabels(col_labels[:max_len], rotation=45, ha="right", fontsize=7)
+                    ax.set_yticks(range(len(row_labels)))
+                    ax.set_yticklabels(row_labels, fontsize=7)
+
+        # ================================================================
+        # 16. VOLCANO
+        # ================================================================
+        elif pt == PlotType.VOLCANO:
+            for si, s in enumerate(result.series):
+                col = colors[si % len(colors)]
+                xv, yv = _xy_numeric(s)
+                if xv and yv:
+                    ax.scatter(xv, yv, color=col, s=12, alpha=0.6, label=s.name)
+            # Threshold lines
+            ax.axhline(y=1.3, color="gray", linestyle="--", linewidth=0.7, alpha=0.6)  # -log10(0.05)
+            ax.axvline(x=-1, color="gray", linestyle="--", linewidth=0.7, alpha=0.6)
+            ax.axvline(x=1, color="gray", linestyle="--", linewidth=0.7, alpha=0.6)
+
+        # ================================================================
+        # 17. FUNNEL
+        # ================================================================
+        elif pt == PlotType.FUNNEL:
+            for si, s in enumerate(result.series):
+                col = colors[si % len(colors)]
+                xv, yv = _xy_numeric(s)
+                if xv and yv:
+                    ax.scatter(xv, yv, color=col, s=25, alpha=0.7, label=s.name)
+            # Reference line at pooled estimate (mean of x)
+            all_x = [v for s in result.series for v in s.x_values if v is not None and not isinstance(v, str)]
+            if all_x:
+                mean_x = float(np.mean(all_x))
+                ax.axvline(x=mean_x, color="black", linestyle="-", linewidth=0.8)
+                # Approximate CI bounds (widening with SE)
+                all_y = [v for s in result.series for v in s.y_values if v is not None]
+                if all_y:
+                    y_range = np.linspace(0, max(all_y), 50)
+                    ax.plot(mean_x - 1.96 * y_range, y_range, "k--", linewidth=0.5, alpha=0.4)
+                    ax.plot(mean_x + 1.96 * y_range, y_range, "k--", linewidth=0.5, alpha=0.4)
+            ax.invert_yaxis()
+
+        # ================================================================
+        # 18. DOSE_RESPONSE
+        # ================================================================
+        elif pt == PlotType.DOSE_RESPONSE:
+            markers = ["o", "s", "^", "D", "v"]
+            for si, s in enumerate(result.series):
+                col = colors[si % len(colors)]
+                mk = markers[si % len(markers)]
+                xv, yv = _xy_numeric(s)
+                if xv and yv:
+                    n = len(yv)
+                    elo = [abs(s.error_bars_lower[i]) if i < len(s.error_bars_lower) and s.error_bars_lower[i] is not None else 0 for i in range(n)]
+                    ehi = [abs(s.error_bars_upper[i]) if i < len(s.error_bars_upper) and s.error_bars_upper[i] is not None else 0 for i in range(n)]
+                    has_err = any(e for e in elo + ehi)
+                    ax.errorbar(xv, yv,
+                                yerr=[elo, ehi] if has_err else None,
+                                fmt=f"-{mk}", color=col, capsize=3, markersize=5,
+                                linewidth=1.5, label=s.name)
+            ax.set_xscale("log")
+
+        # ================================================================
+        # 19. AREA
+        # ================================================================
+        elif pt == PlotType.AREA:
+            # Stacked area if multiple series
+            if len(result.series) > 1:
+                all_x: list[float] = []
+                all_y: list[list[float]] = []
+                area_labels: list[str] = []
+                for s in result.series:
+                    xv, yv = _xy_numeric(s)
+                    if xv and yv:
+                        if not all_x:
+                            all_x = xv
+                        all_y.append(yv[:len(all_x)])
+                        area_labels.append(s.name)
+                if all_x and all_y:
+                    # Pad to same length
+                    min_len = min(len(all_x), *(len(y) for y in all_y))
+                    ax.stackplot(all_x[:min_len], *[y[:min_len] for y in all_y],
+                                 labels=area_labels,
+                                 colors=colors[:len(all_y)], alpha=0.7)
+            else:
+                for si, s in enumerate(result.series):
+                    col = colors[si % len(colors)]
+                    xv, yv = _xy_numeric(s)
+                    if xv and yv:
+                        ax.fill_between(xv, yv, alpha=0.5, color=col, label=s.name)
+                        ax.plot(xv, yv, color=col, linewidth=1)
+
+        # ================================================================
+        # 20. BLAND_ALTMAN
+        # ================================================================
+        elif pt == PlotType.BLAND_ALTMAN:
+            all_x_vals: list[float] = []
+            all_y_vals: list[float] = []
+            for si, s in enumerate(result.series):
+                col = colors[si % len(colors)]
+                xv, yv = _xy_numeric(s)
+                if xv and yv:
+                    ax.scatter(xv, yv, color=col, s=20, alpha=0.7, label=s.name)
+                    all_x_vals.extend(xv)
+                    all_y_vals.extend(yv)
+            if all_y_vals:
+                mean_diff = float(np.mean(all_y_vals))
+                sd_diff = float(np.std(all_y_vals))
+                ax.axhline(y=mean_diff, color="blue", linestyle="-", linewidth=1,
+                            alpha=0.7, label=f"Bias ({mean_diff:.2f})")
+                ax.axhline(y=mean_diff + 1.96 * sd_diff, color="red", linestyle="--",
+                            linewidth=0.8, alpha=0.7, label=f"+1.96 SD")
+                ax.axhline(y=mean_diff - 1.96 * sd_diff, color="red", linestyle="--",
+                            linewidth=0.8, alpha=0.7, label=f"-1.96 SD")
+
+        # ================================================================
+        # FALLBACK: scatter
+        # ================================================================
+        else:
+            markers = ["o", "s", "^", "D", "v", "P", "*", "X"]
+            for si, s in enumerate(result.series):
+                col = colors[si % len(colors)]
+                mk = markers[si % len(markers)]
+                xv, yv = _xy_numeric(s)
+                if xv and yv:
+                    ax.scatter(xv, yv, color=col, s=20, alpha=0.8,
+                               marker=mk, label=s.name)
+
+        # ── Axis scales ──
+        if result.x_scale == "log" and pt != PlotType.DOSE_RESPONSE:
+            try:
+                ax.set_xscale("log")
+            except Exception:
+                pass
+        if result.y_scale == "log":
+            try:
+                ax.set_yscale("log")
+            except Exception:
+                pass
+
+        # ── Labels and title ──
+        if result.x_label:
+            xlabel = result.x_label + (f" ({result.x_unit})" if result.x_unit else "")
+            ax.set_xlabel(xlabel, fontsize=9)
+        if result.y_label:
+            ylabel = result.y_label + (f" ({result.y_unit})" if result.y_unit else "")
+            ax.set_ylabel(ylabel, fontsize=9)
+        if result.title:
+            ax.set_title(result.title, fontsize=10, pad=8)
+        if len(result.series) > 1:
+            ax.legend(fontsize=7, loc="best")
+
+        fig.tight_layout()
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png", dpi=120)
+        plt.close(fig)
+        buf.seek(0)
+        return base64.b64encode(buf.getvalue()).decode()
+
+    except Exception:
+        logger.exception("Failed to render result to PNG")
+        try:
+            plt.close(fig)
+        except Exception:
+            pass
+        return ""
+
+
+async def digitize_figure(figure: Figure) -> tuple[list[ExtractedData], list[Figure]]:
+    """Digitize a figure using a multi-phase pipeline:
+
+    Phase 1 — Panel detection: identify sub-panels in the image
+    Phase 2 — Pre-analysis: identify axes, scale, plot type, legend (per panel)
+    Phase 3 — Data extraction: extract numerical data with full context
+    Phase 4 — Heuristic validation: cheap sanity checks, no API calls
+
+    Returns (results, panel_figures):
+      - results: list of ExtractedData, one per panel
+      - panel_figures: list of cropped Figure objects (empty for single-panel)
+    """
+    # ── Phase 1: Detect panels ──
+    try:
+        panels = await detect_panels(figure)
+    except Exception as e:
+        logger.warning(f"Panel detection failed for {figure.figure_id}: {e}, treating as single panel")
+        panels = [{"label": "main", "plot_type": figure.plot_type.value, "bbox": [0, 0, figure.width, figure.height]}]
+
+    # Single panel — run phases 2+3+4 directly
+    if len(panels) <= 1:
+        # Use panel detection's plot_type if it identified one
+        if panels and panels[0].get("plot_type") and panels[0]["plot_type"] != "other":
+            try:
+                figure = figure.model_copy(update={"plot_type": PlotType(panels[0]["plot_type"])})
+            except ValueError:
+                pass
+        result, pre_analysis = await _digitize_single(figure)
+        result = validate_extraction(result, pre_analysis)
+        return [result], []
+
+    # ── Multi-panel — crop, pre-analyze, and extract each ──
+    logger.info(f"Splitting {figure.figure_id} into {len(panels)} panels: {[p['label'] for p in panels]}")
+    panel_figures = []
+    panel_labels = []
+    for p in panels:
+        pf = _crop_panel(figure, p["bbox"], p["label"], p.get("plot_type", "other"))
+        panel_figures.append(pf)
+        panel_labels.append(p["label"])
+
+    # Pass the full figure image as context so panels can reference
+    # axes, legends, and labels from the complete figure
+    full_b64 = figure.image_base64
+
+    semaphore = asyncio.Semaphore(3)
+
+    async def _extract_panel(pf: Figure, label: str) -> ExtractedData:
+        async with semaphore:
+            try:
+                result, pre_analysis = await _digitize_single(pf, panel_label=label, full_figure_b64=full_b64)
+                result = validate_extraction(result, pre_analysis)
+                return result
+            except Exception as e:
+                logger.error(f"Panel extraction failed for {pf.figure_id}: {e}")
+                return ExtractedData(
+                    figure_id=pf.figure_id,
+                    plot_type=pf.plot_type,
+                    confidence=Confidence.LOW,
+                    notes=f"Extraction failed: {str(e)}",
+                )
+
+    results = await asyncio.gather(*[_extract_panel(pf, lbl) for pf, lbl in zip(panel_figures, panel_labels)])
+    return list(results), panel_figures
+
+
+async def digitize_figures(
+    figures: list[Figure], max_concurrent: int = 3
+) -> tuple[list[ExtractedData], list[Figure]]:
+    """Digitize multiple figures with bounded concurrency.
+
+    Returns (results, panel_figures) — panel_figures contains cropped
+    sub-panel Figure objects for multi-panel images so they can be served.
+    """
+    semaphore = asyncio.Semaphore(max_concurrent)
+    all_panel_figures: list[Figure] = []
+
+    async def _extract(fig: Figure) -> tuple[list[ExtractedData], list[Figure]]:
+        async with semaphore:
+            try:
+                return await digitize_figure(fig)
+            except Exception as e:
+                logger.error(f"Extraction failed for {fig.figure_id}: {e}")
+                return [ExtractedData(
+                    figure_id=fig.figure_id,
+                    plot_type=fig.plot_type,
+                    confidence=Confidence.LOW,
+                    notes=f"Extraction failed: {str(e)}",
+                )], []
+
+    nested = await asyncio.gather(*[_extract(fig) for fig in figures])
+    results = []
+    for data_list, panels in nested:
+        results.extend(data_list)
+        all_panel_figures.extend(panels)
+    return results, all_panel_figures
+
+
+# ── CSV / JSON export ──
+
+
+def export_csv(results: list[ExtractedData], output_path: str) -> str:
+    """Export extraction results to a CSV file. Returns the file path."""
+    import csv
+    from pathlib import Path
+
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            "figure_id", "plot_type", "title", "series_name",
+            "x_label", "y_label", "x_unit", "y_unit",
+            "x_value", "y_value", "error_lower", "error_upper",
+            "confidence", "notes",
+        ])
+        for r in results:
+            for s in r.series:
+                for i in range(len(s.y_values)):
+                    x = s.x_values[i] if i < len(s.x_values) else ""
+                    y = s.y_values[i]
+                    el = s.error_bars_lower[i] if i < len(s.error_bars_lower) else None
+                    eu = s.error_bars_upper[i] if i < len(s.error_bars_upper) else None
+                    writer.writerow([
+                        r.figure_id, r.plot_type.value, r.title or "", s.name,
+                        r.x_label or "", r.y_label or "", r.x_unit or "", r.y_unit or "",
+                        x, y,
+                        el if el is not None else "",
+                        eu if eu is not None else "",
+                        r.confidence.value, r.notes or "",
+                    ])
+    return str(path)
+
+
+def export_json(results: list[ExtractedData], output_path: str) -> str:
+    """Export extraction results to a JSON file. Returns the file path."""
+    from pathlib import Path
+
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = [r.model_dump() for r in results]
+    path.write_text(json.dumps(data, indent=2, default=str))
+    return str(path)
+
+
+async def extract_from_image(
+    image_path: str | None = None,
+    image_bytes: bytes | None = None,
+    plot_type: str | None = None,
+) -> tuple[list[ExtractedData], list[Figure]]:
+    """Extract data from an image file or bytes.
+
+    Convenience wrapper that handles loading, base64-encoding, and
+    creating the Figure object before calling digitize_figure().
+    """
+    if image_bytes is None:
+        if image_path is None:
+            raise ValueError("Either image_path or image_bytes must be provided")
+        from pathlib import Path
+        image_bytes = Path(image_path).read_bytes()
+
+    img = Image.open(io.BytesIO(image_bytes))
+    if img.mode == "RGBA":
+        bg = Image.new("RGB", img.size, (255, 255, 255))
+        bg.paste(img, mask=img.split()[3])
+        img = bg
+    elif img.mode != "RGB":
+        img = img.convert("RGB")
+
+    # Resize if too large
+    if img.width > 1500 or img.height > 1500:
+        img.thumbnail((1500, 1500), Image.LANCZOS)
+
+    buf = io.BytesIO()
+    img.save(buf, format="PNG", optimize=True)
+    b64 = base64.b64encode(buf.getvalue()).decode()
+
+    pt = PlotType.OTHER
+    if plot_type:
+        try:
+            pt = PlotType(plot_type)
+        except ValueError:
+            pass
+
+    figure = Figure(
+        figure_id="image",
+        paper_id="standalone",
+        page_number=1,
+        image_index=0,
+        width=img.width,
+        height=img.height,
+        image_base64=b64,
+        plot_type=pt,
+        plot_type_confidence=Confidence.MEDIUM,
+    )
+
+    return await digitize_figure(figure)

--- a/skills/data-extractor/core/models.py
+++ b/skills/data-extractor/core/models.py
@@ -1,0 +1,86 @@
+"""Pydantic models for the data-extractor skill."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class PlotType(str, Enum):
+    SCATTER = "scatter"
+    BAR = "bar"
+    LINE = "line"
+    BOX = "box"
+    VIOLIN = "violin"
+    HISTOGRAM = "histogram"
+    HEATMAP = "heatmap"
+    FOREST = "forest"
+    KAPLAN_MEIER = "kaplan_meier"
+    DOT_STRIP = "dot_strip"
+    STACKED_BAR = "stacked_bar"
+    FUNNEL = "funnel"
+    ROC = "roc"
+    VOLCANO = "volcano"
+    WATERFALL = "waterfall"
+    BLAND_ALTMAN = "bland_altman"
+    PAIRED = "paired"
+    BUBBLE = "bubble"
+    AREA = "area"
+    DOSE_RESPONSE = "dose_response"
+    MANHATTAN = "manhattan"
+    CORRELATION_MATRIX = "correlation_matrix"
+    ERROR_BAR = "error_bar"
+    TABLE = "table"
+    OTHER = "other"
+    NON_DATA = "non_data"
+
+
+class Confidence(str, Enum):
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class Figure(BaseModel):
+    figure_id: str
+    paper_id: str
+    page_number: int
+    image_index: int
+    width: int
+    height: int
+    image_base64: str
+    title: Optional[str] = None
+    legend: Optional[str] = None
+    plot_type: PlotType = PlotType.OTHER
+    plot_type_confidence: Confidence = Confidence.MEDIUM
+
+
+class DataSeries(BaseModel):
+    name: str = "Series 1"
+    x_values: list[float | str] = Field(default_factory=list)
+    y_values: list[float] = Field(default_factory=list)
+    error_bars_lower: list[float | None] = Field(default_factory=list)
+    error_bars_upper: list[float | None] = Field(default_factory=list)
+
+
+class ExtractedData(BaseModel):
+    figure_id: str
+    plot_type: PlotType
+    title: Optional[str] = None
+    x_label: Optional[str] = None
+    y_label: Optional[str] = None
+    x_unit: Optional[str] = None
+    y_unit: Optional[str] = None
+    x_min: Optional[float] = None
+    x_max: Optional[float] = None
+    y_min: Optional[float] = None
+    y_max: Optional[float] = None
+    x_scale: Optional[str] = None  # "linear" or "log"
+    y_scale: Optional[str] = None  # "linear" or "log"
+    series: list[DataSeries] = Field(default_factory=list)
+    confidence: Confidence = Confidence.MEDIUM
+    notes: Optional[str] = None
+    legend_text: Optional[str] = None
+    text_mentions: list[str] = Field(default_factory=list)

--- a/skills/data-extractor/data_extractor.py
+++ b/skills/data-extractor/data_extractor.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""ClawBio data-extractor CLI.
+
+Usage:
+    python data_extractor.py --image figure.png --output results/
+    python data_extractor.py --web --port 8765
+    python data_extractor.py --demo
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Ensure skill root is on sys.path
+_SKILL_DIR = Path(__file__).resolve().parent
+if str(_SKILL_DIR) not in sys.path:
+    sys.path.insert(0, str(_SKILL_DIR))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="ClawBio Data Extractor — digitize scientific figures",
+    )
+    parser.add_argument("--image", dest="image_path", help="Path to figure image (PNG/JPG)")
+    parser.add_argument("--output", "-o", dest="output_dir", help="Output directory for CSV/JSON")
+    parser.add_argument("--web", action="store_true", help="Launch interactive web UI")
+    parser.add_argument("--port", type=int, default=8765, help="Web UI port (default: 8765)")
+    parser.add_argument("--plot-type", dest="plot_type", help="Force plot type (skip auto-detection)")
+    parser.add_argument("--demo", action="store_true", help="Run on bundled demo figure")
+    parser.add_argument("--json", action="store_true", help="Output results as JSON to stdout")
+
+    args = parser.parse_args()
+
+    from api import run
+
+    if args.demo:
+        demo_fig = _SKILL_DIR / "data" / "demo_figure.png"
+        if not demo_fig.exists():
+            print("Demo figure not found. Place a figure at data/demo_figure.png")
+            sys.exit(1)
+        result = run(options={
+            "image_path": str(demo_fig),
+            "output_dir": args.output_dir or str(_SKILL_DIR / "output" / "demo"),
+        })
+    elif args.web:
+        result = run(options={"web": True, "port": args.port})
+    elif args.image_path:
+        result = run(options={
+            "image_path": args.image_path,
+            "output_dir": args.output_dir or str(_SKILL_DIR / "output"),
+            "plot_type": args.plot_type,
+        })
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+    if args.json:
+        print(json.dumps(result, indent=2, default=str))
+    elif result.get("success"):
+        summary = result.get("summary", {})
+        print(f"\n  Extracted {summary.get('n_panels', 0)} panel(s), "
+              f"{summary.get('n_series', 0)} series, "
+              f"{summary.get('total_points', 0)} data points")
+        for f in result.get("output_files", []):
+            print(f"  -> {f}")
+        if result.get("mode") == "web":
+            print(f"  Web UI running on port {result.get('port', 8765)}")
+    else:
+        print(f"\n  Error: {result.get('error', 'Unknown error')}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/data-extractor/tests/test_extractor.py
+++ b/skills/data-extractor/tests/test_extractor.py
@@ -1,0 +1,181 @@
+"""Tests for the data-extractor skill."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add skill root to sys.path
+_SKILL_DIR = Path(__file__).resolve().parent.parent
+if str(_SKILL_DIR) not in sys.path:
+    sys.path.insert(0, str(_SKILL_DIR))
+
+
+def test_models_import():
+    """Test that core models can be imported."""
+    from core.models import PlotType, Confidence, Figure, DataSeries, ExtractedData
+
+    assert PlotType.BAR.value == "bar"
+    assert Confidence.HIGH.value == "high"
+    assert len(PlotType) == 26
+
+
+def test_plot_type_enum():
+    """Test all expected plot types exist."""
+    from core.models import PlotType
+
+    expected = [
+        "scatter", "bar", "line", "box", "violin", "histogram",
+        "heatmap", "forest", "kaplan_meier", "dot_strip", "stacked_bar",
+        "funnel", "roc", "volcano", "waterfall", "bland_altman",
+        "paired", "bubble", "area", "dose_response", "manhattan",
+        "correlation_matrix", "error_bar", "table", "other", "non_data",
+    ]
+    for pt in expected:
+        assert PlotType(pt), f"PlotType missing: {pt}"
+
+
+def test_extracted_data_model():
+    """Test ExtractedData model creation."""
+    from core.models import ExtractedData, PlotType, Confidence, DataSeries
+
+    data = ExtractedData(
+        figure_id="test_fig",
+        plot_type=PlotType.BAR,
+        title="Test bar chart",
+        x_label="Category",
+        y_label="Value",
+        series=[
+            DataSeries(
+                name="Group A",
+                x_values=["Cat1", "Cat2", "Cat3"],
+                y_values=[10.5, 20.3, 15.7],
+                error_bars_lower=[1.2, 2.1, 1.5],
+                error_bars_upper=[1.3, 1.9, 1.6],
+            ),
+        ],
+        confidence=Confidence.HIGH,
+    )
+
+    assert data.figure_id == "test_fig"
+    assert len(data.series) == 1
+    assert data.series[0].name == "Group A"
+    assert len(data.series[0].y_values) == 3
+
+
+def test_cv_calibration_import():
+    """Test that cv_calibration module can be imported."""
+    from core.cv_calibration import (
+        PlotRegion, DetectedMarker, DetectedBar, CalibrationResult,
+        calibrate_image, format_calibration_prompt,
+    )
+
+    # Test CalibrationResult creation
+    result = CalibrationResult()
+    assert result.markers == []
+    assert result.bars == []
+
+
+def test_digitizer_prompts():
+    """Test that digitizer prompts are defined."""
+    from core.digitizer import BASE_PROMPT, PLOT_GUIDANCE, DEFAULT_GUIDANCE
+
+    assert "STEP 1" in BASE_PROMPT
+    assert "STEP 4" in BASE_PROMPT
+    assert len(PLOT_GUIDANCE) > 10  # Should have many plot types
+
+
+def test_export_csv(tmp_path):
+    """Test CSV export."""
+    from core.models import ExtractedData, PlotType, Confidence, DataSeries
+    from core.digitizer import export_csv
+
+    results = [
+        ExtractedData(
+            figure_id="test",
+            plot_type=PlotType.SCATTER,
+            series=[
+                DataSeries(
+                    name="Series 1",
+                    x_values=[1.0, 2.0, 3.0],
+                    y_values=[4.0, 5.0, 6.0],
+                ),
+            ],
+            confidence=Confidence.MEDIUM,
+        ),
+    ]
+
+    csv_path = export_csv(results, str(tmp_path / "test.csv"))
+    assert Path(csv_path).exists()
+
+    content = Path(csv_path).read_text()
+    assert "Series 1" in content
+    assert "scatter" in content
+
+
+def test_export_json(tmp_path):
+    """Test JSON export."""
+    import json
+    from core.models import ExtractedData, PlotType, Confidence, DataSeries
+    from core.digitizer import export_json
+
+    results = [
+        ExtractedData(
+            figure_id="test",
+            plot_type=PlotType.BAR,
+            series=[
+                DataSeries(name="A", x_values=["x"], y_values=[1.0]),
+            ],
+            confidence=Confidence.HIGH,
+        ),
+    ]
+
+    json_path = export_json(results, str(tmp_path / "test.json"))
+    assert Path(json_path).exists()
+
+    data = json.loads(Path(json_path).read_text())
+    assert len(data) == 1
+    assert data[0]["plot_type"] == "bar"
+
+
+def test_api_run_no_input():
+    """Test api.run() with no input returns error."""
+    from api import run
+
+    result = run()
+    assert result["success"] is False
+    assert "No image" in result["error"]
+
+
+def test_validate_extraction():
+    """Test heuristic validation."""
+    from core.models import ExtractedData, PlotType, Confidence, DataSeries
+    from core.digitizer import validate_extraction
+
+    # Valid result — should pass
+    result = ExtractedData(
+        figure_id="test",
+        plot_type=PlotType.BAR,
+        y_min=0, y_max=100,
+        series=[
+            DataSeries(name="A", x_values=["x"], y_values=[50.0]),
+        ],
+        confidence=Confidence.HIGH,
+    )
+    validated = validate_extraction(result)
+    assert validated.confidence == Confidence.HIGH
+
+    # Out-of-range value — should flag
+    result2 = ExtractedData(
+        figure_id="test",
+        plot_type=PlotType.BAR,
+        y_min=0, y_max=100,
+        series=[
+            DataSeries(name="A", x_values=["x"], y_values=[250.0]),
+        ],
+        confidence=Confidence.HIGH,
+    )
+    validated2 = validate_extraction(result2)
+    assert "outside axis range" in (validated2.notes or "")

--- a/skills/data-extractor/web/app.js
+++ b/skills/data-extractor/web/app.js
@@ -1,0 +1,1733 @@
+// Get Me The Data — Frontend (screenshot-only mode)
+
+var currentImageId = null;
+var extractedResults = [];
+
+// ── Helpers ──
+
+function show(id) { document.getElementById(id).classList.remove("hidden"); }
+function hide(id) { document.getElementById(id).classList.add("hidden"); }
+
+function setStatus(id, msg, type) {
+    type = type || "info";
+    var el = document.getElementById(id);
+    if (!el) return;
+    var colors = { info: "text-gray-500", success: "text-green-600", error: "text-red-600", loading: "text-blue-600" };
+    el.className = "text-sm " + (colors[type] || colors.info);
+    el.innerHTML = type === "loading" ? '<span class="spinner"></span> ' + msg : msg;
+}
+
+async function api(url, options) {
+    options = options || {};
+    var resp = await fetch(url, {
+        headers: { "Content-Type": "application/json" },
+        ...options,
+    });
+    if (!resp.ok) {
+        var err = await resp.json().catch(function() { return { detail: resp.statusText }; });
+        throw new Error(err.detail || "Request failed");
+    }
+    return resp;
+}
+
+// ── Image Upload ──
+
+async function uploadImage(file) {
+    setStatus("viewer-status", "Uploading image...", "loading");
+    var formData = new FormData();
+    formData.append("file", file);
+    try {
+        var resp = await fetch("/api/upload-image", { method: "POST", body: formData });
+        if (!resp.ok) {
+            var err = await resp.json();
+            throw new Error(err.detail);
+        }
+        var data = await resp.json();
+        currentImageId = data.image_id;
+        document.getElementById("main-image").src = "/api/image/" + data.image_id;
+        hide("drop-section");
+        show("viewer-section");
+        setStatus("viewer-status", "Image loaded. Draw boxes around plots to extract data.", "success");
+
+        document.getElementById("main-image").onload = function() {
+            _initDrawing();
+        };
+    } catch (e) {
+        setStatus("viewer-status", "Upload failed: " + e.message, "error");
+    }
+}
+
+function handleImageUpload(event) {
+    var file = event.target.files[0];
+    if (file) uploadImage(file);
+}
+
+async function loadExample(name) {
+    try {
+        var resp = await fetch("/static/examples/" + name + ".png");
+        if (!resp.ok) throw new Error("Example not found");
+        var blob = await resp.blob();
+        var file = new File([blob], name + ".png", { type: "image/png" });
+        uploadImage(file);
+    } catch (e) {
+        setStatus("viewer-status", "Failed to load example: " + e.message, "error");
+    }
+}
+
+function clearImage() {
+    currentImageId = null;
+    extractedResults = [];
+    pageBoxes = {};
+    boxIdCounter = 0;
+    _drawingInitialized = false;
+    document.getElementById("main-image").src = "";
+    document.getElementById("plot-boxes-layer").innerHTML = "";
+    document.getElementById("page-results").innerHTML = "";
+    document.getElementById("results-container").innerHTML = "";
+    hide("viewer-section");
+    hide("results-section");
+    show("drop-section");
+    document.getElementById("image-upload").value = "";
+}
+
+// ── Drag-and-drop + paste ──
+
+// Prevent browser default file-open on ALL drag/drop events globally.
+// Without this, dropping a file anywhere opens it in a new tab.
+window.addEventListener("dragover", function(e) { e.preventDefault(); }, false);
+window.addEventListener("drop", function(e) { e.preventDefault(); }, false);
+
+document.addEventListener("DOMContentLoaded", function() {
+    var zone = document.getElementById("drop-zone");
+    zone.addEventListener("dragover", function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        zone.classList.add("dragover");
+    });
+    zone.addEventListener("dragleave", function() { zone.classList.remove("dragover"); });
+    zone.addEventListener("drop", function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        zone.classList.remove("dragover");
+        var file = e.dataTransfer.files[0];
+        if (file && file.type.startsWith("image/")) {
+            uploadImage(file);
+        }
+    });
+
+    // Also allow dropping on the whole page (handles drops outside the zone)
+    document.addEventListener("drop", function(e) {
+        e.preventDefault();
+        var file = e.dataTransfer && e.dataTransfer.files[0];
+        if (file && file.type.startsWith("image/")) {
+            uploadImage(file);
+        }
+    });
+
+    // Paste from clipboard
+    document.addEventListener("paste", function(e) {
+        var items = e.clipboardData && e.clipboardData.items;
+        if (!items) return;
+        for (var i = 0; i < items.length; i++) {
+            if (items[i].type.indexOf("image") !== -1) {
+                var file = items[i].getAsFile();
+                if (file) uploadImage(file);
+                break;
+            }
+        }
+    });
+});
+
+// ── Drawing rectangles ──
+
+var pageBoxes = {};  // { 1: [ {id, num, x_pct, y_pct, w_pct, h_pct} ] }
+var boxIdCounter = 0;
+var _drawingInitialized = false;
+
+function _initDrawing() {
+    if (_drawingInitialized) return;
+    _drawingInitialized = true;
+
+    var drawLayer = document.getElementById("draw-layer");
+    var drawing = false;
+    var preview = null;
+    var startX, startY;
+
+    drawLayer.addEventListener("mousedown", function(e) {
+        if (e.target !== drawLayer) return;
+        e.preventDefault();
+        drawing = true;
+        var rect = drawLayer.getBoundingClientRect();
+        startX = e.clientX - rect.left;
+        startY = e.clientY - rect.top;
+
+        preview = document.createElement("div");
+        preview.className = "draw-preview";
+        preview.style.left = startX + "px";
+        preview.style.top = startY + "px";
+        preview.style.width = "0px";
+        preview.style.height = "0px";
+        drawLayer.appendChild(preview);
+    });
+
+    document.addEventListener("mousemove", function(e) {
+        if (!drawing || !preview) return;
+        var rect = drawLayer.getBoundingClientRect();
+        var curX = Math.max(0, Math.min(e.clientX - rect.left, rect.width));
+        var curY = Math.max(0, Math.min(e.clientY - rect.top, rect.height));
+
+        var x = Math.min(startX, curX), y = Math.min(startY, curY);
+        var w = Math.abs(curX - startX), h = Math.abs(curY - startY);
+
+        preview.style.left = x + "px";
+        preview.style.top = y + "px";
+        preview.style.width = w + "px";
+        preview.style.height = h + "px";
+    });
+
+    document.addEventListener("mouseup", function(e) {
+        if (!drawing || !preview) return;
+        drawing = false;
+
+        var rect = drawLayer.getBoundingClientRect();
+        var px = parseFloat(preview.style.left);
+        var py = parseFloat(preview.style.top);
+        var pw = parseFloat(preview.style.width);
+        var ph = parseFloat(preview.style.height);
+
+        preview.remove();
+        preview = null;
+
+        if (pw < 20 || ph < 20) return;
+
+        var x_pct = px / rect.width * 100;
+        var y_pct = py / rect.height * 100;
+        var w_pct = pw / rect.width * 100;
+        var h_pct = ph / rect.height * 100;
+
+        _addBox(x_pct, y_pct, w_pct, h_pct);
+    });
+}
+
+function _addBox(x_pct, y_pct, w_pct, h_pct) {
+    if (!pageBoxes[1]) pageBoxes[1] = [];
+    boxIdCounter++;
+    var num = pageBoxes[1].length + 1;
+    var b = {
+        id: boxIdCounter,
+        num: num,
+        x_pct: x_pct, y_pct: y_pct,
+        w_pct: w_pct, h_pct: h_pct,
+    };
+    pageBoxes[1].push(b);
+    _renderOneBox(b);
+}
+
+function _renumberBoxes() {
+    var boxes = pageBoxes[1] || [];
+    boxes.forEach(function(b, i) {
+        b.num = i + 1;
+        var label = document.querySelector("#plot-box-" + b.id + " .box-label");
+        if (label) label.textContent = "#" + b.num;
+    });
+}
+
+async function autoDetectPlots() {
+    if (!currentImageId) return;
+    setStatus("viewer-status", "Auto-detecting plots...", "loading");
+    document.getElementById("auto-detect-btn").disabled = true;
+    try {
+        var resp = await api("/api/detect-plots/" + currentImageId);
+        var data = await resp.json();
+        var plots = data.plots || [];
+        plots.forEach(function(p) {
+            _addBox(p.x_pct, p.y_pct, p.w_pct, p.h_pct);
+        });
+        setStatus("viewer-status", plots.length + " plot(s) detected and added", "success");
+    } catch (e) {
+        setStatus("viewer-status", "Detection failed: " + e.message, "error");
+    } finally {
+        document.getElementById("auto-detect-btn").disabled = false;
+    }
+}
+
+// ── Plot box rendering ──
+
+function renderPlotBoxes() {
+    var layer = document.getElementById("plot-boxes-layer");
+    layer.innerHTML = "";
+    var boxes = pageBoxes[1] || [];
+    boxes.forEach(function(b) { _renderOneBox(b); });
+}
+
+function _renderOneBox(b) {
+    var layer = document.getElementById("plot-boxes-layer");
+    var el = document.createElement("div");
+    el.className = "plot-box";
+    el.id = "plot-box-" + b.id;
+    el.style.cssText = "left:" + b.x_pct + "%;top:" + b.y_pct + "%;width:" + b.w_pct + "%;height:" + b.h_pct + "%";
+
+    el.innerHTML =
+        '<span class="box-label">#' + b.num + '</span>' +
+        '<div class="box-controls">' +
+            '<button class="box-btn btn-extract" onclick="extractBox(' + b.id + ')">Extract</button>' +
+            '<button class="box-btn btn-delete" onclick="deleteBox(' + b.id + ')">&times;</button>' +
+        '</div>' +
+        '<div class="box-handle se" data-handle="se"></div>' +
+        '<div class="box-handle sw" data-handle="sw"></div>' +
+        '<div class="box-handle ne" data-handle="ne"></div>' +
+        '<div class="box-handle nw" data-handle="nw"></div>';
+
+    layer.appendChild(el);
+    _makeBoxDraggable(b.id, el);
+}
+
+function _makeBoxDraggable(boxId, el) {
+    function clamp(v, mn, mx) { return Math.max(mn, Math.min(mx, v)); }
+
+    el.addEventListener("mousedown", function(e) {
+        if (e.target.classList.contains("box-btn")) return;
+        e.preventDefault();
+        e.stopPropagation();
+        var handle = e.target.dataset.handle;
+        var dragging = handle || "move";
+        var layer = document.getElementById("plot-boxes-layer");
+        var lw = layer.clientWidth, lh = layer.clientHeight;
+        var startX = e.clientX, startY = e.clientY;
+        var startL = parseFloat(el.style.left) / 100 * lw;
+        var startT = parseFloat(el.style.top) / 100 * lh;
+        var startW = parseFloat(el.style.width) / 100 * lw;
+        var startH = parseFloat(el.style.height) / 100 * lh;
+
+        function onMove(e) {
+            var dx = e.clientX - startX, dy = e.clientY - startY;
+            var nl, nt, nw, nh;
+
+            if (dragging === "move") {
+                nl = clamp(startL + dx, 0, lw - startW); nt = clamp(startT + dy, 0, lh - startH);
+                nw = startW; nh = startH;
+            } else if (dragging === "se") {
+                nl = startL; nt = startT;
+                nw = clamp(startW + dx, 20, lw - startL); nh = clamp(startH + dy, 20, lh - startT);
+            } else if (dragging === "nw") {
+                nw = clamp(startW - dx, 20, startL + startW); nh = clamp(startH - dy, 20, startT + startH);
+                nl = startL + startW - nw; nt = startT + startH - nh;
+            } else if (dragging === "ne") {
+                nl = startL; nw = clamp(startW + dx, 20, lw - startL);
+                nh = clamp(startH - dy, 20, startT + startH); nt = startT + startH - nh;
+            } else if (dragging === "sw") {
+                nw = clamp(startW - dx, 20, startL + startW); nl = startL + startW - nw;
+                nt = startT; nh = clamp(startH + dy, 20, lh - startT);
+            }
+
+            el.style.left = (nl / lw * 100) + "%";
+            el.style.top = (nt / lh * 100) + "%";
+            el.style.width = (nw / lw * 100) + "%";
+            el.style.height = (nh / lh * 100) + "%";
+        }
+
+        function onUp() {
+            document.removeEventListener("mousemove", onMove);
+            document.removeEventListener("mouseup", onUp);
+            var boxes = pageBoxes[1] || [];
+            var b = boxes.find(function(x) { return x.id === boxId; });
+            if (b) {
+                b.x_pct = parseFloat(el.style.left);
+                b.y_pct = parseFloat(el.style.top);
+                b.w_pct = parseFloat(el.style.width);
+                b.h_pct = parseFloat(el.style.height);
+            }
+        }
+
+        document.addEventListener("mousemove", onMove);
+        document.addEventListener("mouseup", onUp);
+    });
+}
+
+function deleteBox(boxId) {
+    var boxes = pageBoxes[1] || [];
+    pageBoxes[1] = boxes.filter(function(b) { return b.id !== boxId; });
+    var el = document.getElementById("plot-box-" + boxId);
+    if (el) el.remove();
+    var resultEl = document.getElementById("result-box-" + boxId);
+    if (resultEl) resultEl.remove();
+    _renumberBoxes();
+}
+
+// ── Extraction ──
+
+async function extractBox(boxId) {
+    var boxes = pageBoxes[1] || [];
+    var b = boxes.find(function(x) { return x.id === boxId; });
+    if (!b || !currentImageId) return;
+
+    var el = document.getElementById("plot-box-" + boxId);
+    if (el) el.classList.add("extracting");
+
+    try {
+        var resp = await api("/api/extract-image-region", {
+            method: "POST",
+            body: JSON.stringify({
+                image_id: currentImageId,
+                crop_x_pct: b.x_pct,
+                crop_y_pct: b.y_pct,
+                crop_w_pct: b.w_pct,
+                crop_h_pct: b.h_pct,
+            }),
+        });
+        var results = await resp.json();
+        extractedResults = extractedResults.concat(results);
+
+        if (el) { el.classList.remove("extracting"); el.classList.add("done"); }
+
+        var container = document.getElementById("page-results");
+        var oldResult = document.getElementById("result-box-" + boxId);
+        if (oldResult) oldResult.remove();
+
+        results.forEach(function(result, ri) {
+            var rIdx = extractedResults.length - results.length + ri;
+            var div = document.createElement("div");
+            div.className = "border border-gray-200 rounded-lg p-4";
+            div.id = "result-box-" + boxId;
+            div.innerHTML = '<p class="text-xs font-semibold text-purple-600 mb-1">Region #' + b.num + '</p>' +
+                _buildResultHtml(result, rIdx);
+            container.appendChild(div);
+        });
+
+        if (extractedResults.length > 0) show("results-section");
+    } catch (e) {
+        if (el) el.classList.remove("extracting");
+        setStatus("viewer-status", "Extraction failed: " + e.message, "error");
+    }
+}
+
+// ── Result HTML ──
+
+function _buildResultHtml(result, idx) {
+    var confIcon = { high: "\u2713", medium: "~", low: "?" }[result.confidence] || "?";
+    var pointCount = 0;
+    if (result.series) result.series.forEach(function(s) { pointCount += s.y_values.length; });
+
+    var displayTitle = result.title || result.figure_id;
+
+    var html = '<div class="border-t border-gray-100 pt-3 mt-3">';
+    html += '<div class="flex justify-between items-start mb-2"><div>' +
+        '<p class="text-sm font-medium text-gray-700">' + displayTitle + '</p>' +
+        '<p class="text-xs text-gray-500">' +
+            '<span class="badge badge-' + result.plot_type + '">' + result.plot_type.replace("_", " ") + '</span>' +
+            ' <span class="ml-1 confidence-' + result.confidence + '">' + confIcon + " " + result.confidence + '</span>' +
+            ' <span class="ml-1 text-gray-400">' + (result.series ? result.series.length + " series, " + pointCount + " pts" : "") + '</span>' +
+        '</p>' +
+        (result.x_label ? '<p class="text-xs text-gray-400">X: ' + result.x_label + (result.x_unit ? " (" + result.x_unit + ")" : "") + (result.x_scale === "log" ? ' <span class="text-purple-500 font-medium">[log]</span>' : "") + " / Y: " + (result.y_label || "") + (result.y_unit ? " (" + result.y_unit + ")" : "") + (result.y_scale === "log" ? ' <span class="text-purple-500 font-medium">[log]</span>' : "") + '</p>' : "") +
+        (result.notes ? '<p class="text-xs text-amber-600 mt-1">' + result.notes + '</p>' : "") +
+    '</div>' +
+    '<button onclick="downloadFigureCsv(' + idx + ')" class="text-xs bg-gray-100 px-2 py-1 rounded hover:bg-gray-200 flex-shrink-0">CSV</button></div>';
+
+    // Context: legend text and text mentions
+    if (result.legend_text || (result.text_mentions && result.text_mentions.length > 0)) {
+        html += '<details class="mb-2"><summary class="text-xs text-blue-600 cursor-pointer hover:text-blue-800">Extraction context (legend &amp; mentions)</summary>';
+        html += '<div class="mt-1 p-2 bg-blue-50 rounded text-xs text-gray-700 space-y-1">';
+        if (result.legend_text) {
+            html += '<p><span class="font-semibold text-gray-800">Legend:</span> ' + result.legend_text + '</p>';
+        }
+        if (result.text_mentions && result.text_mentions.length > 0) {
+            html += '<div class="mt-1"><span class="font-semibold text-gray-800">Mentioned in text:</span><ul class="list-disc ml-4 mt-0.5">';
+            result.text_mentions.forEach(function(m) {
+                html += '<li>' + m + '</li>';
+            });
+            html += '</ul></div>';
+        }
+        html += '</div></details>';
+    }
+
+    // Check if ANY series has actual error bar values (not all null)
+    var hasErrors = false;
+    if (result.series) {
+        result.series.forEach(function(s) {
+            if (s.error_bars_lower && s.error_bars_lower.some(function(v) { return v != null && v !== 0; })) hasErrors = true;
+            if (s.error_bars_upper && s.error_bars_upper.some(function(v) { return v != null && v !== 0; })) hasErrors = true;
+        });
+    }
+    var ncols = hasErrors ? 4 : 2;
+
+    // Data table — full width, no max-height
+    html += '<div class="overflow-auto"><table class="data-table w-full text-sm border-collapse">';
+    if (result.series && result.series.length > 0) {
+        result.series.forEach(function(series) {
+            html += '<tr class="bg-gray-50"><td colspan="' + ncols + '" class="font-medium py-1 px-2 text-gray-700 text-xs">' + series.name + '</td></tr>';
+            html += '<tr class="border-b border-gray-200 text-gray-500 text-xs bg-white">' +
+                '<th class="py-1 px-2 text-left">' + (result.x_label || "X") + '</th>' +
+                '<th class="py-1 px-2 text-left">' + (result.y_label || "Y") + '</th>';
+            if (hasErrors) html += '<th class="py-1 px-2 text-left">Err-</th><th class="py-1 px-2 text-left">Err+</th>';
+            html += '</tr>';
+            for (var i = 0; i < series.y_values.length; i++) {
+                var x = i < series.x_values.length ? series.x_values[i] : "";
+                var y = series.y_values[i];
+                html += '<tr class="border-b border-gray-100">' +
+                    '<td class="px-1"><input value="' + x + '" data-result="' + idx + '" data-series="' + series.name + '" data-row="' + i + '" data-col="x" onchange="updateCell(this)"></td>' +
+                    '<td class="px-1"><input value="' + y + '" data-result="' + idx + '" data-series="' + series.name + '" data-row="' + i + '" data-col="y" onchange="updateCell(this)"></td>';
+                if (hasErrors) {
+                    var el = (series.error_bars_lower && i < series.error_bars_lower.length && series.error_bars_lower[i] != null) ? series.error_bars_lower[i] : "";
+                    var eu = (series.error_bars_upper && i < series.error_bars_upper.length && series.error_bars_upper[i] != null) ? series.error_bars_upper[i] : "";
+                    html += '<td class="px-1"><input value="' + el + '" data-result="' + idx + '" data-series="' + series.name + '" data-row="' + i + '" data-col="el" onchange="updateCell(this)"></td>' +
+                        '<td class="px-1"><input value="' + eu + '" data-result="' + idx + '" data-series="' + series.name + '" data-row="' + i + '" data-col="eu" onchange="updateCell(this)"></td>';
+                }
+                html += '</tr>';
+            }
+        });
+    } else {
+        html += '<tr><td colspan="' + ncols + '" class="py-4 text-center text-gray-400">No data extracted</td></tr>';
+    }
+    html += '</table></div>';
+
+    // SVG preview — below table, not side-by-side
+    if (result.series && result.series.length > 0) {
+        html += '<div class="mt-3">' + makeDataPlotSvg(result) + '</div>';
+    }
+    html += '</div>';
+    return html;
+}
+
+// ── Cell editing ──
+
+function updateCell(input) {
+    var idx = parseInt(input.dataset.result);
+    var seriesName = input.dataset.series;
+    var row = parseInt(input.dataset.row);
+    var col = input.dataset.col;
+    var val = input.value === "" ? null : isNaN(input.value) ? input.value : parseFloat(input.value);
+
+    var result = extractedResults[idx];
+    if (!result) return;
+    var seriesIdx = -1;
+    var series = null;
+    for (var i = 0; i < result.series.length; i++) {
+        if (result.series[i].name === seriesName) { series = result.series[i]; seriesIdx = i; break; }
+    }
+    if (!series || seriesIdx < 0) return;
+
+    // Update local data
+    var field;
+    if (col === "x") { series.x_values[row] = val; field = "x_values"; }
+    else if (col === "y") { series.y_values[row] = val; field = "y_values"; }
+    else if (col === "el") { series.error_bars_lower[row] = val; field = "error_bars_lower"; }
+    else if (col === "eu") { series.error_bars_upper[row] = val; field = "error_bars_upper"; }
+
+    // Save to server (fire-and-forget)
+    if (currentImageId && field) {
+        fetch("/api/edit-cell", {
+            method: "PATCH",
+            headers: {"Content-Type": "application/json"},
+            body: JSON.stringify({
+                image_id: currentImageId,
+                result_index: idx,
+                series_index: seriesIdx,
+                field: field,
+                point_index: row,
+                value: val
+            })
+        }).catch(function() {});
+    }
+
+    // Refresh SVG preview
+    var svgContainer = input.closest(".border-t").querySelector(".mt-3");
+    if (svgContainer) {
+        svgContainer.innerHTML = makeDataPlotSvg(result);
+    }
+
+    // Visual feedback
+    input.style.backgroundColor = "#fef3c7";
+    setTimeout(function() { input.style.backgroundColor = ""; }, 600);
+}
+
+// ── SVG Preview ──
+
+function makeDataPlotSvg(result) {
+    if (!result.series || result.series.length === 0) return "";
+
+    var PADT = 20, PAD_LEFT = 55, PAD_RIGHT = 20;
+    var colors = ["#3b82f6", "#ef4444", "#10b981", "#f59e0b", "#8b5cf6", "#ec4899"];
+
+    // Collect all y values (including error extents)
+    var allY = [];
+    var isCategory = false;
+    result.series.forEach(function(s) {
+        if (!s.y_values) return;
+        s.y_values.forEach(function(v) { if (v != null && !isNaN(v)) allY.push(v); });
+        if (s.x_values && s.x_values.length > 0 && typeof s.x_values[0] === "string") isCategory = true;
+        if (s.error_bars_lower) s.error_bars_lower.forEach(function(e, i) { if (e && s.y_values[i] != null) allY.push(s.y_values[i] - e); });
+        if (s.error_bars_upper) s.error_bars_upper.forEach(function(e, i) { if (e && s.y_values[i] != null) allY.push(s.y_values[i] + e); });
+    });
+    // Force category routing for plot types handled in the categorical branch
+    var categoricalTypes = ["histogram", "violin", "forest", "waterfall", "heatmap"];
+    var continuousTypes = ["volcano", "funnel", "bland_altman", "bubble", "manhattan"];
+    if (categoricalTypes.indexOf(result.plot_type) >= 0) isCategory = true;
+    if (continuousTypes.indexOf(result.plot_type) >= 0) isCategory = false;
+    // Stacked bar: compute cumulative totals per category for correct y range
+    if (result.plot_type === "stacked_bar") {
+        var stackTotals = {};
+        result.series.forEach(function(s) {
+            if (!s.x_values) return;
+            for (var i = 0; i < s.x_values.length; i++) {
+                var cat = String(s.x_values[i]);
+                if (!stackTotals[cat]) stackTotals[cat] = 0;
+                stackTotals[cat] += (s.y_values[i] || 0);
+            }
+        });
+        Object.keys(stackTotals).forEach(function(k) { allY.push(stackTotals[k]); });
+        allY.push(0); // stacked bars always start at 0
+    }
+    // Box plot whisker/outlier extents from notes
+    if (result.plot_type === "box" && result.notes) {
+        result.notes.split(/\n/).forEach(function(line) {
+            var m = line.match(/min\s*=\s*([\d.\-]+)/i);
+            if (m) allY.push(parseFloat(m[1]));
+            m = line.match(/max\s*=\s*([\d.\-]+)/i);
+            if (m) allY.push(parseFloat(m[1]));
+            var om = line.match(/outliers?\s*:\s*\[([^\]]*)\]/i);
+            if (om) om[1].split(",").forEach(function(v) { var n = parseFloat(v.trim()); if (!isNaN(n)) allY.push(n); });
+        });
+    }
+    // Violin plot whisker extents from notes (same format as box)
+    if (result.plot_type === "violin" && result.notes) {
+        result.notes.split(/\n/).forEach(function(line) {
+            var m = line.match(/min\s*=\s*([\d.\-]+)/i);
+            if (m) allY.push(parseFloat(m[1]));
+            m = line.match(/max\s*=\s*([\d.\-]+)/i);
+            if (m) allY.push(parseFloat(m[1]));
+        });
+    }
+    // Waterfall: ensure y range includes 0 and RECIST thresholds if close
+    if (result.plot_type === "waterfall") {
+        allY.push(0);
+    }
+    // Forest plot: y_values are effect sizes, include CI extents
+    if (result.plot_type === "forest") {
+        result.series.forEach(function(s) {
+            if (!s.y_values) return;
+            for (var i = 0; i < s.y_values.length; i++) {
+                if (s.y_values[i] == null) continue;
+                var eLo = (s.error_bars_lower && s.error_bars_lower[i]) || 0;
+                var eHi = (s.error_bars_upper && s.error_bars_upper[i]) || 0;
+                allY.push(s.y_values[i] - eLo);
+                allY.push(s.y_values[i] + eHi);
+            }
+        });
+    }
+    allY = allY.filter(function(v) { return isFinite(v); });
+    if (allY.length === 0) return "";
+
+    // Collect x labels for category plots
+    var catLabels = [];
+    if (isCategory) {
+        if (result.plot_type === "box") {
+            result.series.forEach(function(s) { catLabels.push(s.name || ""); });
+        } else if (result.series[0] && result.series[0].x_values) {
+            result.series[0].x_values.forEach(function(v) { catLabels.push(String(v)); });
+        }
+    }
+
+    // ── Adaptive dimensions based on data shape ──
+    var nCatLabels = catLabels.length;
+    // Unique categories for bar/box
+    var uniqueCats = [];
+    if (isCategory && result.series[0]) {
+        var seen = {};
+        result.series[0].x_values.forEach(function(v) {
+            var k = String(v);
+            if (!seen[k]) { seen[k] = true; uniqueCats.push(k); }
+        });
+    }
+    var nUniqueCats = uniqueCats.length || nCatLabels;
+    var nSeries = result.series.length;
+    var totalPoints = 0;
+    result.series.forEach(function(s) { totalPoints += s.y_values.length; });
+
+    var W;
+    if (result.plot_type === "box") {
+        // Box: scale with number of groups
+        W = Math.max(250, Math.min(600, 80 + nSeries * 70));
+    } else if (isCategory) {
+        // Bar: scale with unique categories × series
+        var barsPerCat = nSeries;
+        W = Math.max(250, Math.min(700, 80 + nUniqueCats * barsPerCat * 22 + nUniqueCats * 20));
+    } else {
+        // Scatter/line: roughly 4:3, wider if many points
+        W = Math.max(300, Math.min(600, 350 + totalPoints * 0.5));
+    }
+    W = Math.round(W);
+
+    var plotW = W - PAD_LEFT - PAD_RIGHT;
+
+    // Label angle detection
+    var maxLabelLen = 0;
+    catLabels.forEach(function(l) { if (l.length > maxLabelLen) maxLabelLen = l.length; });
+    var labelCharWidth = 4.5;
+    var labelPixelWidth = maxLabelLen * labelCharWidth;
+    var slotWidth = nCatLabels > 0 ? plotW / nCatLabels : plotW;
+    var angleLabels = isCategory && nCatLabels > 0 && labelPixelWidth > slotWidth * 0.85;
+    var PADB_LABEL = angleLabels ? Math.min(50, maxLabelLen * 3.2 + 8) : 18;
+    var PADB_AXIS = (result.x_label ? 14 : 0);
+    var PADB = PADB_LABEL + PADB_AXIS + 4;
+
+    // Plot height: aim for roughly square plot area, clamped
+    var targetPlotH = Math.max(150, Math.min(400, plotW * 0.75));
+    var H = PADT + targetPlotH + PADB;
+    var plotH = targetPlotH;
+
+    // Scale detection
+    function isLogScale(scaleStr) {
+        if (!scaleStr) return false;
+        var s = scaleStr.toLowerCase();
+        return s === "log" || s === "log10" || s === "log2" || s === "logarithmic" || s.indexOf("log") === 0;
+    }
+    var yLog = isLogScale(result.y_scale);
+    var xLog = isLogScale(result.x_scale);
+    if (!yLog && result.y_min > 0 && result.y_max > 0 && result.y_max / result.y_min >= 1000) yLog = true;
+    if (!xLog && result.x_min > 0 && result.x_max > 0 && result.x_max / result.x_min >= 1000) xLog = true;
+
+    // Y range
+    var yMin, yMax;
+    if (result.y_min != null && result.y_max != null) {
+        yMin = result.y_min; yMax = result.y_max;
+    } else {
+        yMin = Math.min.apply(null, allY); yMax = Math.max.apply(null, allY);
+        if (yMin === yMax) { yMin -= 1; yMax += 1; }
+        var yPad = (yMax - yMin) * 0.1;
+        yMin -= yPad; yMax += yPad;
+    }
+    if (yLog && yMin <= 0) yMin = Math.min.apply(null, allY.filter(function(v) { return v > 0; })) * 0.5 || 0.01;
+    var yRange = yMax - yMin;
+    if (yRange === 0) { yRange = 2; yMin -= 1; yMax += 1; }
+
+    function yToPixel(v) {
+        if (yLog) {
+            if (v <= 0) v = yMin;
+            var logMin = Math.log10(yMin), logMax = Math.log10(yMax);
+            var logRange = logMax - logMin;
+            if (logRange === 0) logRange = 1;
+            return PADT + plotH - ((Math.log10(v) - logMin) / logRange) * plotH;
+        }
+        return PADT + plotH - ((v - yMin) / yRange) * plotH;
+    }
+
+    function fmtTick(v, range) {
+        if (range >= 100) return Math.round(v).toString();
+        if (range >= 1) return v.toFixed(1);
+        if (range >= 0.1) return v.toFixed(2);
+        return v.toPrecision(3);
+    }
+    function fmtLogTick(v) {
+        if (v >= 1 && v === Math.round(v)) return v.toString();
+        if (v >= 0.01) return v.toPrecision(2);
+        return v.toExponential(0);
+    }
+
+    // SVG header
+    var parts = [];
+    parts.push('<svg width="' + W + '" height="' + H + '" viewBox="0 0 ' + W + ' ' + H + '" xmlns="http://www.w3.org/2000/svg" style="max-width:100%">');
+    parts.push('<rect width="' + W + '" height="' + H + '" fill="#fafafa" rx="4"/>');
+
+    // Axes
+    parts.push('<line x1="' + PAD_LEFT + '" y1="' + PADT + '" x2="' + PAD_LEFT + '" y2="' + (PADT + plotH) + '" stroke="#d1d5db"/>');
+    parts.push('<line x1="' + PAD_LEFT + '" y1="' + (PADT + plotH) + '" x2="' + (PAD_LEFT + plotW) + '" y2="' + (PADT + plotH) + '" stroke="#d1d5db"/>');
+
+    // Y ticks
+    if (yLog) {
+        var logYMin = Math.log10(yMin), logYMax = Math.log10(yMax);
+        var startPow = Math.floor(logYMin), endPow = Math.ceil(logYMax);
+        for (var p = startPow; p <= endPow; p++) {
+            var tv = Math.pow(10, p);
+            if (tv < yMin * 0.9 || tv > yMax * 1.1) continue;
+            var ty = yToPixel(tv);
+            parts.push('<text x="' + (PAD_LEFT - 5) + '" y="' + (ty + 3) + '" text-anchor="end" font-size="8" fill="#9ca3af">' + fmtLogTick(tv) + '</text>');
+            parts.push('<line x1="' + PAD_LEFT + '" y1="' + ty + '" x2="' + (PAD_LEFT + plotW) + '" y2="' + ty + '" stroke="#f3f4f6"/>');
+        }
+    } else {
+        for (var t = 0; t <= 4; t++) {
+            var tv = yMin + (yRange * t / 4);
+            var ty = yToPixel(tv);
+            parts.push('<text x="' + (PAD_LEFT - 5) + '" y="' + (ty + 3) + '" text-anchor="end" font-size="8" fill="#9ca3af">' + fmtTick(tv, yRange) + '</text>');
+            parts.push('<line x1="' + PAD_LEFT + '" y1="' + ty + '" x2="' + (PAD_LEFT + plotW) + '" y2="' + ty + '" stroke="#f3f4f6"/>');
+        }
+    }
+
+    // Category labels helper
+    var xLabelBaseY = PADT + plotH + 3;
+    function renderCatLabels(labels, positions) {
+        for (var i = 0; i < labels.length; i++) {
+            var lbl = labels[i];
+            if (lbl.length > 18) lbl = lbl.substring(0, 16) + "\u2026";
+            var lx = positions[i];
+            if (angleLabels) {
+                parts.push('<text x="' + lx + '" y="' + (xLabelBaseY + 6) + '" text-anchor="end" font-size="8" fill="#6b7280" transform="rotate(-35,' + lx + ',' + (xLabelBaseY + 6) + ')">' + lbl + '</text>');
+            } else {
+                parts.push('<text x="' + lx + '" y="' + (xLabelBaseY + 10) + '" text-anchor="middle" font-size="8" fill="#6b7280">' + lbl + '</text>');
+            }
+        }
+    }
+
+    // Plot type routing
+    if (result.plot_type === "box") {
+        // Box-and-whisker
+        var nGroups = result.series.length;
+        var groupW = plotW / nGroups;
+        var boxW = Math.min(40, groupW - 10);
+
+        var boxStats = {};
+        var outlierData = {};
+        if (result.notes) {
+            result.notes.split(/\n/).forEach(function(line) {
+                var statsMatch = line.match(/^(.+?):\s*min\s*=\s*([\d.\-]+)\s*,\s*Q1\s*=\s*([\d.\-]+)\s*,\s*median\s*=\s*([\d.\-]+)\s*,\s*Q3\s*=\s*([\d.\-]+)\s*,\s*max\s*=\s*([\d.\-]+)/i);
+                if (statsMatch) {
+                    boxStats[statsMatch[1].trim()] = {
+                        min: parseFloat(statsMatch[2]), q1: parseFloat(statsMatch[3]),
+                        median: parseFloat(statsMatch[4]), q3: parseFloat(statsMatch[5]),
+                        max: parseFloat(statsMatch[6])
+                    };
+                }
+                var outlierMatch = line.match(/^(.+?)\s*outliers?\s*:\s*\[([^\]]*)\]/i);
+                if (outlierMatch) {
+                    outlierData[outlierMatch[1].trim()] = outlierMatch[2].split(",").map(function(v) { return parseFloat(v.trim()); }).filter(function(v) { return !isNaN(v); });
+                }
+            });
+        }
+
+        var labelPositions = [];
+        result.series.forEach(function(s, si) {
+            var col = colors[si % colors.length];
+            var cx = PAD_LEFT + si * groupW + groupW / 2;
+            var bx = cx - boxW / 2;
+            labelPositions.push(cx);
+
+            var stats = boxStats[s.name];
+            var median, q1, q3, wMin, wMax;
+            if (stats) {
+                median = stats.median; q1 = stats.q1; q3 = stats.q3;
+                wMin = stats.min; wMax = stats.max;
+            } else {
+                median = s.y_values[0] || 0;
+                var eLo = (s.error_bars_lower && s.error_bars_lower[0]) || 0;
+                var eHi = (s.error_bars_upper && s.error_bars_upper[0]) || 0;
+                wMin = median - eLo; wMax = median + eHi;
+                q1 = median - eLo * 0.5; q3 = median + eHi * 0.5;
+            }
+
+            var yQ1 = yToPixel(q1), yQ3 = yToPixel(q3);
+            var yMed = yToPixel(median), yWMin = yToPixel(wMin), yWMax = yToPixel(wMax);
+
+            parts.push('<rect x="' + bx + '" y="' + yQ3 + '" width="' + boxW + '" height="' + Math.max(1, yQ1 - yQ3) + '" fill="' + col + '" opacity="0.2" stroke="' + col + '" stroke-width="1.5" rx="1"/>');
+            parts.push('<line x1="' + bx + '" y1="' + yMed + '" x2="' + (bx + boxW) + '" y2="' + yMed + '" stroke="' + col + '" stroke-width="2"/>');
+            parts.push('<line x1="' + cx + '" y1="' + yQ1 + '" x2="' + cx + '" y2="' + yWMin + '" stroke="' + col + '" stroke-width="1"/>');
+            parts.push('<line x1="' + (cx - boxW * 0.3) + '" y1="' + yWMin + '" x2="' + (cx + boxW * 0.3) + '" y2="' + yWMin + '" stroke="' + col + '" stroke-width="1"/>');
+            parts.push('<line x1="' + cx + '" y1="' + yQ3 + '" x2="' + cx + '" y2="' + yWMax + '" stroke="' + col + '" stroke-width="1"/>');
+            parts.push('<line x1="' + (cx - boxW * 0.3) + '" y1="' + yWMax + '" x2="' + (cx + boxW * 0.3) + '" y2="' + yWMax + '" stroke="' + col + '" stroke-width="1"/>');
+
+            (outlierData[s.name] || []).forEach(function(ov) {
+                var oy = yToPixel(ov);
+                parts.push('<circle cx="' + cx + '" cy="' + oy + '" r="2.5" fill="none" stroke="' + col + '" stroke-width="1" opacity="0.7"/>');
+            });
+        });
+        var boxLabels = result.series.map(function(s) { return s.name || ""; });
+        renderCatLabels(boxLabels, labelPositions);
+
+    } else if (isCategory) {
+        // Category-based plot routing
+        var catOrder = [];
+        var catSet = {};
+        result.series.forEach(function(s) {
+            if (!s.x_values) return;
+            s.x_values.forEach(function(v) {
+                var k = String(v);
+                if (!catSet[k]) { catSet[k] = true; catOrder.push(k); }
+            });
+        });
+        var nCats = catOrder.length;
+        var nBarSeries = result.series.length;
+
+        // Check if this is individual-dots data (many y-values per unique category)
+        var hasRepeatedCats = false;
+        result.series.forEach(function(s) {
+            if (s.x_values && s.y_values && s.y_values.length > nCats * 1.5) hasRepeatedCats = true;
+        });
+
+        var groupW = plotW / Math.max(1, nCats);
+
+        if (result.plot_type === "stacked_bar") {
+            // ── Stacked bar chart ──
+            var barW = Math.min(40, Math.max(8, groupW - 12));
+            catOrder.forEach(function(cat, ci) {
+                var cx = PAD_LEFT + ci * groupW + groupW / 2;
+                var bx = cx - barW / 2;
+                var yBase = 0; // stack from zero upward
+                result.series.forEach(function(s, si) {
+                    // Find the value for this category in this series
+                    var val = 0;
+                    for (var i = 0; i < s.x_values.length; i++) {
+                        if (String(s.x_values[i]) === cat) { val = s.y_values[i] || 0; break; }
+                    }
+                    if (val === 0) { yBase += val; return; }
+                    var col = colors[si % colors.length];
+                    var segTop = yToPixel(yBase + val);
+                    var segBot = yToPixel(yBase);
+                    var segH = Math.max(1, segBot - segTop);
+                    parts.push('<rect x="' + bx + '" y="' + segTop + '" width="' + barW + '" height="' + segH + '" fill="' + col + '" opacity="0.85" stroke="#fff" stroke-width="0.5"/>');
+                    yBase += val;
+                });
+            });
+            var barLabelPositions = [];
+            for (var i = 0; i < nCats; i++) barLabelPositions.push(PAD_LEFT + i * groupW + groupW / 2);
+            catLabels = catOrder;
+            renderCatLabels(catLabels, barLabelPositions);
+
+        } else if (result.plot_type === "error_bar") {
+            // ── Error bar plot (means with error bars, no bars) ──
+            var seriesSlotW = groupW / (nBarSeries + 1);
+            result.series.forEach(function(s, si) {
+                var col = colors[si % colors.length];
+                for (var i = 0; i < s.y_values.length; i++) {
+                    if (s.y_values[i] == null || isNaN(s.y_values[i])) continue;
+                    var catIdx = catOrder.indexOf(String(s.x_values[i]));
+                    if (catIdx < 0) catIdx = i;
+                    var cx = PAD_LEFT + catIdx * groupW + seriesSlotW * (si + 1);
+                    var py = yToPixel(s.y_values[i]);
+                    // Mean marker
+                    parts.push('<circle cx="' + cx + '" cy="' + py + '" r="4" fill="' + col + '"/>');
+                    // Error bars
+                    var eLo = (s.error_bars_lower && s.error_bars_lower[i]) || 0;
+                    var eHi = (s.error_bars_upper && s.error_bars_upper[i]) || 0;
+                    if (eHi > 0 || eLo > 0) {
+                        var eTop = yToPixel(s.y_values[i] + eHi);
+                        var eBot = yToPixel(s.y_values[i] - eLo);
+                        parts.push('<line x1="' + cx + '" y1="' + eTop + '" x2="' + cx + '" y2="' + eBot + '" stroke="' + col + '" stroke-width="1.5"/>');
+                        parts.push('<line x1="' + (cx - 4) + '" y1="' + eTop + '" x2="' + (cx + 4) + '" y2="' + eTop + '" stroke="' + col + '" stroke-width="1.5"/>');
+                        parts.push('<line x1="' + (cx - 4) + '" y1="' + eBot + '" x2="' + (cx + 4) + '" y2="' + eBot + '" stroke="' + col + '" stroke-width="1.5"/>');
+                    }
+                }
+            });
+            var barLabelPositions = [];
+            for (var i = 0; i < nCats; i++) barLabelPositions.push(PAD_LEFT + i * groupW + groupW / 2);
+            catLabels = catOrder;
+            renderCatLabels(catLabels, barLabelPositions);
+
+        } else if (hasRepeatedCats || result.plot_type === "dot_strip") {
+            // ── Individual data points mode — jittered dots per category ──
+            var seriesSlotW = groupW / (nBarSeries + 1);
+            result.series.forEach(function(s, si) {
+                var col = colors[si % colors.length];
+                var bycat = {};
+                for (var i = 0; i < s.y_values.length; i++) {
+                    if (s.y_values[i] == null || isNaN(s.y_values[i])) continue;
+                    var cat = i < s.x_values.length ? String(s.x_values[i]) : "";
+                    if (!bycat[cat]) bycat[cat] = [];
+                    bycat[cat].push(s.y_values[i]);
+                }
+                catOrder.forEach(function(cat, ci) {
+                    var pts = bycat[cat] || [];
+                    var cx = PAD_LEFT + ci * groupW + seriesSlotW * (si + 1);
+                    pts.forEach(function(yv, pi) {
+                        var jitter = (pi - (pts.length - 1) / 2) * 2.5;
+                        var px = cx + jitter;
+                        var py = yToPixel(yv);
+                        parts.push('<circle cx="' + px + '" cy="' + py + '" r="3" fill="' + col + '" opacity="0.7"/>');
+                    });
+                });
+            });
+            var barLabelPositions = [];
+            for (var i = 0; i < nCats; i++) barLabelPositions.push(PAD_LEFT + i * groupW + groupW / 2);
+            catLabels = catOrder;
+            renderCatLabels(catLabels, barLabelPositions);
+
+        } else if (result.plot_type === "paired") {
+            // ── Paired/spaghetti plot — connected before-after ──
+            var seriesSlotW = groupW / 2;
+            result.series.forEach(function(s, si) {
+                var col = colors[si % colors.length];
+                if (!s.x_values || !s.y_values) return;
+                // Draw connected line through each x position
+                var pts = [];
+                for (var i = 0; i < s.y_values.length; i++) {
+                    if (s.y_values[i] == null) continue;
+                    var catIdx = catOrder.indexOf(String(s.x_values[i]));
+                    if (catIdx < 0) catIdx = i;
+                    var px = PAD_LEFT + catIdx * groupW + groupW / 2;
+                    var py = yToPixel(s.y_values[i]);
+                    pts.push({ x: px, y: py });
+                    parts.push('<circle cx="' + px + '" cy="' + py + '" r="3" fill="' + col + '" opacity="0.7"/>');
+                }
+                if (pts.length > 1) {
+                    var pathD = "M" + pts[0].x + "," + pts[0].y;
+                    for (var j = 1; j < pts.length; j++) pathD += "L" + pts[j].x + "," + pts[j].y;
+                    parts.push('<path d="' + pathD + '" fill="none" stroke="' + col + '" stroke-width="1.2" opacity="0.5"/>');
+                }
+            });
+            var barLabelPositions = [];
+            for (var i = 0; i < nCats; i++) barLabelPositions.push(PAD_LEFT + i * groupW + groupW / 2);
+            catLabels = catOrder;
+            renderCatLabels(catLabels, barLabelPositions);
+
+        } else if (result.plot_type === "histogram") {
+            // ── Histogram — bars at bin centers ──
+            // Treat each series independently; x_values are bin centers (as strings)
+            result.series.forEach(function(s, si) {
+                var col = colors[si % colors.length];
+                if (!s.x_values || !s.y_values) return;
+                var numXs = s.x_values.map(Number).filter(function(v) { return isFinite(v); });
+                // Calculate bar width from spacing between consecutive bins
+                var barPixelW;
+                if (numXs.length > 1) {
+                    var gaps = [];
+                    for (var g = 1; g < numXs.length; g++) gaps.push(Math.abs(numXs[g] - numXs[g - 1]));
+                    gaps.sort(function(a, b) { return a - b; });
+                    var binWidth = gaps[0]; // smallest gap = bin width
+                    barPixelW = (binWidth / ((numXs[numXs.length - 1] - numXs[0]) || 1)) * plotW * 0.9;
+                } else {
+                    barPixelW = plotW / 3;
+                }
+                barPixelW = Math.max(4, Math.min(barPixelW, plotW / numXs.length - 2));
+                // We need our own xToPixel for histogram since we're in categorical branch
+                var hxMin = Math.min.apply(null, numXs);
+                var hxMax = Math.max.apply(null, numXs);
+                if (hxMin === hxMax) { hxMin -= 1; hxMax += 1; }
+                var hxRange = hxMax - hxMin;
+                var hxPad = hxRange * 0.1;
+                hxMin -= hxPad; hxMax += hxPad; hxRange = hxMax - hxMin;
+                function histXToPixel(v) { return PAD_LEFT + ((v - hxMin) / hxRange) * plotW; }
+                for (var i = 0; i < s.y_values.length; i++) {
+                    if (s.y_values[i] == null || isNaN(s.y_values[i])) continue;
+                    var xv = Number(s.x_values[i]);
+                    if (!isFinite(xv)) continue;
+                    var cx = histXToPixel(xv);
+                    var by = yToPixel(s.y_values[i]);
+                    var baseY = yToPixel(Math.max(yMin, 0));
+                    var bh = baseY - by;
+                    if (bh < 0) { by = by + bh; bh = -bh; }
+                    parts.push('<rect x="' + (cx - barPixelW / 2) + '" y="' + by + '" width="' + barPixelW + '" height="' + Math.max(1, bh) + '" fill="' + col + '" opacity="0.75" stroke="' + col + '" stroke-width="0.5"/>');
+                }
+                // X tick labels for histogram
+                var step = Math.max(1, Math.floor(numXs.length / 6));
+                for (var i = 0; i < numXs.length; i += step) {
+                    var tx = histXToPixel(numXs[i]);
+                    var label = numXs[i] % 1 === 0 ? numXs[i].toString() : numXs[i].toFixed(1);
+                    parts.push('<text x="' + tx + '" y="' + (xLabelBaseY + 10) + '" text-anchor="middle" font-size="8" fill="#9ca3af">' + label + '</text>');
+                }
+            });
+
+        } else if (result.plot_type === "violin") {
+            // ── Violin plot — rendered as box plots (box + whiskers + median) ──
+            var nGroups = result.series.length;
+            var vGroupW = plotW / Math.max(1, nGroups);
+            var vBoxW = Math.min(50, vGroupW - 10);
+
+            var violinStats = {};
+            if (result.notes) {
+                result.notes.split(/\n/).forEach(function(line) {
+                    var statsMatch = line.match(/^(.+?):\s*min\s*=\s*([\d.\-]+)\s*,\s*Q1\s*=\s*([\d.\-]+)\s*,\s*median\s*=\s*([\d.\-]+)\s*,\s*Q3\s*=\s*([\d.\-]+)\s*,\s*max\s*=\s*([\d.\-]+)/i);
+                    if (statsMatch) {
+                        violinStats[statsMatch[1].trim()] = {
+                            min: parseFloat(statsMatch[2]), q1: parseFloat(statsMatch[3]),
+                            median: parseFloat(statsMatch[4]), q3: parseFloat(statsMatch[5]),
+                            max: parseFloat(statsMatch[6])
+                        };
+                    }
+                });
+            }
+
+            var vLabelPositions = [];
+            result.series.forEach(function(s, si) {
+                var col = colors[si % colors.length];
+                var cx = PAD_LEFT + si * vGroupW + vGroupW / 2;
+                var bx = cx - vBoxW / 2;
+                vLabelPositions.push(cx);
+
+                var stats = violinStats[s.name];
+                var median, q1, q3, wMin, wMax;
+                if (stats) {
+                    median = stats.median; q1 = stats.q1; q3 = stats.q3;
+                    wMin = stats.min; wMax = stats.max;
+                } else {
+                    // Estimate from raw y_values
+                    var sorted = (s.y_values || []).filter(function(v) { return v != null && !isNaN(v); }).sort(function(a, b) { return a - b; });
+                    if (sorted.length === 0) return;
+                    wMin = sorted[0]; wMax = sorted[sorted.length - 1];
+                    q1 = sorted[Math.floor(sorted.length * 0.25)];
+                    median = sorted[Math.floor(sorted.length * 0.5)];
+                    q3 = sorted[Math.floor(sorted.length * 0.75)];
+                }
+
+                var yQ1 = yToPixel(q1), yQ3 = yToPixel(q3);
+                var yMed = yToPixel(median), yWMin = yToPixel(wMin), yWMax = yToPixel(wMax);
+
+                // Wider box shape with rounded corners for violin appearance
+                parts.push('<rect x="' + bx + '" y="' + yQ3 + '" width="' + vBoxW + '" height="' + Math.max(1, yQ1 - yQ3) + '" fill="' + col + '" opacity="0.25" stroke="' + col + '" stroke-width="1.5" rx="' + Math.min(6, vBoxW / 4) + '"/>');
+                // Median line
+                parts.push('<line x1="' + bx + '" y1="' + yMed + '" x2="' + (bx + vBoxW) + '" y2="' + yMed + '" stroke="' + col + '" stroke-width="2.5"/>');
+                // Whiskers (thinner for violin)
+                parts.push('<line x1="' + cx + '" y1="' + yQ1 + '" x2="' + cx + '" y2="' + yWMin + '" stroke="' + col + '" stroke-width="1" stroke-dasharray="2,2"/>');
+                parts.push('<line x1="' + cx + '" y1="' + yQ3 + '" x2="' + cx + '" y2="' + yWMax + '" stroke="' + col + '" stroke-width="1" stroke-dasharray="2,2"/>');
+                // Whisker caps
+                parts.push('<line x1="' + (cx - vBoxW * 0.2) + '" y1="' + yWMin + '" x2="' + (cx + vBoxW * 0.2) + '" y2="' + yWMin + '" stroke="' + col + '" stroke-width="1"/>');
+                parts.push('<line x1="' + (cx - vBoxW * 0.2) + '" y1="' + yWMax + '" x2="' + (cx + vBoxW * 0.2) + '" y2="' + yWMax + '" stroke="' + col + '" stroke-width="1"/>');
+            });
+            var violinLabels = result.series.map(function(s) { return s.name || ""; });
+            renderCatLabels(violinLabels, vLabelPositions);
+
+        } else if (result.plot_type === "forest") {
+            // ── Forest plot — horizontal: study names on left, effect sizes + CI ──
+            // x_values = study names, y_values = effect sizes, error bars = CI
+            var studies = [];
+            result.series.forEach(function(s) {
+                if (!s.x_values || !s.y_values) return;
+                for (var i = 0; i < s.y_values.length; i++) {
+                    if (s.y_values[i] == null || isNaN(s.y_values[i])) continue;
+                    var name = i < s.x_values.length ? String(s.x_values[i]) : ("Study " + (i + 1));
+                    var eLo = (s.error_bars_lower && s.error_bars_lower[i]) || 0;
+                    var eHi = (s.error_bars_upper && s.error_bars_upper[i]) || 0;
+                    var isOverall = /overall|pooled|summary|combined/i.test(name);
+                    studies.push({ name: name, est: s.y_values[i], ciLo: s.y_values[i] - eLo, ciHi: s.y_values[i] + eHi, overall: isOverall });
+                }
+            });
+            if (studies.length === 0) { parts.push('</svg>'); return parts.join(""); }
+
+            // X axis = effect size (horizontal), Y axis = studies (vertical)
+            var allEst = [];
+            studies.forEach(function(st) { allEst.push(st.est); allEst.push(st.ciLo); allEst.push(st.ciHi); });
+            var fxMin = Math.min.apply(null, allEst);
+            var fxMax = Math.max.apply(null, allEst);
+            if (fxMin === fxMax) { fxMin -= 1; fxMax += 1; }
+            var fxPad = (fxMax - fxMin) * 0.15;
+            fxMin -= fxPad; fxMax += fxPad;
+            var fxRange = fxMax - fxMin;
+            function forestXToPixel(v) { return PAD_LEFT + ((v - fxMin) / fxRange) * plotW; }
+
+            var nStudies = studies.length;
+            var rowH = plotH / Math.max(1, nStudies);
+
+            // Vertical reference line at 0 (or 1 if all estimates > 0, suggesting OR/HR)
+            var refVal = (fxMin > 0.5 && allEst.every(function(v) { return v > 0; })) ? 1 : 0;
+            var refX = forestXToPixel(refVal);
+            parts.push('<line x1="' + refX + '" y1="' + PADT + '" x2="' + refX + '" y2="' + (PADT + plotH) + '" stroke="#9ca3af" stroke-width="1" stroke-dasharray="4,3"/>');
+
+            studies.forEach(function(st, si) {
+                var cy = PADT + si * rowH + rowH / 2;
+                var estX = forestXToPixel(st.est);
+                var ciLoX = forestXToPixel(st.ciLo);
+                var ciHiX = forestXToPixel(st.ciHi);
+                var col = st.overall ? "#ef4444" : "#3b82f6";
+
+                // CI horizontal line
+                parts.push('<line x1="' + ciLoX + '" y1="' + cy + '" x2="' + ciHiX + '" y2="' + cy + '" stroke="' + col + '" stroke-width="1.5"/>');
+
+                if (st.overall) {
+                    // Diamond for overall estimate
+                    var dW = Math.min(8, rowH * 0.4);
+                    var dH = Math.min(6, rowH * 0.35);
+                    parts.push('<polygon points="' + (estX - dW) + ',' + cy + ' ' + estX + ',' + (cy - dH) + ' ' + (estX + dW) + ',' + cy + ' ' + estX + ',' + (cy + dH) + '" fill="' + col + '" stroke="' + col + '"/>');
+                } else {
+                    // Square for individual studies
+                    var sqSz = Math.min(7, rowH * 0.35);
+                    parts.push('<rect x="' + (estX - sqSz / 2) + '" y="' + (cy - sqSz / 2) + '" width="' + sqSz + '" height="' + sqSz + '" fill="' + col + '"/>');
+                }
+
+                // Study name label on left
+                var lbl = st.name;
+                if (lbl.length > 22) lbl = lbl.substring(0, 20) + "\u2026";
+                parts.push('<text x="' + (PAD_LEFT - 5) + '" y="' + (cy + 3) + '" text-anchor="end" font-size="7" fill="#374151">' + lbl + '</text>');
+            });
+
+            // X tick labels for effect size
+            for (var t = 0; t <= 4; t++) {
+                var txv = fxMin + (fxRange * t / 4);
+                var txx = forestXToPixel(txv);
+                parts.push('<text x="' + txx + '" y="' + (xLabelBaseY + 10) + '" text-anchor="middle" font-size="8" fill="#9ca3af">' + fmtTick(txv, fxRange) + '</text>');
+            }
+
+        } else if (result.plot_type === "waterfall") {
+            // ── Waterfall — ordered bars from baseline, colored by sign ──
+            var wfData = [];
+            result.series.forEach(function(s) {
+                if (!s.x_values || !s.y_values) return;
+                for (var i = 0; i < s.y_values.length; i++) {
+                    if (s.y_values[i] == null || isNaN(s.y_values[i])) continue;
+                    var label = i < s.x_values.length ? String(s.x_values[i]) : "";
+                    wfData.push({ label: label, value: s.y_values[i] });
+                }
+            });
+            // Sort by value (most negative to most positive) for waterfall
+            wfData.sort(function(a, b) { return a.value - b.value; });
+
+            var wfN = wfData.length;
+            var wfBarW = Math.max(2, Math.min(20, plotW / wfN - 1));
+            var wfGroupW = plotW / Math.max(1, wfN);
+            var baseY = yToPixel(0);
+
+            // Reference lines at -30% and +20% (RECIST thresholds)
+            if (yMin <= -30 && yMax >= -30) {
+                var y30 = yToPixel(-30);
+                parts.push('<line x1="' + PAD_LEFT + '" y1="' + y30 + '" x2="' + (PAD_LEFT + plotW) + '" y2="' + y30 + '" stroke="#10b981" stroke-width="0.8" stroke-dasharray="4,3"/>');
+                parts.push('<text x="' + (PAD_LEFT + plotW + 2) + '" y="' + (y30 + 3) + '" font-size="7" fill="#10b981">-30%</text>');
+            }
+            if (yMin <= 20 && yMax >= 20) {
+                var y20 = yToPixel(20);
+                parts.push('<line x1="' + PAD_LEFT + '" y1="' + y20 + '" x2="' + (PAD_LEFT + plotW) + '" y2="' + y20 + '" stroke="#ef4444" stroke-width="0.8" stroke-dasharray="4,3"/>');
+                parts.push('<text x="' + (PAD_LEFT + plotW + 2) + '" y="' + (y20 + 3) + '" font-size="7" fill="#ef4444">+20%</text>');
+            }
+            // Zero line
+            parts.push('<line x1="' + PAD_LEFT + '" y1="' + baseY + '" x2="' + (PAD_LEFT + plotW) + '" y2="' + baseY + '" stroke="#6b7280" stroke-width="0.5"/>');
+
+            wfData.forEach(function(d, i) {
+                var cx = PAD_LEFT + i * wfGroupW + wfGroupW / 2;
+                var by = yToPixel(d.value);
+                var bh = baseY - by;
+                var col = d.value < 0 ? "#10b981" : "#ef4444"; // green for negative, red for positive
+                if (bh < 0) { by = by + bh; bh = -bh; }
+                parts.push('<rect x="' + (cx - wfBarW / 2) + '" y="' + by + '" width="' + wfBarW + '" height="' + Math.max(1, bh) + '" fill="' + col + '" opacity="0.85"/>');
+            });
+
+        } else if (result.plot_type === "heatmap") {
+            // ── Heatmap — grid of colored cells ──
+            // Each series = one row, x_values = column labels, y_values = cell values
+            var hmRows = [];
+            var hmColLabels = [];
+            result.series.forEach(function(s, si) {
+                if (!s.y_values) return;
+                hmRows.push({ name: s.name || ("Row " + (si + 1)), values: s.y_values });
+                if (hmColLabels.length === 0 && s.x_values) {
+                    hmColLabels = s.x_values.map(String);
+                }
+            });
+            var nRows = hmRows.length;
+            var nCols = hmColLabels.length || (hmRows[0] ? hmRows[0].values.length : 0);
+            if (nCols === 0 && hmColLabels.length === 0) {
+                for (var c = 0; c < nCols; c++) hmColLabels.push(String(c + 1));
+            }
+
+            // Find value range for color mapping
+            var hmAllVals = [];
+            hmRows.forEach(function(r) { r.values.forEach(function(v) { if (v != null && isFinite(v)) hmAllVals.push(v); }); });
+            var hmMin = hmAllVals.length > 0 ? Math.min.apply(null, hmAllVals) : 0;
+            var hmMax = hmAllVals.length > 0 ? Math.max.apply(null, hmAllVals) : 1;
+            if (hmMin === hmMax) { hmMin -= 1; hmMax += 1; }
+
+            function hmColor(v) {
+                // Blue-white-red gradient: min=blue, mid=white, max=red
+                var t = (v - hmMin) / (hmMax - hmMin);
+                t = Math.max(0, Math.min(1, t));
+                var r, g, b;
+                if (t < 0.5) {
+                    var s = t / 0.5; // 0..1 for blue-to-white
+                    r = Math.round(59 + (255 - 59) * s);
+                    g = Math.round(130 + (255 - 130) * s);
+                    b = Math.round(246 + (255 - 246) * s);
+                } else {
+                    var s = (t - 0.5) / 0.5; // 0..1 for white-to-red
+                    r = Math.round(255);
+                    g = Math.round(255 - (255 - 68) * s);
+                    b = Math.round(255 - (255 - 68) * s);
+                }
+                return "rgb(" + r + "," + g + "," + b + ")";
+            }
+
+            var cellW = plotW / Math.max(1, nCols);
+            var cellH = plotH / Math.max(1, nRows);
+            var showText = (nRows <= 10 && nCols <= 10);
+
+            hmRows.forEach(function(row, ri) {
+                // Row label on left
+                var lbl = row.name;
+                if (lbl.length > 14) lbl = lbl.substring(0, 12) + "\u2026";
+                var ry = PADT + ri * cellH + cellH / 2;
+                parts.push('<text x="' + (PAD_LEFT - 3) + '" y="' + (ry + 3) + '" text-anchor="end" font-size="7" fill="#6b7280">' + lbl + '</text>');
+
+                for (var ci = 0; ci < nCols && ci < row.values.length; ci++) {
+                    var v = row.values[ci];
+                    var cx = PAD_LEFT + ci * cellW;
+                    var cy = PADT + ri * cellH;
+                    var fill = (v != null && isFinite(v)) ? hmColor(v) : "#f3f4f6";
+                    parts.push('<rect x="' + cx + '" y="' + cy + '" width="' + cellW + '" height="' + cellH + '" fill="' + fill + '" stroke="#fff" stroke-width="0.5"/>');
+                    if (showText && v != null && isFinite(v)) {
+                        var txt = Math.abs(v) >= 100 ? Math.round(v).toString() : v.toFixed(1);
+                        parts.push('<text x="' + (cx + cellW / 2) + '" y="' + (cy + cellH / 2 + 3) + '" text-anchor="middle" font-size="7" fill="#374151">' + txt + '</text>');
+                    }
+                }
+            });
+
+            // Column labels at bottom
+            var colLabelPositions = [];
+            for (var ci = 0; ci < nCols; ci++) colLabelPositions.push(PAD_LEFT + ci * cellW + cellW / 2);
+            if (hmColLabels.length > 0) renderCatLabels(hmColLabels, colLabelPositions);
+
+        } else {
+            // ── Standard bar mode — one bar per x-value per series ──
+            var barW = Math.min(28, Math.max(4, (groupW - 8) / nBarSeries));
+            result.series.forEach(function(s, si) {
+                var col = colors[si % colors.length];
+                for (var i = 0; i < s.y_values.length; i++) {
+                    if (s.y_values[i] == null || isNaN(s.y_values[i])) continue;
+                    var catIdx = catOrder.indexOf(String(s.x_values[i]));
+                    if (catIdx < 0) catIdx = i;
+                    var bx = PAD_LEFT + catIdx * groupW + (groupW - nBarSeries * barW) / 2 + si * barW;
+                    var by = yToPixel(s.y_values[i]);
+                    var bh = yToPixel(Math.max(yMin, 0)) - by;
+                    if (bh < 0) { by = by + bh; bh = -bh; }
+                    parts.push('<rect x="' + bx + '" y="' + by + '" width="' + (barW - 1) + '" height="' + Math.max(1, bh) + '" fill="' + col + '" opacity="0.8" rx="1"/>');
+
+                    var eLo = (s.error_bars_lower && s.error_bars_lower[i]) || 0;
+                    var eHi = (s.error_bars_upper && s.error_bars_upper[i]) || 0;
+                    if (eHi > 0 || eLo > 0) {
+                        var ecx = bx + barW / 2;
+                        var eTop = yToPixel(s.y_values[i] + eHi);
+                        var eBot = yToPixel(s.y_values[i] - eLo);
+                        parts.push('<line x1="' + ecx + '" y1="' + eTop + '" x2="' + ecx + '" y2="' + eBot + '" stroke="' + col + '" stroke-width="1"/>');
+                        parts.push('<line x1="' + (ecx - 3) + '" y1="' + eTop + '" x2="' + (ecx + 3) + '" y2="' + eTop + '" stroke="' + col + '"/>');
+                        parts.push('<line x1="' + (ecx - 3) + '" y1="' + eBot + '" x2="' + (ecx + 3) + '" y2="' + eBot + '" stroke="' + col + '"/>');
+                    }
+                }
+            });
+            var barLabelPositions = [];
+            for (var i = 0; i < nCats; i++) barLabelPositions.push(PAD_LEFT + i * groupW + groupW / 2);
+            catLabels = catOrder;
+            renderCatLabels(catLabels, barLabelPositions);
+        }
+
+    } else {
+        // Scatter / Line plot
+        var allX = [];
+        result.series.forEach(function(s) {
+            if (!s.x_values) return;
+            s.x_values.forEach(function(v) { var n = Number(v); if (isFinite(n)) allX.push(n); });
+        });
+        if (allX.length === 0) { parts.push('</svg>'); return parts.join(""); }
+
+        var xMin, xMax;
+        if (result.x_min != null && result.x_max != null) {
+            xMin = result.x_min; xMax = result.x_max;
+        } else {
+            xMin = Math.min.apply(null, allX); xMax = Math.max.apply(null, allX);
+            if (xMin === xMax) { xMin -= 1; xMax += 1; }
+        }
+        if (xLog && xMin <= 0) xMin = Math.min.apply(null, allX.filter(function(v) { return v > 0; })) * 0.5 || 0.01;
+        var xRange = xMax - xMin;
+        if (xRange === 0) { xRange = 2; xMin -= 1; xMax += 1; }
+
+        function xToPixel(v) {
+            if (xLog) {
+                if (v <= 0) v = xMin;
+                var logMin = Math.log10(xMin), logMax = Math.log10(xMax);
+                var logRange = logMax - logMin;
+                if (logRange === 0) logRange = 1;
+                return PAD_LEFT + ((Math.log10(v) - logMin) / logRange) * plotW;
+            }
+            return PAD_LEFT + ((v - xMin) / xRange) * plotW;
+        }
+
+        // X ticks
+        if (xLog) {
+            var logXMin = Math.log10(xMin), logXMax = Math.log10(xMax);
+            var xStartPow = Math.floor(logXMin), xEndPow = Math.ceil(logXMax);
+            for (var p = xStartPow; p <= xEndPow; p++) {
+                var txv = Math.pow(10, p);
+                if (txv < xMin * 0.9 || txv > xMax * 1.1) continue;
+                var txx = xToPixel(txv);
+                parts.push('<text x="' + txx + '" y="' + (xLabelBaseY + 10) + '" text-anchor="middle" font-size="8" fill="#9ca3af">' + fmtLogTick(txv) + '</text>');
+            }
+        } else {
+            for (var t = 0; t <= 4; t++) {
+                var txv = xMin + (xRange * t / 4);
+                var txx = PAD_LEFT + (t / 4) * plotW;
+                parts.push('<text x="' + txx + '" y="' + (xLabelBaseY + 10) + '" text-anchor="middle" font-size="8" fill="#9ca3af">' + fmtTick(txv, xRange) + '</text>');
+            }
+        }
+
+        var pt = result.plot_type;
+
+        if (pt === "volcano") {
+            // ── Volcano plot — scatter with threshold lines ──
+            // Vertical dashed lines at x = ±1 (log2FC), horizontal at y = 1.3 (-log10(0.05))
+            var vxThresh = 1; // log2FC threshold
+            var vyThresh = 1.3; // -log10(0.05)
+            // Parse thresholds from notes if available
+            if (result.notes) {
+                var fcMatch = result.notes.match(/log2?\s*FC\s*(?:threshold|cutoff)\s*[=:]\s*([\d.]+)/i);
+                if (fcMatch) vxThresh = parseFloat(fcMatch[1]);
+                var pvMatch = result.notes.match(/(?:p[\-_]?value|significance)\s*(?:threshold|cutoff)\s*[=:]\s*([\d.]+)/i);
+                if (pvMatch) vyThresh = parseFloat(pvMatch[1]);
+            }
+            // Draw threshold lines
+            if (xMin <= -vxThresh && xMax >= -vxThresh) {
+                var vlx = xToPixel(-vxThresh);
+                parts.push('<line x1="' + vlx + '" y1="' + PADT + '" x2="' + vlx + '" y2="' + (PADT + plotH) + '" stroke="#9ca3af" stroke-width="0.8" stroke-dasharray="4,3"/>');
+            }
+            if (xMin <= vxThresh && xMax >= vxThresh) {
+                var vrx = xToPixel(vxThresh);
+                parts.push('<line x1="' + vrx + '" y1="' + PADT + '" x2="' + vrx + '" y2="' + (PADT + plotH) + '" stroke="#9ca3af" stroke-width="0.8" stroke-dasharray="4,3"/>');
+            }
+            if (yMin <= vyThresh && yMax >= vyThresh) {
+                var vhy = yToPixel(vyThresh);
+                parts.push('<line x1="' + PAD_LEFT + '" y1="' + vhy + '" x2="' + (PAD_LEFT + plotW) + '" y2="' + vhy + '" stroke="#9ca3af" stroke-width="0.8" stroke-dasharray="4,3"/>');
+            }
+            // Plot points colored by series (typically "up", "down", "non-significant")
+            var volcanoColors = { "up": "#ef4444", "down": "#3b82f6", "non-significant": "#9ca3af", "ns": "#9ca3af", "not significant": "#9ca3af" };
+            result.series.forEach(function(s, si) {
+                var sName = (s.name || "").toLowerCase().trim();
+                var col = volcanoColors[sName] || colors[si % colors.length];
+                if (!s.x_values || !s.y_values) return;
+                for (var i = 0; i < s.y_values.length; i++) {
+                    if (s.y_values[i] == null || isNaN(s.y_values[i])) continue;
+                    var xv = Number(s.x_values[i]);
+                    if (!isFinite(xv)) continue;
+                    var px = xToPixel(xv);
+                    var py = yToPixel(s.y_values[i]);
+                    parts.push('<circle cx="' + px + '" cy="' + py + '" r="2.5" fill="' + col + '" opacity="0.7"/>');
+                }
+            });
+
+        } else if (pt === "funnel") {
+            // ── Funnel plot — scatter with inverted y-axis (SE), reference line ──
+            // Vertical reference line at pooled estimate (mean of effect sizes or first x value)
+            var pooledEst = 0;
+            var allFx = [];
+            result.series.forEach(function(s) {
+                if (!s.x_values) return;
+                s.x_values.forEach(function(v) { var n = Number(v); if (isFinite(n)) allFx.push(n); });
+            });
+            if (allFx.length > 0) pooledEst = allFx.reduce(function(a, b) { return a + b; }, 0) / allFx.length;
+            // Parse pooled estimate from notes
+            if (result.notes) {
+                var poolMatch = result.notes.match(/(?:pooled|overall|summary)\s*(?:estimate|effect)?\s*[=:]\s*([\d.\-]+)/i);
+                if (poolMatch) pooledEst = parseFloat(poolMatch[1]);
+            }
+            var refLineX = xToPixel(pooledEst);
+            parts.push('<line x1="' + refLineX + '" y1="' + PADT + '" x2="' + refLineX + '" y2="' + (PADT + plotH) + '" stroke="#6b7280" stroke-width="0.8" stroke-dasharray="4,3"/>');
+
+            // Pseudo-CI funnel lines (95% CI envelope)
+            // SE on y-axis (inverted: higher SE = lower on plot = bottom)
+            // For a standard funnel, CI bounds = pooled ± 1.96 * SE
+            var funnelPts = 20;
+            var seMax = yMax; // top of y range = max SE = bottom of plot
+            var seMin = Math.max(0, yMin);
+            for (var side = -1; side <= 1; side += 2) {
+                var fPath = "";
+                for (var fi = 0; fi <= funnelPts; fi++) {
+                    var se = seMin + (seMax - seMin) * fi / funnelPts;
+                    var bound = pooledEst + side * 1.96 * se;
+                    if (bound < xMin || bound > xMax) continue;
+                    var fx = xToPixel(bound);
+                    var fy = yToPixel(se);
+                    fPath += (fPath === "" ? "M" : "L") + fx + "," + fy;
+                }
+                if (fPath) parts.push('<path d="' + fPath + '" fill="none" stroke="#d1d5db" stroke-width="0.8" stroke-dasharray="3,2"/>');
+            }
+
+            // Plot points
+            result.series.forEach(function(s, si) {
+                var col = colors[si % colors.length];
+                if (!s.x_values || !s.y_values) return;
+                for (var i = 0; i < s.y_values.length; i++) {
+                    if (s.y_values[i] == null || isNaN(s.y_values[i])) continue;
+                    var xv = Number(s.x_values[i]);
+                    if (!isFinite(xv)) continue;
+                    var px = xToPixel(xv);
+                    var py = yToPixel(s.y_values[i]);
+                    parts.push('<circle cx="' + px + '" cy="' + py + '" r="3" fill="' + col + '" opacity="0.7"/>');
+                }
+            });
+
+        } else if (pt === "bland_altman") {
+            // ── Bland-Altman — scatter with bias and LoA reference lines ──
+            var baBias = 0, baSD = 0;
+            // Try to parse bias and SD from notes
+            if (result.notes) {
+                var biasMatch = result.notes.match(/(?:bias|mean\s*diff(?:erence)?)\s*[=:]\s*([\d.\-]+)/i);
+                if (biasMatch) baBias = parseFloat(biasMatch[1]);
+                var sdMatch = result.notes.match(/(?:SD|std\s*dev)\s*[=:]\s*([\d.\-]+)/i);
+                if (sdMatch) baSD = parseFloat(sdMatch[1]);
+            }
+            // If not in notes, compute from data
+            if (baBias === 0 && baSD === 0) {
+                var baYVals = [];
+                result.series.forEach(function(s) {
+                    if (!s.y_values) return;
+                    s.y_values.forEach(function(v) { if (v != null && isFinite(v)) baYVals.push(v); });
+                });
+                if (baYVals.length > 0) {
+                    baBias = baYVals.reduce(function(a, b) { return a + b; }, 0) / baYVals.length;
+                    var baVariance = baYVals.reduce(function(a, b) { return a + (b - baBias) * (b - baBias); }, 0) / baYVals.length;
+                    baSD = Math.sqrt(baVariance);
+                }
+            }
+            // Draw reference lines
+            var biasY = yToPixel(baBias);
+            parts.push('<line x1="' + PAD_LEFT + '" y1="' + biasY + '" x2="' + (PAD_LEFT + plotW) + '" y2="' + biasY + '" stroke="#3b82f6" stroke-width="1"/>');
+            parts.push('<text x="' + (PAD_LEFT + plotW + 2) + '" y="' + (biasY + 3) + '" font-size="7" fill="#3b82f6">Bias</text>');
+            var loaUp = baBias + 1.96 * baSD;
+            var loaLo = baBias - 1.96 * baSD;
+            if (loaUp >= yMin && loaUp <= yMax) {
+                var loaUpY = yToPixel(loaUp);
+                parts.push('<line x1="' + PAD_LEFT + '" y1="' + loaUpY + '" x2="' + (PAD_LEFT + plotW) + '" y2="' + loaUpY + '" stroke="#ef4444" stroke-width="0.8" stroke-dasharray="4,3"/>');
+                parts.push('<text x="' + (PAD_LEFT + plotW + 2) + '" y="' + (loaUpY + 3) + '" font-size="6" fill="#ef4444">+1.96SD</text>');
+            }
+            if (loaLo >= yMin && loaLo <= yMax) {
+                var loaLoY = yToPixel(loaLo);
+                parts.push('<line x1="' + PAD_LEFT + '" y1="' + loaLoY + '" x2="' + (PAD_LEFT + plotW) + '" y2="' + loaLoY + '" stroke="#ef4444" stroke-width="0.8" stroke-dasharray="4,3"/>');
+                parts.push('<text x="' + (PAD_LEFT + plotW + 2) + '" y="' + (loaLoY + 3) + '" font-size="6" fill="#ef4444">-1.96SD</text>');
+            }
+            // Plot points
+            result.series.forEach(function(s, si) {
+                var col = colors[si % colors.length];
+                if (!s.x_values || !s.y_values) return;
+                for (var i = 0; i < s.y_values.length; i++) {
+                    if (s.y_values[i] == null || isNaN(s.y_values[i])) continue;
+                    var xv = Number(s.x_values[i]);
+                    if (!isFinite(xv)) continue;
+                    var px = xToPixel(xv);
+                    var py = yToPixel(s.y_values[i]);
+                    parts.push('<circle cx="' + px + '" cy="' + py + '" r="3" fill="' + col + '" opacity="0.7"/>');
+                }
+            });
+
+        } else if (pt === "bubble") {
+            // ── Bubble plot — scatter with variable circle size ──
+            // If error_bars data exists, use it as size dimension; otherwise uniform
+            result.series.forEach(function(s, si) {
+                var col = colors[si % colors.length];
+                if (!s.x_values || !s.y_values) return;
+                // Determine bubble sizes: use error_bars_upper as size proxy if available
+                var sizes = null;
+                if (s.error_bars_upper && s.error_bars_upper.some(function(v) { return v != null && v > 0; })) {
+                    sizes = s.error_bars_upper;
+                }
+                var maxSize = 0;
+                if (sizes) sizes.forEach(function(v) { if (v != null && v > maxSize) maxSize = v; });
+                for (var i = 0; i < s.y_values.length; i++) {
+                    if (s.y_values[i] == null || isNaN(s.y_values[i])) continue;
+                    var xv = Number(s.x_values[i]);
+                    if (!isFinite(xv)) continue;
+                    var px = xToPixel(xv);
+                    var py = yToPixel(s.y_values[i]);
+                    var r = 4; // default radius
+                    if (sizes && sizes[i] != null && maxSize > 0) {
+                        r = 3 + (sizes[i] / maxSize) * 12; // scale between 3 and 15
+                    }
+                    parts.push('<circle cx="' + px + '" cy="' + py + '" r="' + r.toFixed(1) + '" fill="' + col + '" opacity="0.5" stroke="' + col + '" stroke-width="0.5"/>');
+                }
+            });
+
+        } else if (pt === "manhattan") {
+            // ── Manhattan plot — scatter with alternating chromosome colors + threshold ──
+            // Significance threshold at y = -log10(5e-8) ≈ 7.3
+            var mhThresh = 7.3;
+            if (result.notes) {
+                var threshMatch = result.notes.match(/(?:threshold|significance)\s*[=:]\s*([\d.]+)/i);
+                if (threshMatch) mhThresh = parseFloat(threshMatch[1]);
+            }
+            if (mhThresh >= yMin && mhThresh <= yMax) {
+                var mhThreshY = yToPixel(mhThresh);
+                parts.push('<line x1="' + PAD_LEFT + '" y1="' + mhThreshY + '" x2="' + (PAD_LEFT + plotW) + '" y2="' + mhThreshY + '" stroke="#ef4444" stroke-width="0.8" stroke-dasharray="4,3"/>');
+                parts.push('<text x="' + (PAD_LEFT + plotW + 2) + '" y="' + (mhThreshY + 3) + '" font-size="6" fill="#ef4444">5e-8</text>');
+            }
+            // Suggestive threshold at y = -log10(1e-5) ≈ 5
+            var sugThresh = 5;
+            if (sugThresh >= yMin && sugThresh <= yMax) {
+                var sugThreshY = yToPixel(sugThresh);
+                parts.push('<line x1="' + PAD_LEFT + '" y1="' + sugThreshY + '" x2="' + (PAD_LEFT + plotW) + '" y2="' + sugThreshY + '" stroke="#3b82f6" stroke-width="0.5" stroke-dasharray="3,3"/>');
+            }
+            // Alternating colors by chromosome group (use series or detect from x gaps)
+            var mhColors = ["#3b82f6", "#6366f1", "#8b5cf6", "#a855f7", "#3b82f6", "#6366f1"];
+            result.series.forEach(function(s, si) {
+                var col = mhColors[si % mhColors.length];
+                if (!s.x_values || !s.y_values) return;
+                for (var i = 0; i < s.y_values.length; i++) {
+                    if (s.y_values[i] == null || isNaN(s.y_values[i])) continue;
+                    var xv = Number(s.x_values[i]);
+                    if (!isFinite(xv)) continue;
+                    var px = xToPixel(xv);
+                    var py = yToPixel(s.y_values[i]);
+                    // Points above threshold are highlighted
+                    var aboveThresh = s.y_values[i] >= mhThresh;
+                    var ptCol = aboveThresh ? "#ef4444" : col;
+                    var ptR = aboveThresh ? 3 : 2;
+                    parts.push('<circle cx="' + px + '" cy="' + py + '" r="' + ptR + '" fill="' + ptCol + '" opacity="' + (aboveThresh ? 0.9 : 0.6) + '"/>');
+                }
+            });
+
+        } else {
+            // ── Default: Scatter / Line plot ──
+            var isLine = (pt === "line" || pt === "dose_response" || pt === "roc" || pt === "area");
+            var isStep = (pt === "kaplan_meier");
+
+            result.series.forEach(function(s, si) {
+                var col = colors[si % colors.length];
+                if (!s.x_values || !s.y_values) return;
+                var xVals = s.x_values.map(Number);
+
+                var pts = [];
+                for (var i = 0; i < s.y_values.length; i++) {
+                    if (s.y_values[i] == null || isNaN(s.y_values[i]) || !isFinite(xVals[i])) continue;
+                    pts.push({ x: xVals[i], y: s.y_values[i], idx: i });
+                }
+                pts.sort(function(a, b) { return a.x - b.x; });
+
+                if ((isLine || isStep) && pts.length > 1) {
+                    var pathD = "M" + xToPixel(pts[0].x) + "," + yToPixel(pts[0].y);
+                    for (var j = 1; j < pts.length; j++) {
+                        if (isStep) {
+                            // Step function: horizontal then vertical (Kaplan-Meier style)
+                            pathD += "H" + xToPixel(pts[j].x);
+                            pathD += "V" + yToPixel(pts[j].y);
+                        } else {
+                            pathD += "L" + xToPixel(pts[j].x) + "," + yToPixel(pts[j].y);
+                        }
+                    }
+                    parts.push('<path d="' + pathD + '" fill="none" stroke="' + col + '" stroke-width="1.5" opacity="0.8"/>');
+                }
+
+                pts.forEach(function(p) {
+                    var px = xToPixel(p.x);
+                    var py = yToPixel(p.y);
+                    parts.push('<circle cx="' + px + '" cy="' + py + '" r="' + (isLine ? 2 : 3) + '" fill="' + col + '" opacity="0.8"/>');
+
+                    var eLo = (s.error_bars_lower && s.error_bars_lower[p.idx]) || 0;
+                    var eHi = (s.error_bars_upper && s.error_bars_upper[p.idx]) || 0;
+                    if (eHi > 0 || eLo > 0) {
+                        var eTop = yToPixel(p.y + eHi);
+                        var eBot = yToPixel(p.y - eLo);
+                        parts.push('<line x1="' + px + '" y1="' + eTop + '" x2="' + px + '" y2="' + eBot + '" stroke="' + col + '" stroke-width="1" opacity="0.5"/>');
+                        parts.push('<line x1="' + (px - 2) + '" y1="' + eTop + '" x2="' + (px + 2) + '" y2="' + eTop + '" stroke="' + col + '" opacity="0.5"/>');
+                        parts.push('<line x1="' + (px - 2) + '" y1="' + eBot + '" x2="' + (px + 2) + '" y2="' + eBot + '" stroke="' + col + '" opacity="0.5"/>');
+                    }
+                });
+            });
+        }
+    }
+
+    // Axis labels
+    if (result.y_label) {
+        var yLabelText = result.y_label + (result.y_unit ? ' (' + result.y_unit + ')' : '');
+        if (yLabelText.length > 30) yLabelText = yLabelText.substring(0, 28) + "\u2026";
+        parts.push('<text x="12" y="' + (PADT + plotH / 2) + '" text-anchor="middle" font-size="8" fill="#6b7280" transform="rotate(-90,12,' + (PADT + plotH / 2) + ')">' + yLabelText + '</text>');
+    }
+    if (result.x_label) {
+        var xLabelText = result.x_label + (result.x_unit ? ' (' + result.x_unit + ')' : '');
+        if (xLabelText.length > 50) xLabelText = xLabelText.substring(0, 48) + "\u2026";
+        parts.push('<text x="' + (PAD_LEFT + plotW / 2) + '" y="' + (H - 2) + '" text-anchor="middle" font-size="8" fill="#6b7280">' + xLabelText + '</text>');
+    }
+
+    // Legend
+    var legendX = PAD_LEFT, legendY = 5;
+    result.series.forEach(function(s, si) {
+        var name = s.name || ("Series " + (si + 1));
+        if (name.length > 16) name = name.substring(0, 14) + "\u2026";
+        var itemW = name.length * 5 + 16;
+        if (legendX + itemW > W - 10) { legendX = PAD_LEFT; legendY += 12; }
+        parts.push('<rect x="' + legendX + '" y="' + legendY + '" width="8" height="8" fill="' + colors[si % colors.length] + '" rx="1"/>');
+        parts.push('<text x="' + (legendX + 11) + '" y="' + (legendY + 7) + '" font-size="8" fill="#6b7280">' + name + '</text>');
+        legendX += itemW;
+    });
+
+    parts.push('</svg>');
+    return parts.join("");
+}
+
+// ── Export ──
+
+function downloadFigureCsv(idx) {
+    var result = extractedResults[idx];
+    if (!result) return;
+
+    var hasErrors = false;
+    result.series.forEach(function(s) {
+        if (s.error_bars_lower && s.error_bars_lower.some(function(v) { return v != null && v !== 0; })) hasErrors = true;
+        if (s.error_bars_upper && s.error_bars_upper.some(function(v) { return v != null && v !== 0; })) hasErrors = true;
+    });
+
+    var rows = [];
+    var header = ["series", result.x_label || "x", result.y_label || "y"];
+    if (hasErrors) header.push("error_lower", "error_upper");
+    rows.push(header.join(","));
+
+    result.series.forEach(function(s) {
+        for (var i = 0; i < s.y_values.length; i++) {
+            var x = i < s.x_values.length ? s.x_values[i] : "";
+            var y = s.y_values[i];
+            if (typeof x === "string" && x.indexOf(",") !== -1) x = '"' + x + '"';
+            var row = [s.name, x, y];
+            if (hasErrors) {
+                var el = (s.error_bars_lower && i < s.error_bars_lower.length && s.error_bars_lower[i] != null) ? s.error_bars_lower[i] : "";
+                var eu = (s.error_bars_upper && i < s.error_bars_upper.length && s.error_bars_upper[i] != null) ? s.error_bars_upper[i] : "";
+                row.push(el, eu);
+            }
+            rows.push(row.join(","));
+        }
+    });
+    var blob = new Blob([rows.join("\n")], { type: "text/csv" });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement("a");
+    a.href = url;
+    var fname = (result.title || result.figure_id || "extracted").replace(/[^a-zA-Z0-9_\-]/g, "_").substring(0, 60);
+    a.download = fname + ".csv";
+    a.click();
+    URL.revokeObjectURL(url);
+}
+
+function exportAllCsv() {
+    if (extractedResults.length === 0) return;
+    var rows = [];
+    rows.push(["figure_id", "plot_type", "series", "x", "y", "error_lower", "error_upper"].join(","));
+
+    extractedResults.forEach(function(result) {
+        result.series.forEach(function(s) {
+            for (var i = 0; i < s.y_values.length; i++) {
+                var x = i < s.x_values.length ? s.x_values[i] : "";
+                if (typeof x === "string" && x.indexOf(",") !== -1) x = '"' + x + '"';
+                var el = (s.error_bars_lower && i < s.error_bars_lower.length && s.error_bars_lower[i] != null) ? s.error_bars_lower[i] : "";
+                var eu = (s.error_bars_upper && i < s.error_bars_upper.length && s.error_bars_upper[i] != null) ? s.error_bars_upper[i] : "";
+                rows.push([result.figure_id || "", result.plot_type || "", s.name, x, s.y_values[i], el, eu].join(","));
+            }
+        });
+    });
+    var blob = new Blob([rows.join("\n")], { type: "text/csv" });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement("a");
+    a.href = url;
+    a.download = "extracted_data.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+}
+
+function exportAllJson() {
+    if (extractedResults.length === 0) return;
+    var blob = new Blob([JSON.stringify(extractedResults, null, 2)], { type: "application/json" });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement("a");
+    a.href = url;
+    a.download = "extracted_data.json";
+    a.click();
+    URL.revokeObjectURL(url);
+}
+
+function copyPandasCode() {
+    if (extractedResults.length === 0) return;
+    var code = "import pandas as pd\n\n";
+
+    extractedResults.forEach(function(result, idx) {
+        result.series.forEach(function(series) {
+            var varName = "df_fig" + idx + "_" + series.name.replace(/\s+/g, "_").replace(/[^a-zA-Z0-9_]/g, "").toLowerCase();
+            code += "# " + (result.title || result.figure_id || "Region " + idx) + " \u2014 " + series.name + "\n";
+            code += varName + " = pd.DataFrame({\n";
+            code += '    "' + (result.x_label || "x") + '": ' + JSON.stringify(series.x_values) + ",\n";
+            code += '    "' + (result.y_label || "y") + '": ' + JSON.stringify(series.y_values) + ",\n";
+            if (series.error_bars_lower && series.error_bars_lower.some(function(v) { return v !== null; })) {
+                code += '    "error_lower": ' + JSON.stringify(series.error_bars_lower) + ",\n";
+            }
+            if (series.error_bars_upper && series.error_bars_upper.some(function(v) { return v !== null; })) {
+                code += '    "error_upper": ' + JSON.stringify(series.error_bars_upper) + ",\n";
+            }
+            code += "})\n\n";
+        });
+    });
+
+    navigator.clipboard.writeText(code).then(function() {
+        alert("DataFrame code copied to clipboard!");
+    });
+}

--- a/skills/data-extractor/web/index.html
+++ b/skills/data-extractor/web/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Get Me The Data</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="bg-gray-50 min-h-screen">
+
+    <!-- Header -->
+    <header class="bg-white border-b border-gray-200">
+        <div class="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between">
+            <div>
+                <h1 class="text-2xl font-bold text-gray-900">Get Me The Data</h1>
+                <p class="text-sm text-gray-500 mt-1">Drop a screenshot, draw boxes around plots, extract numerical data</p>
+            </div>
+            <div class="flex items-center gap-2 text-sm text-gray-400">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z" fill="#10b981" opacity="0.15"/>
+                    <path d="M8 8c0-1 .5-2 1.5-2.5M16 8c0-1-.5-2-1.5-2.5M9 16c.5.5 1.5 1 3 1s2.5-.5 3-1" stroke="#10b981" stroke-width="1.5" stroke-linecap="round"/>
+                    <circle cx="9" cy="10" r="1.5" fill="#10b981"/>
+                    <circle cx="15" cy="10" r="1.5" fill="#10b981"/>
+                    <path d="M7 13.5Q12 17 17 13.5" stroke="#10b981" stroke-width="1" stroke-linecap="round" fill="none" opacity="0.5"/>
+                </svg>
+                <span>Made with <strong class="text-emerald-600">ClawBio</strong></span>
+            </div>
+        </div>
+    </header>
+
+    <main class="max-w-6xl mx-auto px-4 py-8 space-y-8">
+
+        <!-- Drop Zone (shown when no image loaded) -->
+        <section id="drop-section" class="bg-white rounded-lg shadow p-6">
+            <div
+                id="drop-zone"
+                class="drop-zone rounded-lg p-16 text-center cursor-pointer"
+                onclick="document.getElementById('image-upload').click()"
+            >
+                <p class="text-gray-400 text-2xl mb-2">Drop an image here</p>
+                <p class="text-gray-300 text-sm mb-4">PNG, JPG, or paste from clipboard (Ctrl/Cmd+V)</p>
+                <p class="text-gray-300 text-xs">Screenshots of figures from papers, posters, slides...</p>
+            </div>
+            <input id="image-upload" type="file" accept="image/*" class="hidden" onchange="handleImageUpload(event)">
+        </section>
+
+        <!-- Image Viewer (shown after image loaded) -->
+        <section id="viewer-section" class="bg-white rounded-lg shadow p-6 hidden">
+            <div class="flex justify-between items-center mb-3">
+                <div class="flex items-center gap-3">
+                    <h2 class="text-lg font-semibold text-gray-800">Image</h2>
+                    <button onclick="clearImage()" class="text-xs text-gray-400 hover:text-red-500 underline">Clear</button>
+                </div>
+                <div class="flex items-center gap-2">
+                    <button id="auto-detect-btn" onclick="autoDetectPlots()" class="px-3 py-1 bg-blue-50 text-blue-700 rounded hover:bg-blue-100 text-sm">Auto-detect plots</button>
+                </div>
+            </div>
+            <p class="text-xs text-gray-400 mb-2">Click and drag to select a plot region. Adjust or delete boxes, then click Extract.</p>
+            <div id="viewer-status" class="text-sm mb-2"></div>
+            <div id="image-viewer" class="relative inline-block w-full" style="cursor:crosshair">
+                <img id="main-image" class="w-full rounded border border-gray-200 bg-gray-50" alt="Uploaded image" draggable="false">
+                <div id="plot-boxes-layer" class="absolute inset-0" style="pointer-events:none"></div>
+                <div id="draw-layer" class="absolute inset-0"></div>
+            </div>
+            <div id="page-results" class="mt-4 space-y-4"></div>
+        </section>
+
+        <!-- Extracted Data -->
+        <section id="results-section" class="bg-white rounded-lg shadow p-6 hidden">
+            <div class="flex justify-between items-center mb-4">
+                <h2 class="text-lg font-semibold text-gray-800">Extracted Data</h2>
+                <div class="flex gap-2">
+                    <button onclick="exportAllCsv()" class="text-sm bg-gray-100 px-3 py-1 rounded hover:bg-gray-200">CSV</button>
+                    <button onclick="exportAllJson()" class="text-sm bg-gray-100 px-3 py-1 rounded hover:bg-gray-200">JSON</button>
+                    <button onclick="copyPandasCode()" class="text-sm bg-gray-100 px-3 py-1 rounded hover:bg-gray-200">Copy pd.DataFrame</button>
+                </div>
+            </div>
+            <div id="results-container" class="space-y-8"></div>
+        </section>
+
+    </main>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/skills/data-extractor/web/server.py
+++ b/skills/data-extractor/web/server.py
@@ -1,0 +1,310 @@
+"""Get Me The Data — lightweight FastAPI server for the data-extractor skill."""
+
+from __future__ import annotations
+
+import base64 as b64mod
+import hashlib
+import io
+import logging
+import sys
+from pathlib import Path
+
+# Add skill root to sys.path so `from core.models import ...` works
+_WEB_DIR = Path(__file__).resolve().parent
+_SKILL_ROOT = _WEB_DIR.parent
+if str(_SKILL_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SKILL_ROOT))
+
+from fastapi import FastAPI, HTTPException, UploadFile
+from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
+from PIL import Image as PILImage
+from pydantic import BaseModel
+
+from core.models import (
+    Confidence,
+    ExtractedData,
+    Figure,
+    PlotType,
+)
+from core.digitizer import digitize_figure
+
+logger = logging.getLogger(__name__)
+
+# In-memory stores
+images_store: dict[str, bytes] = {}  # image_id -> PNG bytes
+images_meta: dict[str, dict] = {}  # image_id -> {width, height}
+figures_store: dict[str, list[Figure]] = {}  # image_id -> figures
+extracted_store: dict[str, list[ExtractedData]] = {}  # image_id -> results
+
+app = FastAPI(title="Get Me The Data", version="0.2.0")
+
+# Serve static files from the web/ directory (CSS, JS)
+app.mount("/static", StaticFiles(directory=str(_WEB_DIR)), name="static")
+
+# Also serve CSS/JS at root level (index.html uses relative paths)
+@app.get("/styles.css")
+async def serve_css():
+    return FileResponse(str(_WEB_DIR / "styles.css"), media_type="text/css")
+
+@app.get("/app.js")
+async def serve_js():
+    return FileResponse(str(_WEB_DIR / "app.js"), media_type="application/javascript")
+
+
+@app.get("/")
+async def index():
+    return FileResponse(str(_WEB_DIR / "index.html"))
+
+
+# --- Image Upload & Serving ---
+
+
+@app.post("/api/upload-image")
+async def upload_image(file: UploadFile):
+    """Upload an image (PNG/JPG/etc) and return an image_id."""
+    if not file.content_type or not file.content_type.startswith("image/"):
+        raise HTTPException(status_code=400, detail="File must be an image")
+
+    content = await file.read()
+    image_id = hashlib.sha256(content).hexdigest()[:12]
+
+    # Convert to PNG and store
+    img = PILImage.open(io.BytesIO(content))
+    if img.mode == "RGBA":
+        bg = PILImage.new("RGB", img.size, (255, 255, 255))
+        bg.paste(img, mask=img.split()[3])
+        img = bg
+    elif img.mode != "RGB":
+        img = img.convert("RGB")
+
+    buf = io.BytesIO()
+    img.save(buf, format="PNG", optimize=True)
+    png_bytes = buf.getvalue()
+
+    images_store[image_id] = png_bytes
+    images_meta[image_id] = {"width": img.width, "height": img.height}
+
+    return {"image_id": image_id, "width": img.width, "height": img.height}
+
+
+@app.get("/api/image/{image_id}")
+async def get_image(image_id: str):
+    """Serve an uploaded image as PNG."""
+    if image_id not in images_store:
+        raise HTTPException(status_code=404, detail="Image not found")
+    return StreamingResponse(
+        io.BytesIO(images_store[image_id]),
+        media_type="image/png",
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
+# --- Plot Detection ---
+
+
+@app.get("/api/detect-plots/{image_id}")
+async def detect_plots(image_id: str):
+    """Use Claude vision to detect plot regions on an uploaded image."""
+    import anthropic
+
+    if image_id not in images_store:
+        raise HTTPException(status_code=404, detail="Image not found")
+
+    b64 = b64mod.b64encode(images_store[image_id]).decode()
+
+    client = anthropic.AsyncAnthropic()
+    response = await client.messages.create(
+        model="claude-sonnet-4-20250514",
+        max_tokens=2048,
+        messages=[{
+            "role": "user",
+            "content": [
+                {
+                    "type": "image",
+                    "source": {"type": "base64", "media_type": "image/png", "data": b64},
+                },
+                {
+                    "type": "text",
+                    "text": (
+                        "This is an image (likely a screenshot from a scientific paper). "
+                        "Identify ALL distinct quantitative plots/charts "
+                        "(bar charts, scatter plots, line graphs, box plots, heatmaps, "
+                        "forest plots, Kaplan-Meier curves, histograms, violin plots, etc.).\n\n"
+                        "Do NOT include: text-only areas, photographs, Western blots, gel images, "
+                        "microscopy images, schematics, flowcharts, or diagrams without axes.\n"
+                        "DO include: tables with numerical data.\n\n"
+                        "For each plot found, return its bounding box as percentages (0-100) "
+                        "of the image. Include the axis labels and tick marks in the box.\n\n"
+                        "Return JSON:\n"
+                        '{"plots": [\n'
+                        '  {"label": "a", "type": "bar", "title": "short description", '
+                        '"x_pct": 5, "y_pct": 10, "w_pct": 45, "h_pct": 40},\n'
+                        "  ...\n"
+                        "]}\n\n"
+                        "If no quantitative plots are found, return: {\"plots\": []}\n"
+                        "Plot type must be one of: scatter, bar, line, box, violin, histogram, "
+                        "heatmap, forest, kaplan_meier, dot_strip, stacked_bar, funnel, roc, "
+                        "volcano, waterfall, bland_altman, paired, bubble, area, dose_response, "
+                        "manhattan, correlation_matrix, error_bar, table, other.\n"
+                        "Return ONLY the JSON."
+                    ),
+                },
+            ],
+        }],
+    )
+
+    import json
+    raw = response.content[0].text.strip()
+    if raw.startswith("```"):
+        raw = raw.split("\n", 1)[1]
+    if raw.endswith("```"):
+        raw = raw[:-3]
+    raw = raw.strip()
+
+    try:
+        data = json.loads(raw)
+        return data
+    except json.JSONDecodeError:
+        return {"plots": []}
+
+
+# --- Extraction ---
+
+
+class ImageRegionRequest(BaseModel):
+    image_id: str
+    crop_x_pct: float | None = None
+    crop_y_pct: float | None = None
+    crop_w_pct: float | None = None
+    crop_h_pct: float | None = None
+
+
+@app.post("/api/extract-image-region")
+async def extract_image_region(req: ImageRegionRequest):
+    """Extract data from a region of an uploaded image."""
+    if req.image_id not in images_store:
+        raise HTTPException(status_code=404, detail="Image not found")
+
+    img = PILImage.open(io.BytesIO(images_store[req.image_id]))
+
+    # Crop if region specified
+    if req.crop_x_pct is not None:
+        x = int(req.crop_x_pct / 100 * img.width)
+        y = int(req.crop_y_pct / 100 * img.height)
+        w = int(req.crop_w_pct / 100 * img.width)
+        h = int(req.crop_h_pct / 100 * img.height)
+        img = img.crop((x, y, x + w, y + h))
+
+    # Resize if too large
+    if img.width > 1500 or img.height > 1500:
+        img.thumbnail((1500, 1500), PILImage.LANCZOS)
+
+    buf = io.BytesIO()
+    img.save(buf, format="PNG", optimize=True)
+    b64 = b64mod.b64encode(buf.getvalue()).decode()
+
+    figure_id = req.image_id + "_region"
+
+    fig = Figure(
+        figure_id=figure_id,
+        paper_id=req.image_id,
+        page_number=1,
+        image_index=0,
+        width=img.width,
+        height=img.height,
+        image_base64=b64,
+        plot_type=PlotType.OTHER,
+        plot_type_confidence=Confidence.MEDIUM,
+    )
+
+    # Store so image endpoint can serve panels
+    if req.image_id not in figures_store:
+        figures_store[req.image_id] = []
+    figures_store[req.image_id].append(fig)
+
+    try:
+        results, panel_figures = await digitize_figure(fig)
+        if req.image_id not in extracted_store:
+            extracted_store[req.image_id] = []
+        extracted_store[req.image_id].extend(results)
+        if panel_figures:
+            figures_store[req.image_id].extend(panel_figures)
+        return [r.model_dump() for r in results]
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Extraction failed: {str(e)}")
+
+
+# --- Figure image serving (for panel crops) ---
+
+
+@app.get("/api/figure-image/{figure_id}")
+async def get_figure_image(figure_id: str):
+    """Serve a figure/panel image as PNG."""
+    for figs in figures_store.values():
+        for fig in figs:
+            if fig.figure_id == figure_id:
+                img_bytes = b64mod.b64decode(fig.image_base64)
+                return StreamingResponse(
+                    io.BytesIO(img_bytes),
+                    media_type="image/png",
+                    headers={"Cache-Control": "public, max-age=3600"},
+                )
+    raise HTTPException(status_code=404, detail="Figure not found")
+
+
+# --- Edit extracted data ---
+
+
+class EditCellRequest(BaseModel):
+    image_id: str
+    result_index: int
+    series_index: int
+    field: str  # "x_values" or "y_values"
+    point_index: int
+    value: float | str
+
+
+@app.patch("/api/edit-cell")
+async def edit_cell(req: EditCellRequest):
+    """Edit a single extracted data point (user correction)."""
+    if req.image_id not in extracted_store:
+        raise HTTPException(status_code=404, detail="No results for this image")
+    results = extracted_store[req.image_id]
+    if req.result_index >= len(results):
+        raise HTTPException(status_code=404, detail="Result index out of range")
+
+    result = results[req.result_index]
+    if req.series_index >= len(result.series):
+        raise HTTPException(status_code=404, detail="Series index out of range")
+
+    series = result.series[req.series_index]
+    arr = getattr(series, req.field, None)
+    if arr is None or req.field not in ("x_values", "y_values", "error_bars_lower", "error_bars_upper"):
+        raise HTTPException(status_code=400, detail=f"Invalid field: {req.field}")
+    if req.point_index >= len(arr):
+        raise HTTPException(status_code=404, detail="Point index out of range")
+
+    # Apply the edit
+    if req.field == "y_values":
+        arr[req.point_index] = float(req.value)
+    elif req.field in ("error_bars_lower", "error_bars_upper"):
+        arr[req.point_index] = float(req.value) if req.value is not None else None
+    else:
+        arr[req.point_index] = req.value
+
+    return {"ok": True}
+
+
+def launch(port: int = 8765):
+    """Launch the server on the given port."""
+    import uvicorn
+    uvicorn.run(
+        app,
+        host="0.0.0.0",
+        port=port,
+    )
+
+
+if __name__ == "__main__":
+    launch()

--- a/skills/data-extractor/web/styles.css
+++ b/skills/data-extractor/web/styles.css
@@ -1,0 +1,194 @@
+/* Custom styles beyond Tailwind */
+
+.figure-card {
+    transition: all 0.2s ease;
+}
+
+.figure-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.figure-card.selected {
+    ring: 2px solid #3b82f6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.3);
+}
+
+.badge {
+    font-size: 0.7rem;
+    padding: 2px 8px;
+    border-radius: 9999px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.badge-scatter { background: #dbeafe; color: #1e40af; }
+.badge-bar { background: #dcfce7; color: #166534; }
+.badge-line { background: #fef3c7; color: #92400e; }
+.badge-box { background: #f3e8ff; color: #6b21a8; }
+.badge-violin { background: #fce7f3; color: #9d174d; }
+.badge-histogram { background: #e0e7ff; color: #3730a3; }
+.badge-heatmap { background: #ffedd5; color: #9a3412; }
+.badge-forest { background: #d1fae5; color: #065f46; }
+.badge-kaplan_meier { background: #fecaca; color: #991b1b; }
+.badge-table { background: #cffafe; color: #155e75; }
+.badge-other { background: #f3f4f6; color: #374151; }
+.badge-non_data { background: #e5e7eb; color: #6b7280; }
+
+.confidence-high { color: #059669; }
+.confidence-medium { color: #d97706; }
+.confidence-low { color: #dc2626; }
+
+.spinner {
+    border: 3px solid #e5e7eb;
+    border-top: 3px solid #3b82f6;
+    border-radius: 50%;
+    width: 24px;
+    height: 24px;
+    animation: spin 0.8s linear infinite;
+    display: inline-block;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+.data-table input {
+    width: 100%;
+    border: 1px solid transparent;
+    background: transparent;
+    padding: 2px 4px;
+    font-family: monospace;
+    font-size: 0.85rem;
+}
+
+.data-table input:hover {
+    border-color: #d1d5db;
+}
+
+.data-table input:focus {
+    border-color: #3b82f6;
+    outline: none;
+    background: #eff6ff;
+}
+
+.drop-zone {
+    border: 2px dashed #d1d5db;
+    transition: all 0.2s;
+    background: #fafafa;
+}
+
+.drop-zone:hover {
+    border-color: #93c5fd;
+    background: #f0f7ff;
+}
+
+.drop-zone.dragover {
+    border-color: #3b82f6;
+    background: #eff6ff;
+    transform: scale(1.01);
+}
+
+/* Drawing preview rectangle */
+.draw-preview {
+    position: absolute;
+    border: 2px dashed #7c3aed;
+    background: rgba(124, 58, 237, 0.08);
+    pointer-events: none;
+    box-sizing: border-box;
+}
+
+/* Plot detection boxes */
+.plot-box {
+    position: absolute;
+    border: 2px solid #3b82f6;
+    background: rgba(59, 130, 246, 0.06);
+    cursor: move;
+    box-sizing: border-box;
+    min-width: 30px;
+    min-height: 30px;
+    pointer-events: auto;
+    transition: border-color 0.15s, background 0.15s;
+}
+
+.plot-box:hover {
+    border-color: #2563eb;
+    background: rgba(59, 130, 246, 0.12);
+}
+
+.plot-box.extracting {
+    border-color: #8b5cf6;
+    background: rgba(139, 92, 246, 0.1);
+    animation: pulse-border 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse-border {
+    0%, 100% { border-color: #8b5cf6; }
+    50% { border-color: #c4b5fd; }
+}
+
+.plot-box.done {
+    border-color: #10b981;
+    background: rgba(16, 185, 129, 0.06);
+}
+
+.plot-box .box-handle {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    background: #3b82f6;
+    border: 1px solid white;
+    border-radius: 2px;
+    z-index: 2;
+}
+
+.box-handle.se { bottom: -5px; right: -5px; cursor: se-resize; }
+.box-handle.sw { bottom: -5px; left: -5px; cursor: sw-resize; }
+.box-handle.ne { top: -5px; right: -5px; cursor: ne-resize; }
+.box-handle.nw { top: -5px; left: -5px; cursor: nw-resize; }
+
+.plot-box .box-controls {
+    position: absolute;
+    top: -28px;
+    right: -2px;
+    display: flex;
+    gap: 2px;
+    z-index: 3;
+    white-space: nowrap;
+}
+
+.plot-box .box-label {
+    position: absolute;
+    top: -28px;
+    left: -2px;
+    font-size: 11px;
+    font-weight: 600;
+    background: #3b82f6;
+    color: white;
+    padding: 2px 8px;
+    border-radius: 4px 4px 0 0;
+    z-index: 3;
+    white-space: nowrap;
+}
+
+.plot-box .box-btn {
+    font-size: 11px;
+    padding: 2px 8px;
+    border: none;
+    border-radius: 3px;
+    cursor: pointer;
+    font-weight: 500;
+}
+
+.plot-box .btn-extract {
+    background: #7c3aed;
+    color: white;
+}
+.plot-box .btn-extract:hover { background: #6d28d9; }
+
+.plot-box .btn-delete {
+    background: #fecaca;
+    color: #991b1b;
+}
+.plot-box .btn-delete:hover { background: #fca5a5; }


### PR DESCRIPTION
## Summary
- Ports the `get_me_the_data` extraction engine into ClawBio as a new `data-extractor` skill
- 4-phase pipeline: panel detection → pre-analysis → CV calibration + extraction → validation
- Supports 26 plot types (bar, scatter, forest, Kaplan-Meier, box, violin, heatmap, etc.)
- Includes web UI with "Made with ClawBio" branding, CLI entry point, and importable API
- Integrates with bio-orchestrator (routes `.png/.jpg/.tiff` files and keywords like "digitize", "extract data")
- 9 pytest tests, all passing

## Test plan
- [ ] `python clawbio.py list` shows `data-extract` skill as OK
- [ ] `python clawbio.py run data-extract --web` launches web UI on port 8765
- [ ] Upload a figure image → auto-detect → extract → verify data table + SVG preview
- [ ] `python orchestrator.py --input figure.png` routes to data-extractor
- [ ] `pytest skills/data-extractor/tests/ -v` — 9 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)