### PR TITLE
Add webchat frontend and custom domain docs

### DIFF
--- a/bot/webchat/index.html
+++ b/bot/webchat/index.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>RoboTerri - ClawBio Bioinformatics Assistant</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0a0a0a; color: #e0e0e0; height: 100vh; display: flex; flex-direction: column; }
+  .header { background: #111; border-bottom: 1px solid #222; padding: 12px 20px; display: flex; align-items: center; gap: 12px; }
+  .header h1 { font-size: 18px; font-weight: 600; }
+  .header .sub { font-size: 13px; color: #888; }
+  .status { width: 8px; height: 8px; border-radius: 50%; background: #555; flex-shrink: 0; }
+  .status.connected { background: #24e08a; }
+  .messages { flex: 1; overflow-y: auto; padding: 20px; display: flex; flex-direction: column; gap: 12px; }
+  .msg { max-width: 80%; padding: 10px 14px; border-radius: 12px; font-size: 14px; line-height: 1.5; white-space: pre-wrap; word-wrap: break-word; }
+  .msg.user { align-self: flex-end; background: #1a3a5c; color: #d0e8ff; border-bottom-right-radius: 4px; }
+  .msg.assistant { align-self: flex-start; background: #1a1a1a; border: 1px solid #2a2a2a; border-bottom-left-radius: 4px; }
+  .msg.system { align-self: center; background: none; color: #666; font-size: 12px; font-style: italic; }
+  .input-area { background: #111; border-top: 1px solid #222; padding: 12px 20px; display: flex; gap: 10px; }
+  .input-area textarea { flex: 1; background: #1a1a1a; border: 1px solid #333; border-radius: 10px; color: #e0e0e0; padding: 10px 14px; font-size: 14px; font-family: inherit; resize: none; outline: none; min-height: 42px; max-height: 120px; }
+  .input-area textarea:focus { border-color: #4a9eff; }
+  .input-area textarea::placeholder { color: #555; }
+  .input-area button { background: #1a3a5c; border: none; color: #d0e8ff; padding: 0 18px; border-radius: 10px; font-size: 14px; font-weight: 600; cursor: pointer; white-space: nowrap; }
+  .input-area button:hover { background: #245080; }
+  .input-area button:disabled { opacity: 0.4; cursor: default; }
+  .typing { align-self: flex-start; color: #666; font-size: 13px; padding: 4px 14px; }
+  .disclaimer { text-align: center; padding: 8px; font-size: 11px; color: #555; background: #0a0a0a; }
+</style>
+</head>
+<body>
+
+<div class="header">
+  <div class="status" id="status"></div>
+  <div>
+    <h1>RoboTerri</h1>
+    <div class="sub">ClawBio Bioinformatics Assistant</div>
+  </div>
+</div>
+
+<div class="messages" id="messages">
+  <div class="msg system">Send a message to start. Try "!skills" or "!demo pharmgx".</div>
+</div>
+
+<div class="input-area">
+  <textarea id="input" placeholder="Ask a bioinformatics question..." rows="1"></textarea>
+  <button id="send" onclick="sendMessage()">Send</button>
+</div>
+
+<div class="disclaimer">
+  ClawBio is a research tool, not a medical device. Consult a healthcare professional before making medical decisions.
+</div>
+
+<script>
+const GATEWAY_URL = window.location.origin.replace(/^http/, 'ws');
+const AUTH_TOKEN = new URLSearchParams(window.location.search).get('t') || '';
+
+let ws = null;
+let sessionId = null;
+let reconnectTimer = null;
+
+const messagesEl = document.getElementById('messages');
+const inputEl = document.getElementById('input');
+const sendBtn = document.getElementById('send');
+const statusEl = document.getElementById('status');
+
+function connect() {
+  if (ws && ws.readyState <= 1) return;
+
+  const url = new URL(GATEWAY_URL);
+  ws = new WebSocket(url.href);
+
+  ws.onopen = () => {
+    statusEl.classList.add('connected');
+    // Authenticate
+    ws.send(JSON.stringify({
+      type: 'connect',
+      params: { auth: { token: AUTH_TOKEN } }
+    }));
+  };
+
+  ws.onmessage = (event) => {
+    try {
+      const data = JSON.parse(event.data);
+      handleMessage(data);
+    } catch (e) {
+      console.error('Parse error:', e);
+    }
+  };
+
+  ws.onclose = () => {
+    statusEl.classList.remove('connected');
+    reconnectTimer = setTimeout(connect, 3000);
+  };
+
+  ws.onerror = () => {
+    statusEl.classList.remove('connected');
+  };
+}
+
+function handleMessage(data) {
+  if (data.type === 'connected') {
+    sessionId = data.sessionId;
+    addMessage('Connected to RoboTerri.', 'system');
+    return;
+  }
+
+  if (data.type === 'chat' || data.type === 'chat.stream') {
+    const text = data.text || data.content || '';
+    if (text && data.role === 'assistant') {
+      // Remove typing indicator
+      const typing = document.querySelector('.typing');
+      if (typing) typing.remove();
+      addMessage(text, 'assistant');
+    }
+    return;
+  }
+
+  if (data.type === 'chat.typing') {
+    if (!document.querySelector('.typing')) {
+      const el = document.createElement('div');
+      el.className = 'typing';
+      el.textContent = 'RoboTerri is thinking...';
+      messagesEl.appendChild(el);
+      scrollToBottom();
+    }
+    return;
+  }
+
+  if (data.type === 'error') {
+    addMessage(`Error: ${data.message || JSON.stringify(data)}`, 'system');
+    return;
+  }
+}
+
+function addMessage(text, role) {
+  const el = document.createElement('div');
+  el.className = `msg ${role}`;
+  el.textContent = text;
+  messagesEl.appendChild(el);
+  scrollToBottom();
+}
+
+function scrollToBottom() {
+  messagesEl.scrollTop = messagesEl.scrollHeight;
+}
+
+function sendMessage() {
+  const text = inputEl.value.trim();
+  if (!text || !ws || ws.readyState !== 1) return;
+
+  addMessage(text, 'user');
+  ws.send(JSON.stringify({
+    type: 'chat.send',
+    text: text,
+    sessionId: sessionId,
+  }));
+  inputEl.value = '';
+  inputEl.style.height = 'auto';
+  sendBtn.disabled = true;
+  setTimeout(() => { sendBtn.disabled = false; }, 1000);
+}
+
+// Auto-resize textarea
+inputEl.addEventListener('input', () => {
+  inputEl.style.height = 'auto';
+  inputEl.style.height = Math.min(inputEl.scrollHeight, 120) + 'px';
+});
+
+// Enter to send, Shift+Enter for newline
+inputEl.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter' && !e.shiftKey) {
+    e.preventDefault();
+    sendMessage();
+  }
+});
+
+connect();
+</script>
+</body>
+</html>

--- a/docs/custom-domain-webchat.md
+++ b/docs/custom-domain-webchat.md
@@ -1,0 +1,126 @@
+# Pointing a Custom Domain at an OpenClaw Webchat
+
+## What you need
+
+- A domain you own (e.g. `yourdomain.com`)
+- An OpenClaw gateway running with Tailscale Funnel enabled
+- Your Tailscale Funnel URL (looks like `https://<machine-name>.<tailnet>.ts.net`)
+
+## Option A: Cloudflare Proxy (Recommended)
+
+Cloudflare (free tier) handles TLS and proxies requests to your Tailscale Funnel address. The user sees your clean domain; the `.ts.net` address stays hidden.
+
+### 1. Add your domain to Cloudflare
+
+1. Sign up at https://dash.cloudflare.com (free)
+2. Click **Add a site** and enter your domain
+3. Cloudflare will scan your existing DNS records — review and keep them
+4. Cloudflare will give you two nameservers (e.g. `anna.ns.cloudflare.com`, `bob.ns.cloudflare.com`)
+
+### 2. Update nameservers at your registrar
+
+Go to your domain registrar (GoDaddy, Namecheap, Google Domains, Porkbun, etc.):
+
+1. Find **DNS** or **Nameserver** settings
+2. Switch from default nameservers to **Custom**
+3. Enter the two Cloudflare nameservers
+4. Save — propagation usually takes 10 minutes to 1 hour
+
+### 3. Add a CNAME record in Cloudflare
+
+In Cloudflare DNS settings, add a record:
+
+| Field | Value |
+|---|---|
+| Type | `CNAME` |
+| Name | `chat` (or `@` for root domain) |
+| Target | Your Tailscale Funnel hostname, e.g. `my-machine.tail1234.ts.net` |
+| Proxy status | **Proxied** (orange cloud ON) |
+
+### 4. Set SSL/TLS mode
+
+In Cloudflare: **SSL/TLS** → set encryption mode to **Full**.
+
+This tells Cloudflare to connect to your Tailscale Funnel over HTTPS (Tailscale provides a valid cert on its end).
+
+### 5. Update OpenClaw allowed origins
+
+Edit your OpenClaw config (`~/.openclaw/openclaw.json`) and add your new domain to the allowed origins:
+
+```json
+"controlUi": {
+  "enabled": true,
+  "allowedOrigins": [
+    "https://<your-tailscale-hostname>.ts.net",
+    "https://chat.yourdomain.com"
+  ]
+}
+```
+
+Then restart the gateway:
+
+```bash
+# macOS (launchd)
+launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
+
+# Linux (systemd)
+sudo systemctl restart openclaw-gateway
+
+# Or just kill and relaunch manually
+```
+
+### 6. Test it
+
+Visit `https://chat.yourdomain.com` — you should see the OpenClaw Control UI or your webchat page.
+
+---
+
+## Option B: Registrar Redirect (No Cloudflare)
+
+If you don't want to move DNS, most registrars support subdomain forwarding:
+
+1. Go to your registrar's DNS or Forwarding settings
+2. Add a subdomain forward:
+   - **Subdomain**: `chat`
+   - **Forward to**: `https://<your-tailscale-hostname>.ts.net/`
+   - **Type**: Temporary (302) or Permanent (301)
+
+This works but the URL bar will change to the `.ts.net` address after redirect.
+
+---
+
+## Option C: Static-hosted webchat with custom domain
+
+Host the webchat HTML on a static hosting service (GitHub Pages, Vercel, Netlify, Cloudflare Pages) and have it connect to your gateway over WebSocket.
+
+### 1. Deploy the webchat HTML
+
+Put `chat/index.html` in a GitHub repo, Vercel project, or similar. Set the `GATEWAY_URL` in the HTML to your Tailscale Funnel WebSocket address:
+
+```js
+const GATEWAY_URL = 'wss://<your-tailscale-hostname>.ts.net';
+```
+
+### 2. Set up the custom domain
+
+Follow your hosting provider's docs to point `chat.yourdomain.com` at the deployment:
+
+- **GitHub Pages**: Add a `CNAME` file containing `chat.yourdomain.com`, then add a CNAME DNS record pointing `chat` to `<username>.github.io`
+- **Vercel**: Add the domain in project settings, then add a CNAME DNS record pointing `chat` to `cname.vercel-dns.com`
+- **Netlify**: Add the domain in site settings, then add a CNAME DNS record
+
+### 3. Update OpenClaw allowed origins
+
+Same as Option A step 5 — add `https://chat.yourdomain.com` to `controlUi.allowedOrigins`.
+
+---
+
+## Troubleshooting
+
+| Problem | Fix |
+|---|---|
+| "unauthorized: gateway password missing" | Enter the gateway password in the Control UI settings panel, or pass it as `?p=yourpassword` in the URL |
+| "This device needs pairing approval" | On the gateway host, run `openclaw devices list` then `openclaw devices approve <requestId>` |
+| WebSocket connection fails | Check that Tailscale Funnel is enabled: `tailscale funnel status`. Ensure `gateway.tailscale.mode` is `"funnel"` in openclaw.json |
+| CORS / origin blocked | Add your domain to `controlUi.allowedOrigins` in openclaw.json and restart the gateway |
+| SSL errors with Cloudflare | Make sure SSL/TLS mode is set to **Full** (not Flexible or Full Strict) |


### PR DESCRIPTION
## Summary
- **bot/webchat/index.html**: WebSocket-based chat UI for the OpenClaw gateway (dark theme, auto-reconnect, status indicator)
- **docs/custom-domain-webchat.md**: Setup guide for pointing a custom domain at the gateway via Cloudflare proxy, registrar redirect, or static hosting

## Test plan
- [ ] Open `bot/webchat/index.html` locally and verify WebSocket connection to gateway
- [ ] Verify `!demo pharmgx` works through the webchat UI
- [ ] Review custom domain docs for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)