### PR TITLE
Add one-click Deploy to Railway support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.env
+output/
+__pycache__/
+*.pyc
+.pytest_cache/
+docs/
+slides/
+img/
+prs/
+compare/
+lab-orchestrator-workspace/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./requirements.txt
+COPY bot/requirements.txt ./bot-requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt -r bot-requirements.txt
+COPY . .
+CMD ["python3", "bot/roboterri.py"]

--- a/README.md
+++ b/README.md
@@ -289,6 +289,24 @@ python -m pytest
 
 ---
 
+## Deploy Your Own (One Click)
+
+Get your own ClawBio Telegram bot running in the cloud — no coding required.
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/TEMPLATE_ID)
+
+**You'll need:**
+1. A **Telegram bot token** — message [@BotFather](https://t.me/BotFather) on Telegram, send `/newbot`
+2. A **free LLM API key** — get one at [aistudio.google.com/apikey](https://aistudio.google.com/apikey)
+
+Railway will ask you to paste these during setup. That's it — your bot will be live in ~2 minutes.
+
+> **Privacy note:** When running on Railway, genetic data is processed on Railway's servers (not your machine). Data is not sent to external APIs, but it does exist on the Railway container temporarily. For maximum privacy, use the [local install](#quick-start) instead.
+
+> **Note:** The `TEMPLATE_ID` above is a placeholder. After deploying to Railway yourself, publish it as a template to get the real URL, then update this button.
+
+---
+
 ## Run via Telegram (RoboTerri)
 
 <p align="center">

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE"
+  },
+  "deploy": {
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,6 @@
+[build]
+builder = "dockerfile"
+
+[deploy]
+restartPolicyType = "on_failure"
+restartPolicyMaxRetries = 3


### PR DESCRIPTION
Dockerfile, railway.toml, railway.json, and .dockerignore for cloud deployment. README updated with deploy button and privacy note.

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

## Skill affected

<!-- Which skill does this change? e.g. pharmgx-reporter, equity-scorer, or "new skill: my-skill-name" -->

## Checklist

- [ ] SKILL.md is present and complete (YAML frontmatter + methodology)
- [ ] Tests included and passing (`pytest -v`)
- [ ] Demo data included for reviewers to test
- [ ] No patient/sensitive data committed
- [ ] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

<!-- Paste pytest output or describe how you tested -->
