### PR TITLE
Add skill-builder: scaffold new ClawBio skills from spec or interactively

### DIFF
--- a/clawbio.py
+++ b/clawbio.py
@@ -473,6 +473,14 @@ SKILLS = {
         },
         "accepts_genotypes": False,
     },
+    "skill-builder": {
+        "script": SKILLS_DIR / "skill-builder" / "skill_builder.py",
+        "demo_args": ["--demo"],
+        "description": "Skill builder — scaffold a new ClawBio skill from a spec or interactively",
+        "allowed_extra_flags": {"--dry-run", "--interactive", "--agent", "--edit", "--validate-only"},
+        "no_input_required": True,
+        "accepts_genotypes": False,
+    },
 }
 
 # Skills that run in the full-profile pipeline (order matters)

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "generated_by": "scripts/generate_catalog.py",
-  "skill_count": 28,
+  "skill_count": 29,
   "galaxy_tool_count": 8182,
   "skills": [
     {
@@ -681,6 +681,29 @@
       "dependencies": [],
       "tags": [],
       "trigger_keywords": [],
+      "chaining_partners": []
+    },
+    {
+      "name": "skill-builder",
+      "cli_alias": "skill-builder",
+      "description": "Scaffold a new ClawBio skill from a JSON/YAML spec or interactively — generates SKILL.md, Python skeleton, pytest tests, and auto-registers in catalog.json and clawbio.py",
+      "version": "0.1.0",
+      "status": "mvp",
+      "has_script": true,
+      "has_tests": true,
+      "has_demo": true,
+      "demo_command": "python clawbio.py run skill-builder --demo",
+      "dependencies": [],
+      "tags": ["scaffold", "developer-tools", "meta", "cli"],
+      "trigger_keywords": [
+        "create a new skill",
+        "scaffold a skill",
+        "add a skill",
+        "new clawbio skill",
+        "build a skill",
+        "skill template",
+        "skill builder"
+      ],
       "chaining_partners": []
     }
   ]

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: skill-builder
+description: Scaffold a new ClawBio skill from a spec file (JSON/YAML) or interactively — generates SKILL.md, Python skeleton, tests, and updates catalog.json
+version: 0.1.0
+author: Mj
+license: MIT
+tags: [meta, scaffolding, developer-tools, skill-creation]
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - python3
+      env: []
+      config: []
+    always: false
+    emoji: "🦖"
+    homepage: https://github.com/ClawBio/ClawBio
+    os: [macos, linux, windows]
+    install: []
+    trigger_keywords:
+      - create skill
+      - new skill
+      - scaffold skill
+      - skill template
+      - skill builder
+      - add a skill
+      - build a skill
+      - make a skill
+---
+
+# 🦖 Skill Builder
+
+You are **Skill Builder**, a specialised ClawBio meta-skill for scaffolding new skills. Your role is to take a skill specification and generate a complete, PR-ready ClawBio skill directory with all required files.
+
+## Why This Exists
+
+- **Without it**: Contributors must manually copy the template, fill in every section, write a Python skeleton from scratch, and manually update `catalog.json` and `clawbio.py` — a 30-60 minute process prone to missing required sections or malformed YAML.
+- **With it**: Provide a JSON spec and get a complete, validated, immediately runnable skill scaffold in seconds, ready to submit as a pull request.
+- **Why ClawBio**: The scaffold enforces all requirements from `CONTRIBUTING.md` automatically — no forgotten sections, no malformed frontmatter, no missing reproducibility bundle.
+
+## Core Capabilities
+
+1. **Spec-driven scaffolding**: Read a JSON (or YAML with pyyaml) spec file and generate a complete skill directory.
+2. **Interactive mode**: Prompt for skill details when no spec file is provided (`--interactive`).
+3. **Validation**: Check any existing `SKILL.md` against the CONTRIBUTING.md checklist (`--validate-only`).
+4. **Auto-registration**: Update `skills/catalog.json` and patch `clawbio.py`'s `SKILLS` dict when run from inside the ClawBio repo.
+5. **Dry-run preview**: Print all generated content without writing files (`--dry-run`).
+
+## Input Formats
+
+| Format | Extension | Required Fields | Example |
+|--------|-----------|-----------------|---------|
+| JSON spec | `.json` | name, description, author | `spec.json` |
+| YAML spec | `.yaml` / `.yml` | name, description, author | `spec.yaml` (requires pyyaml) |
+| Existing SKILL.md | `.md` | Any SKILL.md | Used with `--validate-only` |
+
+## Workflow
+
+When the user asks to create a new skill:
+
+1. **Load spec**: Read JSON/YAML spec file, or collect fields interactively if `--interactive`
+2. **Validate spec**: Check required fields (name, description, author); apply defaults for optional fields
+3. **Generate files**: Create `SKILL.md`, `<name>.py`, `tests/test_<name>.py`, `examples/example_spec.json`
+4. **Update registry**: If repo root found, append entry to `catalog.json` and patch `SKILLS` dict in `clawbio.py`
+5. **Report**: Print a summary of generated files and next steps
+
+## CLI Reference
+
+```bash
+# Spec-driven (recommended for agents)
+python skills/skill-builder/skill_builder.py --input spec.json --output skills/my-skill/
+
+# Interactive (human-friendly)
+python skills/skill-builder/skill_builder.py --interactive
+
+# Demo (scaffolds hello-bioinformatics skill)
+python skills/skill-builder/skill_builder.py --demo --output /tmp/skill_builder_demo
+
+# Validate an existing SKILL.md
+python skills/skill-builder/skill_builder.py --validate-only --input skills/my-skill/SKILL.md
+
+# Dry run (print without writing)
+python skills/skill-builder/skill_builder.py --input spec.json --dry-run
+
+# Via ClawBio runner
+python clawbio.py run skill-builder --demo
+python clawbio.py run skill-builder --input spec.json
+```
+
+## Demo
+
+```bash
+python clawbio.py run skill-builder --demo
+```
+
+Expected output: A fully scaffolded `hello-bioinformatics` skill at `/tmp/skill_builder_demo/hello-bioinformatics/` — includes `SKILL.md`, `hello_bioinformatics.py`, `tests/test_hello_bioinformatics.py`, and a `result.json` + `report.md` in the skill-builder output directory documenting what was created.
+
+## Spec File Reference
+
+Minimal spec (JSON):
+```json
+{
+  "name": "my-skill",
+  "description": "What this skill does",
+  "author": "Your Name"
+}
+```
+
+Full spec with all optional fields:
+```json
+{
+  "name": "my-skill",
+  "description": "One-line description of what this skill does",
+  "author": "Your Name",
+  "domain": "genomics",
+  "capabilities": ["Capability 1", "Capability 2"],
+  "trigger_keywords": ["keyword1", "another phrase"],
+  "tags": ["tag1", "tag2"],
+  "dependencies": {
+    "required": ["package >= 1.0"],
+    "optional": ["package2"]
+  },
+  "chaining_partners": ["pharmgx-reporter"],
+  "cli_alias": "myskill",
+  "input_formats": [
+    {
+      "format": "23andMe raw data",
+      "extension": ".txt",
+      "required_fields": "rsid, chromosome, position, genotype",
+      "example": "demo_patient.txt"
+    }
+  ]
+}
+```
+
+## Algorithm / Methodology
+
+1. **Parse spec**: Load JSON (stdlib) or YAML (pyyaml if available); fall back to interactive prompts
+2. **Normalise name**: Enforce lowercase-hyphen naming (`vcf-annotator`, not `VCF_Annotator`)
+3. **Fill defaults**: domain → "bioinformatics", version → "0.1.0", capabilities/triggers → generic placeholders
+4. **Render SKILL.md**: Fill YAML frontmatter + all 13 required body sections from template
+5. **Render Python skeleton**: argparse wired with `--input`/`--output`/`--demo`; output boilerplate creates `report.md`, `result.json`, reproducibility bundle
+6. **Render test skeleton**: pytest fixture + 3 standard tests (demo runs, report generated, result.json valid)
+7. **Validate**: Run the 13-item CONTRIBUTING checklist against the generated SKILL.md before writing
+8. **Register**: Append catalog entry; patch `clawbio.py` SKILLS dict via targeted string replacement
+
+## Example Queries
+
+- "Create a new skill called vcf-annotator that annotates VCF files with ClinVar"
+- "Scaffold a skill for running PLINK GWAS pipelines"
+- "Build a skill template for GO enrichment analysis"
+- "Validate my SKILL.md before I submit a PR"
+
+## Output Structure
+
+```
+output_directory/
+├── report.md                   # Summary of what was generated
+├── result.json                 # Machine-readable scaffold manifest
+└── reproducibility/
+    └── commands.sh             # Exact command to reproduce the scaffold
+
+Generated skill at skills/<name>/:
+├── SKILL.md                    # Complete skill definition
+├── <name>.py                   # Python skeleton with --input/--output/--demo
+├── tests/
+│   └── test_<name>.py          # pytest skeleton with 3 standard tests
+└── examples/
+    └── example_spec.json       # The spec that generated this skill
+```
+
+## Dependencies
+
+**Required** (stdlib only — zero install):
+- Python 3.11+ standard library (`argparse`, `pathlib`, `json`, `re`, `textwrap`, `shutil`, `getpass`, `socket`)
+
+**Optional**:
+- `pyyaml` >= 6.0 — enables YAML spec files in addition to JSON; graceful fallback to JSON-only mode if absent
+
+## Safety
+
+- **Local-first**: No network calls; all generation is offline
+- **Non-destructive**: Never overwrites existing files without `--force`; prompts or errors if destination exists
+- **No hallucinated science**: All generated SKILL.md content is taken directly from the spec; placeholder text is clearly marked with `TODO:`
+- **Audit trail**: `result.json` and `commands.sh` record exactly what was generated and when
+
+## Integration with Bio Orchestrator
+
+**Trigger conditions** — the orchestrator routes here when:
+- User says "create a skill", "scaffold a skill", "new skill", "build a skill", "add a skill"
+- User provides a JSON/YAML file with `name`, `description`, `author` fields and asks to build a skill
+
+**Chaining partners**:
+- `bio-orchestrator`: Skill builder output feeds back into the orchestrator once registered
+
+## Citations
+
+- [CONTRIBUTING.md](https://github.com/ClawBio/ClawBio/blob/main/CONTRIBUTING.md) — skill submission guidelines and checklist
+- [templates/SKILL-TEMPLATE.md](https://github.com/ClawBio/ClawBio/blob/main/templates/SKILL-TEMPLATE.md) — canonical SKILL.md template

--- a/skills/skill-builder/demo_spec.json
+++ b/skills/skill-builder/demo_spec.json
@@ -1,0 +1,36 @@
+{
+  "name": "hello-bioinformatics",
+  "description": "A minimal demo skill that greets a list of sample IDs and produces a formatted report — used to verify the Skill Builder pipeline end-to-end",
+  "author": "ClawBio Skill Builder (auto-generated demo)",
+  "version": "0.1.0",
+  "license": "MIT",
+  "domain": "bioinformatics",
+  "emoji": "👋",
+  "cli_alias": "hello-bio",
+  "tags": ["demo", "tutorial", "scaffold"],
+  "trigger_keywords": [
+    "hello bioinformatics",
+    "demo skill",
+    "test scaffold",
+    "skill builder demo"
+  ],
+  "capabilities": [
+    "Accept a list of sample IDs from a plain-text file (one per line)",
+    "Produce a formatted markdown report greeting each sample",
+    "Write a machine-readable result.json with sample count and IDs",
+    "Provide a full reproducibility bundle (commands.sh + environment.yml)"
+  ],
+  "input_formats": [
+    {
+      "format": "Plain text — sample list",
+      "extension": ".txt",
+      "required_fields": "one sample ID per line (lines starting with # are comments)",
+      "example": "demo_input.txt"
+    }
+  ],
+  "dependencies": {
+    "required": [],
+    "optional": []
+  },
+  "chaining_partners": ["skill-builder"]
+}

--- a/skills/skill-builder/skill_builder.py
+++ b/skills/skill-builder/skill_builder.py
@@ -1,0 +1,1758 @@
+#!/usr/bin/env python3
+"""
+skill_builder.py — ClawBio Skill Builder
+=========================================
+Scaffold a new ClawBio skill from a spec file (JSON/YAML) or interactively.
+
+Usage:
+    # Spec-driven (JSON — no extra deps)
+    python skill_builder.py --input spec.json
+
+    # Spec-driven (YAML — requires pyyaml)
+    python skill_builder.py --input spec.yaml
+
+    # Interactive mode
+    python skill_builder.py --interactive
+
+    # Demo (scaffolds hello-bioinformatics)
+    python skill_builder.py --demo --output /tmp/skill_builder_demo
+
+    # Validate an existing SKILL.md
+    python skill_builder.py --validate-only --input skills/my-skill/SKILL.md
+
+    # Dry run — print without writing
+    python skill_builder.py --input spec.json --dry-run
+
+    # Via ClawBio runner
+    python clawbio.py run skill-builder --demo
+    python clawbio.py run skill-builder --input spec.json
+
+    # Agent / LLM pipeline — JSON manifest to stdout, no interactive prompts
+    python skill_builder.py --agent --input spec.json
+    python skill_builder.py --agent --input spec.json --dry-run
+    echo '{"name":"foo",...}' | python skill_builder.py --agent --input -
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import textwrap
+from datetime import datetime
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+VERSION = "0.1.0"
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEMO_SPEC_PATH = SCRIPT_DIR / "demo_spec.json"
+
+# Sentinel file that marks the ClawBio repo root
+REPO_SENTINEL = "clawbio.py"
+
+# Sections required in every SKILL.md body (from CONTRIBUTING.md checklist)
+REQUIRED_SECTIONS = [
+    ("YAML frontmatter",             r"^---"),
+    ("trigger_keywords",             r"trigger_keywords"),
+    ("Why This Exists",              r"##\s+Why This Exists"),
+    ("Core Capabilities",            r"##\s+Core Capabilities"),
+    ("Input Formats",                r"##\s+Input Formats"),
+    ("Workflow",                     r"##\s+Workflow"),
+    ("CLI Reference",                r"##\s+CLI Reference"),
+    ("Demo section",                 r"##\s+Demo"),
+    ("Output Structure",             r"##\s+Output Structure"),
+    ("Dependencies",                 r"##\s+Dependencies"),
+    ("Safety",                       r"##\s+Safety"),
+    ("Integration with Bio Orchestrator", r"##\s+Integration with Bio Orchestrator"),
+    ("Citations",                    r"##\s+Citations"),
+]
+
+# ---------------------------------------------------------------------------
+# ANSI colours
+# ---------------------------------------------------------------------------
+
+def _use_color() -> bool:
+    return sys.stdout.isatty() and os.environ.get("NO_COLOR") is None
+
+
+_C = _use_color()
+BOLD  = "\033[1m"  if _C else ""
+DIM   = "\033[2m"  if _C else ""
+GREEN = "\033[32m" if _C else ""
+RED   = "\033[31m" if _C else ""
+CYAN  = "\033[36m" if _C else ""
+RESET = "\033[0m"  if _C else ""
+
+# ---------------------------------------------------------------------------
+# Draft management (auto-save between interactive sessions)
+# ---------------------------------------------------------------------------
+
+DRAFT_SPEC_PATH = Path.home() / ".clawbio_skill_builder_draft.json"
+
+
+class _Jump(Exception):
+    """Raised inside _ask()/_ask_list() when the user wants to navigate."""
+    def __init__(self, target: int) -> None:
+        self.target = target   # 0-based field index to jump to
+
+
+def _save_draft(spec: dict) -> None:
+    try:
+        DRAFT_SPEC_PATH.write_text(json.dumps(spec, indent=2), encoding="utf-8")
+    except OSError:
+        pass  # non-fatal
+
+
+def _load_draft() -> dict | None:
+    if not DRAFT_SPEC_PATH.exists():
+        return None
+    try:
+        return json.loads(DRAFT_SPEC_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _clear_draft() -> None:
+    try:
+        DRAFT_SPEC_PATH.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Spec loading
+# ---------------------------------------------------------------------------
+
+def _try_load_yaml(path: Path) -> dict:
+    """Attempt to parse a YAML file; falls back gracefully if pyyaml absent."""
+    try:
+        import yaml  # type: ignore
+        with path.open() as fh:
+            return yaml.safe_load(fh) or {}
+    except ImportError:
+        print(
+            f"{RED}pyyaml is not installed. Install it with `pip install pyyaml` "
+            f"or convert your spec to JSON.{RESET}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def load_spec(path: Path) -> dict:
+    """Load and return a skill spec from a JSON or YAML file."""
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            print(f"{RED}Invalid JSON in {path}: {exc}{RESET}", file=sys.stderr)
+            sys.exit(1)
+    elif suffix in (".yaml", ".yml"):
+        return _try_load_yaml(path)
+    else:
+        # Sniff content
+        text = path.read_text(encoding="utf-8").lstrip()
+        if text.startswith("{"):
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError:
+                pass
+        return _try_load_yaml(path)
+
+
+# ---------------------------------------------------------------------------
+# Module-level interactive helpers
+# ---------------------------------------------------------------------------
+
+# Ordered field definitions: (key, label, kind, default, help_text)
+# kind: "str" | "str_required" | "list" | "deps" | "partners"
+_FIELDS: list[tuple[str, str, str, str, str]] = [
+    (
+        "name",
+        "Skill name (lowercase-hyphen)",
+        "str_required",
+        "",
+        "Unique identifier for the skill.\n"
+        "  Affects: directory name (skills/<name>/), Python script (<name>.py),\n"
+        "           test file (test_<name>.py), and the key in catalog.json.",
+    ),
+    (
+        "description",
+        "One-line description",
+        "str_required",
+        "",
+        "One-sentence summary of what this skill does.\n"
+        "  Affects: SKILL.md YAML frontmatter 'description:', the opening paragraph\n"
+        "           of SKILL.md, and the catalog.json description field.",
+    ),
+    (
+        "author",
+        "Your name or handle",
+        "str_required",
+        "",
+        "Credit for the skill author.\n"
+        "  Affects: SKILL.md YAML frontmatter 'author:' and the Python script header.",
+    ),
+    (
+        "domain",
+        "Scientific domain (e.g. genomics, metagenomics)",
+        "str",
+        "bioinformatics",
+        "The scientific domain this skill belongs to.\n"
+        "  Affects: SKILL.md preamble — 'specialised ClawBio agent for <domain>'.",
+    ),
+    (
+        "cli_alias",
+        "CLI alias for clawbio.py run <alias>",
+        "str",
+        "",
+        "Short command name users type to invoke the skill.\n"
+        "  Affects: the key in the clawbio.py SKILLS dict and catalog.json\n"
+        "           demo_command field (python clawbio.py run <alias>).\n"
+        "  Defaults to the first hyphen-segment of the skill name.",
+    ),
+    (
+        "capabilities",
+        "Core capabilities",
+        "list",
+        "",
+        "What this skill can do — one capability per line.\n"
+        "  Affects: SKILL.md '## Core Capabilities' section (one numbered bullet\n"
+        "           per entry).",
+    ),
+    (
+        "trigger_keywords",
+        "Trigger keywords (phrases that route here)",
+        "list",
+        "",
+        "Phrases the ClawBio router matches to dispatch to this skill.\n"
+        "  Affects: SKILL.md YAML frontmatter 'trigger_keywords:' and the\n"
+        "           catalog.json trigger_keywords field.",
+    ),
+    (
+        "tags",
+        "Tags (optional, e.g. alignment, QC)",
+        "list",
+        "",
+        "Short discoverability labels for the skill.\n"
+        "  Affects: SKILL.md YAML frontmatter 'tags:' and the catalog.json\n"
+        "           tags field.",
+    ),
+    (
+        "_deps_raw",
+        "Required pip dependencies (comma-separated, e.g. pysam>=0.22, biopython)",
+        "str",
+        "",
+        "Python packages this skill needs at runtime.\n"
+        "  Affects: SKILL.md YAML 'metadata.openclaw.install:', the\n"
+        "           '## Dependencies' section, and import hints in the Python script.",
+    ),
+    (
+        "chaining_partners",
+        "Chaining partners (comma-separated skill names, e.g. fastqc, multiqc)",
+        "str",
+        "",
+        "Other ClawBio skills this one is commonly used alongside.\n"
+        "  Affects: SKILL.md '## Integration with Bio Orchestrator' section\n"
+        "           and the catalog.json chaining_partners field.",
+    ),
+]
+_NUM_FIELDS = len(_FIELDS)
+
+
+def _find_resume_cursor(spec: dict) -> int:
+    """Return the 0-based index of the first unfilled required-ish field."""
+    for i, (key, _label, kind, _default, _help) in enumerate(_FIELDS):
+        if kind == "str_required" and not spec.get(key, ""):
+            return i
+        if kind == "list" and not spec.get(key):
+            return i
+    return _NUM_FIELDS  # all filled; go straight to review
+
+
+def _ask(prompt: str, default: str = "", required: bool = False,
+         field_num: int = 0) -> str:
+    """Prompt for a single string value; support !back / !N navigation."""
+    hint = f"  {DIM}(Field {field_num}/{_NUM_FIELDS}  — !back to go back, !N to jump){RESET}"
+    while True:
+        print(hint)
+        display = f"{prompt} [{default}]: " if default else f"{prompt}: "
+        value = input(display).strip()
+
+        # Navigation commands
+        if value.startswith("!"):
+            cmd = value[1:].lower()
+            if cmd == "back":
+                raise _Jump(max(0, field_num - 2))   # field_num is 1-based, index is 0-based
+            try:
+                target = int(cmd)
+                if 1 <= target <= _NUM_FIELDS:
+                    raise _Jump(target - 1)
+                print(f"  {RED}Jump target must be 1–{_NUM_FIELDS}.{RESET}")
+            except ValueError:
+                print(f"  {RED}Unknown command '{value}'. Use !back or !N (1–{_NUM_FIELDS}).{RESET}")
+            continue
+
+        if not value:
+            value = default
+        if required and not value:
+            print(f"  {RED}This field is required.{RESET}")
+            continue
+        return value
+
+
+def _ask_list(prompt: str, field_num: int = 0) -> list[str]:
+    """Prompt for a list of strings; support !back / !N navigation."""
+    hint = f"  {DIM}(Field {field_num}/{_NUM_FIELDS}  — !back to go back, !N to jump){RESET}"
+    print(f"{hint}")
+    print(f"{prompt} (one per line, blank line to finish):")
+    items: list[str] = []
+    while True:
+        line = input("  > ").strip()
+        if not line:
+            break
+        if line.startswith("!"):
+            cmd = line[1:].lower()
+            if items:
+                print(f"  {RED}Partial input discarded — previous value kept.{RESET}")
+            if cmd == "back":
+                raise _Jump(max(0, field_num - 2))
+            try:
+                target = int(cmd)
+                if 1 <= target <= _NUM_FIELDS:
+                    raise _Jump(target - 1)
+                print(f"  {RED}Jump target must be 1–{_NUM_FIELDS}.{RESET}")
+            except ValueError:
+                print(f"  {RED}Unknown command '{line}'. Use !back or !N (1–{_NUM_FIELDS}).{RESET}")
+            continue
+        items.append(line)
+    return items
+
+
+def _fmt_list(items: list[str]) -> str:
+    if not items:
+        return f"{DIM}(none){RESET}"
+    return "\n".join(f"      • {item}" for item in items)
+
+
+def _print_review(s: dict) -> None:
+    deps_req = s.get("dependencies", {}).get("required", [])
+    print(f"\n{CYAN}{'─' * 56}{RESET}")
+    print(f"{BOLD}  Review your spec{RESET}")
+    print(f"{CYAN}{'─' * 56}{RESET}")
+    print(f"  {BOLD}[1] name{RESET}             {s.get('name','')}")
+    print(f"  {BOLD}[2] description{RESET}      {s.get('description','')}")
+    print(f"  {BOLD}[3] author{RESET}           {s.get('author','')}")
+    print(f"  {BOLD}[4] domain{RESET}           {s.get('domain','')}")
+    print(f"  {BOLD}[5] cli_alias{RESET}        {s.get('cli_alias','')}")
+    print(f"  {BOLD}[6] capabilities{RESET}")
+    print(_fmt_list(s.get("capabilities", [])))
+    print(f"  {BOLD}[7] trigger_keywords{RESET}")
+    print(_fmt_list(s.get("trigger_keywords", [])))
+    print(f"  {BOLD}[8] tags{RESET}")
+    print(_fmt_list(s.get("tags", [])))
+    print(f"  {BOLD}[9] dependencies{RESET}     {', '.join(deps_req) if deps_req else '(none)'}")
+    print(f"  {BOLD}[10] chaining_partners{RESET} {', '.join(s.get('chaining_partners', [])) or '(none)'}")
+    print(f"{CYAN}{'─' * 56}{RESET}")
+
+
+def _prompt_field(s: dict, idx: int) -> dict:
+    """Re-prompt field at 0-based index *idx* and update spec in-place."""
+    key, label, kind, default, help_text = _FIELDS[idx]
+    field_num = idx + 1
+
+    if help_text:
+        print(f"\n  {DIM}{help_text}{RESET}\n")
+
+    if kind in ("str", "str_required"):
+        current = s.get(key, default or "")
+        # A stored list (e.g. chaining_partners already set) must be joined back to a
+        # comma-separated string so that _ask() receives a str default, not a list.
+        if isinstance(current, list):
+            current = ", ".join(current)
+        new_val = _ask(label, default=current, required=(kind == "str_required"),
+                       field_num=field_num)
+        if key == "_deps_raw":
+            s["dependencies"] = {
+                "required": [d.strip() for d in new_val.split(",") if d.strip()],
+                "optional": s.get("dependencies", {}).get("optional", []),
+            }
+        elif key == "chaining_partners":
+            s["chaining_partners"] = [p.strip() for p in new_val.split(",") if p.strip()]
+        else:
+            s[key] = new_val
+    elif kind == "list":
+        new_val = _ask_list(label, field_num=field_num)
+        s[key] = new_val
+    elif kind == "deps":
+        current = ", ".join(s.get("dependencies", {}).get("required", []))
+        raw = _ask(label, default=current, field_num=field_num)
+        s["dependencies"] = {
+            "required": [d.strip() for d in raw.split(",") if d.strip()],
+            "optional": s.get("dependencies", {}).get("optional", []),
+        }
+    elif kind == "partners":
+        current = ", ".join(s.get("chaining_partners", []))
+        raw = _ask(label, default=current, field_num=field_num)
+        s["chaining_partners"] = [p.strip() for p in raw.split(",") if p.strip()]
+
+    # Keep cli_alias default in sync if name changed
+    if key == "name" and not s.get("cli_alias"):
+        s["cli_alias"] = re.sub(r"[^a-z0-9]", "", s["name"].lower())
+
+    return s
+
+
+def _run_review_loop(spec: dict) -> dict:
+    """
+    Show review, let user confirm / edit individual fields / abort.
+    Returns the final confirmed spec.
+    Jumping to a field from within the review edit re-opens that field and
+    returns to review afterward (nested jumps are suppressed).
+    """
+    while True:
+        _print_review(spec)
+        print(f"\n  {BOLD}Proceed?{RESET}  Y = yes   n = abort   1-10 = edit a field")
+        choice = input("  > ").strip().lower()
+
+        if choice in ("", "y", "yes"):
+            break
+        elif choice in ("n", "no", "abort"):
+            print(f"\n{RED}Aborted — no files written.{RESET}")
+            _clear_draft()
+            sys.exit(0)
+        elif choice in {str(i) for i in range(1, _NUM_FIELDS + 1)}:
+            idx = int(choice) - 1
+            try:
+                spec = _prompt_field(spec, idx)
+            except _Jump as j:
+                # User typed !N inside an edit — honour the jump
+                try:
+                    spec = _prompt_field(spec, j.target)
+                except _Jump:
+                    pass  # suppress nested jumps; return to review
+        else:
+            print(f"  {DIM}Enter Y, n, or a field number (1-{_NUM_FIELDS}).{RESET}")
+
+    print()
+    return spec
+
+
+# ---------------------------------------------------------------------------
+# Interactive spec collection
+# ---------------------------------------------------------------------------
+
+def collect_spec_interactive() -> dict:
+    """Collect skill spec interactively via stdin prompts, with draft resume and review/edit loop."""
+    print(f"\n{CYAN}{BOLD}ClawBio Skill Builder — Interactive Mode{RESET}")
+    print(f"{DIM}Press Enter to accept defaults shown in [brackets].{RESET}")
+    print(f"{DIM}Type !back to go back one field, !N to jump to field N.{RESET}")
+    print(f"{DIM}Progress is auto-saved after each field to: {DRAFT_SPEC_PATH}{RESET}\n")
+
+    # ----------------------------------------------------------------
+    # Draft resume
+    # ----------------------------------------------------------------
+    spec: dict = {}
+    start_cursor = 0
+    draft = _load_draft()
+    if draft:
+        print(f"{CYAN}A saved draft was found: {DRAFT_SPEC_PATH}{RESET}")
+        resume_choice = input("  Resume? [Y/n]: ").strip().lower()
+        if resume_choice in ("", "y", "yes"):
+            spec = draft
+            start_cursor = _find_resume_cursor(spec)
+            print(f"  {DIM}Resuming from field {start_cursor + 1}.{RESET}\n")
+        else:
+            _clear_draft()
+            print(f"  {DIM}Starting fresh.{RESET}\n")
+
+    # ----------------------------------------------------------------
+    # Cursor-based collection loop
+    # ----------------------------------------------------------------
+    cursor = start_cursor
+    while cursor < _NUM_FIELDS:
+        try:
+            spec = _prompt_field(spec, cursor)
+            _save_draft(spec)
+            cursor += 1
+        except _Jump as j:
+            cursor = j.target
+
+    # ----------------------------------------------------------------
+    # Review / edit / confirm loop
+    # ----------------------------------------------------------------
+    spec = _run_review_loop(spec)
+    return spec
+
+
+# ---------------------------------------------------------------------------
+# Spec validation
+# ---------------------------------------------------------------------------
+
+_VALID_NAME_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+
+
+def validate_spec(spec: dict) -> list[str]:
+    """Return a list of error strings (empty = valid)."""
+    errors: list[str] = []
+
+    if not spec.get("name"):
+        errors.append("'name' is required")
+    elif not _VALID_NAME_RE.match(spec["name"]):
+        errors.append(
+            f"'name' must be lowercase letters, digits, and hyphens — got '{spec['name']}'"
+        )
+
+    if not spec.get("description"):
+        errors.append("'description' is required")
+
+    if not spec.get("author"):
+        errors.append("'author' is required")
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# SKILL.md generation
+# ---------------------------------------------------------------------------
+
+def _yaml_list(items: list[str], indent: int = 6) -> str:
+    """Render a YAML block list with given indent."""
+    pad = " " * indent
+    return "\n".join(f"{pad}- {item}" for item in items) if items else f"{' ' * indent}[]"
+
+
+def _md_input_table(formats: list) -> str:
+    """Render the Input Formats markdown table.
+
+    Accepts either a list of dicts (full metadata) or a list of strings
+    (bare format names / extensions).
+    """
+    if not formats:
+        formats = [
+            {
+                "format": "TODO: format name",
+                "extension": ".ext",
+                "required_fields": "field1, field2",
+                "example": "demo_input.ext",
+            }
+        ]
+    # Normalise: strings → minimal dicts
+    normalised = []
+    for f in formats:
+        if isinstance(f, str):
+            ext = f if f.startswith(".") else f"*.{f}"
+            normalised.append({
+                "format": f.upper(),
+                "extension": ext,
+                "required_fields": "—",
+                "example": f"demo_input.{f.lstrip('.')}",
+            })
+        else:
+            normalised.append(f)
+    header = "| Format | Extension | Required Fields | Example |\n|--------|-----------|-----------------|---------|"
+    rows = "\n".join(
+        f"| {f.get('format','TODO')} | `{f.get('extension','.ext')}` "
+        f"| {f.get('required_fields','TODO')} | `{f.get('example','demo')}` |"
+        for f in normalised
+    )
+    return f"{header}\n{rows}"
+
+
+def _md_chaining(partners: list[str]) -> str:
+    if not partners:
+        return "- *(none yet — add partners as you build)*"
+    return "\n".join(f"- `{p}`: TODO — describe how they connect" for p in partners)
+
+
+def _md_deps(deps: dict) -> str:
+    req = deps.get("required", [])
+    opt = deps.get("optional", [])
+    out = "**Required** (in `requirements.txt` or skill-level install):\n"
+    if req:
+        out += "\n".join(f"- `{d}` — TODO: purpose" for d in req)
+    else:
+        out += "- Python 3.11+ standard library only — no external packages"
+    if opt:
+        out += "\n\n**Optional**:\n"
+        out += "\n".join(f"- `{d}` — TODO: purpose (graceful degradation without it)" for d in opt)
+    return out
+
+
+def _yaml_inline_list(items: list[str]) -> str:
+    if not items:
+        return "[]"
+    return "[" + ", ".join(items) + "]"
+
+
+def generate_skill_md(spec: dict) -> str:
+    """Generate a complete SKILL.md from a skill spec dict."""
+    name         = spec["name"]
+    description  = spec["description"]
+    author       = spec.get("author", "TODO")
+    version      = spec.get("version", "0.1.0")
+    domain       = spec.get("domain", "bioinformatics")
+    emoji        = spec.get("emoji", "🦖")
+    tags         = spec.get("tags", [])
+    trigger_kws  = spec.get("trigger_keywords", [f"TODO: keyword for {name}"])
+    capabilities = spec.get("capabilities", ["TODO: describe capability 1", "TODO: describe capability 2"])
+    formats      = spec.get("input_formats", [])
+    deps         = spec.get("dependencies", {"required": [], "optional": []})
+    partners     = spec.get("chaining_partners", [])
+    license_     = spec.get("license", "MIT")
+    cli_alias    = spec.get("cli_alias", name.split("-")[0])
+    script_name  = name.replace("-", "_")
+    title        = " ".join(w.capitalize() for w in name.split("-"))
+
+    caps_md = "\n".join(
+        f"{i+1}. **Capability {i+1}**: {cap}" for i, cap in enumerate(capabilities)
+    )
+
+    install_section: str
+    req_pkgs = deps.get("required", [])
+    if req_pkgs:
+        install_lines = "\n".join(
+            f"      - kind: pip\n        package: {p.split()[0]}\n        bins: []"
+            for p in req_pkgs
+        )
+        install_section = f"    install:\n{install_lines}"
+    else:
+        install_section = "    install: []"
+
+    return f"""\
+---
+name: {name}
+description: >-
+  {description}
+version: {version}
+author: {author}
+license: {license_}
+tags: {_yaml_inline_list(tags)}
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - python3
+      env: []
+      config: []
+    always: false
+    emoji: "{emoji}"
+    homepage: https://github.com/ClawBio/ClawBio
+    os: [macos, linux]
+{install_section}
+    trigger_keywords:
+{_yaml_list(trigger_kws, indent=8)}
+---
+
+# {emoji} {title}
+
+You are **{title}**, a specialised ClawBio agent for {domain}. Your role is to {description.rstrip('.')}.
+
+## Why This Exists
+
+- **Without it**: Users must TODO: describe the manual process this replaces.
+- **With it**: TODO: describe the automated outcome in seconds/minutes.
+- **Why ClawBio**: TODO: explain what makes this better than an LLM guessing — grounded in real databases/algorithms.
+
+## Core Capabilities
+
+{caps_md}
+
+## Input Formats
+
+{_md_input_table(formats)}
+
+## Workflow
+
+When the user asks for TODO: describe the task type:
+
+1. **Validate**: Check input format and required fields
+2. **Process**: TODO: core computation — be specific about algorithm/database used
+3. **Generate**: TODO: output generation — what gets written where
+4. **Report**: Write `report.md` with findings and reproducibility bundle
+
+## CLI Reference
+
+```bash
+# Standard usage
+python skills/{name}/{script_name}.py \\
+  --input <input_file> --output <report_dir>
+
+# Demo mode (synthetic data, no user files needed)
+python skills/{name}/{script_name}.py --demo --output /tmp/{name}_demo
+
+# Via ClawBio runner
+python clawbio.py run {cli_alias} --input <file> --output <dir>
+python clawbio.py run {cli_alias} --demo
+```
+
+## Demo
+
+```bash
+python clawbio.py run {cli_alias} --demo
+```
+
+Expected output: TODO: brief description of what the demo produces.
+
+## Algorithm / Methodology
+
+Describe the core methodology so an AI agent can apply it even without the Python script:
+
+1. **Step**: TODO: detail
+2. **Step**: TODO: detail
+3. **Step**: TODO: detail
+
+**Key thresholds / parameters**:
+- TODO: Parameter 1: value (source: database/paper)
+
+## Example Queries
+
+- "TODO: example query 1 that would route here"
+- "TODO: example query 2"
+
+## Output Structure
+
+```
+output_directory/
+├── report.md              # Primary markdown report
+├── result.json            # Machine-readable results
+├── figures/
+│   └── plot.png           # Visualisation(s)
+├── tables/
+│   └── results.csv        # Tabular data
+└── reproducibility/
+    ├── commands.sh        # Exact commands to reproduce
+    └── environment.yml    # Conda/pip environment snapshot
+```
+
+## Dependencies
+
+{_md_deps(deps)}
+
+## Safety
+
+- **Local-first**: No data upload without explicit consent
+- **Disclaimer**: Every report includes the ClawBio medical disclaimer
+- **Audit trail**: Log all operations to reproducibility bundle
+- **No hallucinated science**: All parameters trace to cited databases
+
+## Integration with Bio Orchestrator
+
+**Trigger conditions** — the orchestrator routes here when:
+{chr(10).join(f"- {kw}" for kw in trigger_kws[:3])}
+
+**Chaining partners** — this skill connects with:
+{_md_chaining(partners)}
+
+## Citations
+
+- TODO: [Database/Paper 1](URL) — what it provides
+- TODO: [Database/Paper 2](URL) — what it provides
+"""
+
+
+# ---------------------------------------------------------------------------
+# Python skeleton generation
+# ---------------------------------------------------------------------------
+
+def generate_skill_py(spec: dict) -> str:
+    """Generate a Python skeleton for the skill."""
+    name        = spec["name"]
+    description = spec["description"]
+    author      = spec.get("author", "TODO")
+    script_name = name.replace("-", "_")
+    title       = " ".join(w.capitalize() for w in name.split("-"))
+    deps        = spec.get("dependencies", {"required": [], "optional": []})
+    req_pkgs    = deps.get("required", [])
+    import_hint = (
+        "\n".join(f"# import {p.split()[0].split('=')[0].split('>')[0].strip()}" for p in req_pkgs)
+        if req_pkgs else "# No external dependencies required"
+    )
+
+    return textwrap.dedent(f'''\
+        #!/usr/bin/env python3
+        """
+        {script_name}.py — ClawBio {title} Skill
+        {"=" * (len(script_name) + len(title) + 22)}
+        {description}
+
+        Author:  {author}
+        Version: {spec.get("version", "0.1.0")}
+
+        Usage:
+            python {script_name}.py --input <input_file> --output <output_dir>
+            python {script_name}.py --demo --output /tmp/{name}_demo
+        """
+
+        from __future__ import annotations
+
+        import argparse
+        import json
+        import sys
+        from datetime import datetime
+        from pathlib import Path
+
+        {import_hint}
+
+        # ---------------------------------------------------------------------------
+        # Core logic
+        # ---------------------------------------------------------------------------
+
+        def run(input_path: Path, output_dir: Path) -> dict:
+            """
+            Core skill logic.
+
+            Args:
+                input_path:  Path to the input file.
+                output_dir:  Directory where all output files will be written.
+
+            Returns:
+                dict: Machine-readable results (also written to result.json).
+            """
+            output_dir.mkdir(parents=True, exist_ok=True)
+            (output_dir / "figures").mkdir(exist_ok=True)
+            (output_dir / "tables").mkdir(exist_ok=True)
+            repro_dir = output_dir / "reproducibility"
+            repro_dir.mkdir(exist_ok=True)
+
+            # ------------------------------------------------------------------
+            # TODO: Implement your skill logic here.
+            #
+            # Typical pattern:
+            #   data = parse_input(input_path)
+            #   results = analyse(data)
+            #   write_figures(results, output_dir / "figures")
+            #   write_tables(results, output_dir / "tables")
+            # ------------------------------------------------------------------
+
+            results: dict = {{
+                "skill": "{name}",
+                "input": str(input_path),
+                "generated_at": datetime.now().isoformat(),
+                # TODO: add your result fields here
+            }}
+
+            # --- Write report.md ---
+            report_lines = [
+                f"# {title} Report",
+                "",
+                f"**Input**: `{{input_path.name}}`",
+                f"**Generated**: {{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}}",
+                "",
+                "## Summary",
+                "",
+                "TODO: Add your analysis summary here.",
+                "",
+                "---",
+                "",
+                "> **Disclaimer**: This output is for research and educational use only.",
+                "> It is not a medical device and should not replace professional advice.",
+            ]
+            (output_dir / "report.md").write_text("\\n".join(report_lines), encoding="utf-8")
+
+            # --- Write result.json ---
+            (output_dir / "result.json").write_text(
+                json.dumps(results, indent=2, default=str), encoding="utf-8"
+            )
+
+            # --- Write reproducibility bundle ---
+            cmd = (
+                f"python skills/{name}/{script_name}.py "
+                f"--input {{input_path}} --output {{output_dir}}"
+            )
+            (repro_dir / "commands.sh").write_text(
+                f"#!/bin/bash\\n# Reproduced: {{datetime.now().isoformat()}}\\n{{cmd}}\\n",
+                encoding="utf-8",
+            )
+            (repro_dir / "environment.yml").write_text(
+                "name: {name}\\nchannels:\\n  - conda-forge\\ndependencies:\\n  - python=3.11\\n",
+                encoding="utf-8",
+            )
+
+            return results
+
+
+        # ---------------------------------------------------------------------------
+        # Demo mode
+        # ---------------------------------------------------------------------------
+
+        def run_demo(output_dir: Path) -> None:
+            """Run with synthetic demo data to verify the skill works end-to-end."""
+            output_dir.mkdir(parents=True, exist_ok=True)
+
+            # ------------------------------------------------------------------
+            # TODO: Create synthetic demo input that exercises your core logic.
+            # The demo should run in < 10 seconds with no external downloads.
+            # ------------------------------------------------------------------
+
+            demo_input = output_dir / "demo_input.txt"
+            demo_input.write_text(
+                "# Demo input for {title}\\n"
+                "# TODO: replace with realistic synthetic data\\n"
+                "sample_id\\tvalue\\n"
+                "SAMPLE_01\\t42\\n"
+                "SAMPLE_02\\t17\\n",
+                encoding="utf-8",
+            )
+
+            results = run(demo_input, output_dir)
+
+            print(f"  Demo complete. Output: {{output_dir}}")
+            print(f"  Files: {{', '.join(f.name for f in output_dir.rglob('*') if f.is_file())}}")
+            return results
+
+
+        # ---------------------------------------------------------------------------
+        # CLI entry point
+        # ---------------------------------------------------------------------------
+
+        def main() -> None:
+            parser = argparse.ArgumentParser(
+                description="{description}",
+                formatter_class=argparse.RawDescriptionHelpFormatter,
+            )
+            parser.add_argument("--input",  dest="input_path", help="Path to input file")
+            parser.add_argument(
+                "--output",
+                dest="output_dir",
+                default="/tmp/{name}_output",
+                help="Output directory (default: /tmp/{name}_output)",
+            )
+            parser.add_argument("--demo", action="store_true", help="Run with synthetic demo data")
+            args = parser.parse_args()
+
+            out = Path(args.output_dir)
+
+            if args.demo:
+                run_demo(out)
+            elif args.input_path:
+                results = run(Path(args.input_path), out)
+                print(f"  Done. Output: {{out}}")
+                report = out / "report.md"
+                if report.exists():
+                    print(f"  Report: {{report}}")
+            else:
+                parser.error("Provide --input <file> or --demo")
+
+
+        if __name__ == "__main__":
+            main()
+    ''')
+
+
+# ---------------------------------------------------------------------------
+# Test skeleton generation
+# ---------------------------------------------------------------------------
+
+def generate_test_py(spec: dict) -> str:
+    """Generate a pytest skeleton for the skill."""
+    name        = spec["name"]
+    script_name = name.replace("-", "_")
+    title       = " ".join(w.capitalize() for w in name.split("-"))
+
+    return textwrap.dedent(f'''\
+        """
+        Tests for the {title} skill.
+
+        Run:
+            pytest skills/{name}/tests/ -v
+        or via ClawBio runner:
+            python -m pytest skills/{name}/tests/ -v
+        """
+
+        import json
+        from pathlib import Path
+
+        import pytest
+        import sys
+
+        # Make the skill importable regardless of working directory
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+        from {script_name} import run, run_demo
+
+
+        # ---------------------------------------------------------------------------
+        # Fixtures
+        # ---------------------------------------------------------------------------
+
+        @pytest.fixture
+        def tmp_output(tmp_path: Path) -> Path:
+            """Provide a temporary output directory per test."""
+            return tmp_path / "output"
+
+
+        # ---------------------------------------------------------------------------
+        # Tests
+        # ---------------------------------------------------------------------------
+
+        def test_demo_runs(tmp_output: Path) -> None:
+            """Demo mode should complete without raising an exception."""
+            run_demo(tmp_output)
+
+
+        def test_report_generated(tmp_output: Path) -> None:
+            """Demo should produce a non-empty report.md."""
+            run_demo(tmp_output)
+            report = tmp_output / "report.md"
+            assert report.exists(), "report.md was not created"
+            assert report.stat().st_size > 0, "report.md is empty"
+
+
+        def test_result_json_valid(tmp_output: Path) -> None:
+            """result.json should be present and parse as valid JSON."""
+            run_demo(tmp_output)
+            result_file = tmp_output / "result.json"
+            assert result_file.exists(), "result.json was not created"
+            data = json.loads(result_file.read_text())
+            assert isinstance(data, dict), "result.json should be a JSON object"
+            assert data.get("skill") == "{name}", "result.json should include skill name"
+
+
+        def test_reproducibility_bundle(tmp_output: Path) -> None:
+            """Reproducibility bundle (commands.sh + environment.yml) should be present."""
+            run_demo(tmp_output)
+            repro = tmp_output / "reproducibility"
+            assert (repro / "commands.sh").exists(), "commands.sh missing"
+            assert (repro / "environment.yml").exists(), "environment.yml missing"
+
+
+        # ---------------------------------------------------------------------------
+        # TODO: Add domain-specific tests below
+        # ---------------------------------------------------------------------------
+
+        # def test_core_logic(tmp_output: Path) -> None:
+        #     """TODO: Test the actual analysis logic with known input/output."""
+        #     demo_input = tmp_output / "test_input.txt"
+        #     demo_input.parent.mkdir(parents=True, exist_ok=True)
+        #     demo_input.write_text("...")
+        #     results = run(demo_input, tmp_output)
+        #     assert results["..."] == expected_value
+    ''')
+
+
+# ---------------------------------------------------------------------------
+# Catalog.json helpers
+# ---------------------------------------------------------------------------
+
+def generate_catalog_entry(spec: dict) -> dict:
+    """Build a catalog.json entry dict for the skill."""
+    name       = spec["name"]
+    cli_alias  = spec.get("cli_alias") or name.split("-")[0]
+    script_name = name.replace("-", "_")
+    return {
+        "name": name,
+        "cli_alias": cli_alias,
+        "description": spec["description"],
+        "version": spec.get("version", "0.1.0"),
+        "status": "mvp",
+        "has_script": True,
+        "has_tests": True,
+        "has_demo": True,
+        "demo_command": f"python clawbio.py run {cli_alias} --demo",
+        "dependencies": [],
+        "tags": spec.get("tags", []),
+        "trigger_keywords": spec.get("trigger_keywords", []),
+        "chaining_partners": spec.get("chaining_partners", []),
+    }
+
+
+def update_catalog_json(catalog_path: Path, entry: dict) -> bool:
+    """
+    Append the new skill entry to skills/catalog.json.
+    Returns True on success, False if skill already exists.
+    """
+    try:
+        catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"  {RED}Could not read catalog.json: {exc}{RESET}", file=sys.stderr)
+        return False
+
+    existing_names = {s["name"] for s in catalog.get("skills", [])}
+    if entry["name"] in existing_names:
+        print(f"  {DIM}catalog.json: '{entry['name']}' already exists — skipping.{RESET}")
+        return False
+
+    catalog.setdefault("skills", []).append(entry)
+    catalog["skill_count"] = len(catalog["skills"])
+    catalog_path.write_text(json.dumps(catalog, indent=2), encoding="utf-8")
+    print(f"  {GREEN}Updated catalog.json (+1 skill){RESET}")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# clawbio.py patching
+# ---------------------------------------------------------------------------
+
+def _clawbio_entry(spec: dict) -> str:
+    """Render the Python dict literal for the SKILLS entry."""
+    name        = spec["name"]
+    cli_alias   = spec.get("cli_alias") or name.split("-")[0]
+    description = spec["description"]
+    script_name = name.replace("-", "_")
+
+    return textwrap.dedent(f'''\
+        "{cli_alias}": {{
+            "script": SKILLS_DIR / "{name}" / "{script_name}.py",
+            "demo_args": ["--demo"],
+            "description": "{description}",
+            "allowed_extra_flags": set(),
+            "accepts_genotypes": False,
+        }},
+    ''')
+
+
+def patch_clawbio_py(clawbio_path: Path, spec: dict) -> bool:
+    """
+    Insert a new entry into the SKILLS dict in clawbio.py.
+    Returns True on success, False if alias already exists or anchor not found.
+    """
+    try:
+        source = clawbio_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"  {RED}Could not read clawbio.py: {exc}{RESET}", file=sys.stderr)
+        return False
+
+    cli_alias = spec.get("cli_alias") or spec["name"].split("-")[0]
+
+    # Check if alias already present
+    if f'"{cli_alias}"' in source and "SKILLS_DIR" in source:
+        print(f"  {DIM}clawbio.py: alias '{cli_alias}' already present — skipping.{RESET}")
+        return False
+
+    # Find the anchor: the line right after the last SKILLS entry, just before
+    # "# Skills that run in the full-profile pipeline"
+    anchor = "# Skills that run in the full-profile pipeline"
+    if anchor not in source:
+        print(
+            f"  {RED}clawbio.py: could not find anchor '{anchor}' — skipping auto-patch.{RESET}",
+            file=sys.stderr,
+        )
+        return False
+
+    new_entry = _clawbio_entry(spec)
+    # Indent the entry to match the SKILLS dict (4 spaces)
+    indented = textwrap.indent(new_entry, "    ")
+    patched = source.replace(anchor, f"{indented}\n{anchor}")
+    clawbio_path.write_text(patched, encoding="utf-8")
+    print(f"  {GREEN}Patched clawbio.py (+1 SKILLS entry for '{cli_alias}'){RESET}")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Repo root detection
+# ---------------------------------------------------------------------------
+
+def find_repo_root() -> Path | None:
+    """
+    Walk up from the script location looking for clawbio.py (repo root sentinel).
+    Returns the repo root Path, or None if not found.
+    """
+    candidate = SCRIPT_DIR
+    for _ in range(6):  # max 6 levels up
+        if (candidate / REPO_SENTINEL).exists():
+            return candidate
+        candidate = candidate.parent
+    return None
+
+
+# ---------------------------------------------------------------------------
+# SKILL.md validation
+# ---------------------------------------------------------------------------
+
+def validate_skill_md_content(content: str) -> list[tuple[str, bool, str]]:
+    """
+    Validate the *text* of a SKILL.md against the CONTRIBUTING checklist.
+
+    Returns a list of (section_name, passed, detail) tuples.
+    Accepts a plain string so callers that already hold the content in memory
+    (e.g. agent dry-run mode) do not need to touch the filesystem.
+    """
+    results: list[tuple[str, bool, str]] = []
+    for section_name, pattern in REQUIRED_SECTIONS:
+        found = bool(re.search(pattern, content, re.MULTILINE))
+        results.append((section_name, found, "present" if found else "MISSING"))
+    return results
+
+
+def validate_skill_md(md_path: Path) -> list[tuple[str, bool, str]]:
+    """
+    Validate a SKILL.md against the CONTRIBUTING checklist.
+
+    Returns a list of (section_name, passed, detail) tuples.
+    """
+    try:
+        content = md_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [("File readable", False, str(exc))]
+    return validate_skill_md_content(content)
+
+
+def print_validation_report(md_path: Path, results: list[tuple[str, bool, str]]) -> int:
+    """Print the validation report and return the number of failures."""
+    passed = sum(1 for _, ok, _ in results if ok)
+    total  = len(results)
+    print(f"\n{BOLD}SKILL.md Validation — {md_path.name}{RESET}")
+    print(f"{'─' * 50}")
+    for name, ok, detail in results:
+        icon  = f"{GREEN}PASS{RESET}" if ok else f"{RED}FAIL{RESET}"
+        print(f"  [{icon}] {name}")
+    print(f"{'─' * 50}")
+    score = f"{passed}/{total}"
+    if passed == total:
+        print(f"{GREEN}{BOLD}Score: {score} — all checks passed!{RESET}")
+    else:
+        failures = total - passed
+        print(f"{RED}{BOLD}Score: {score} — fix {failures} issue(s) before submitting PR{RESET}")
+    print()
+    return total - passed
+
+
+# ---------------------------------------------------------------------------
+# Scaffold orchestration
+# ---------------------------------------------------------------------------
+
+def scaffold_skill(
+    spec: dict,
+    output_base: Path,
+    dry_run: bool = False,
+    repo_root: Path | None = None,
+    ask_overwrite: bool = False,
+) -> dict:
+    """
+    Create all skill files and (if repo_root found) update registry.
+    Returns a manifest dict summarising what was created.
+
+    ask_overwrite: if True, prompt the user before overwriting existing files
+                   instead of silently skipping them.
+    """
+    name        = spec["name"]
+    script_name = name.replace("-", "_")
+    skill_dir   = output_base / name
+
+    files_written: list[str] = []
+    files_skipped: list[str] = []
+
+    def write_file(path: Path, content: str, label: str, force: bool = False) -> None:
+        """Write content to path, respecting dry_run / overwrite policy."""
+        rel = str(path.relative_to(output_base) if output_base in path.parents else path)
+        if path.exists() and not force:
+            if ask_overwrite:
+                ans = input(f"  Overwrite {rel}? [y/N]: ").strip().lower()
+                if ans not in ("y", "yes"):
+                    print(f"  {DIM}kept:          {rel}{RESET}")
+                    files_skipped.append(rel)
+                    return
+                # Fall through to write (updated)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(content, encoding="utf-8")
+                print(f"  {CYAN}updated:{RESET}       {rel}")
+                files_written.append(rel)
+                return
+            else:
+                print(f"  {DIM}skip (exists):  {rel}{RESET}")
+                files_skipped.append(rel)
+                return
+        if dry_run:
+            print(f"\n{CYAN}{'─' * 60}{RESET}")
+            print(f"{BOLD}{label}: {rel}{RESET}")
+            print(f"{CYAN}{'─' * 60}{RESET}")
+            print(content[:2000])
+            if len(content) > 2000:
+                print(f"{DIM}... ({len(content) - 2000} more chars){RESET}")
+            files_written.append(f"[dry-run] {rel}")
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
+            print(f"  {GREEN}created:{RESET}       {rel}")
+            files_written.append(rel)
+
+    print(f"\n{CYAN}{BOLD}🦖 Scaffolding skill: {name}{RESET}")
+    if dry_run:
+        print(f"{DIM}Dry run — no files will be written.{RESET}\n")
+
+    # 1. SKILL.md
+    write_file(skill_dir / "SKILL.md", generate_skill_md(spec), "SKILL.md")
+
+    # 2. Python script
+    write_file(skill_dir / f"{script_name}.py", generate_skill_py(spec), "Python script")
+
+    # 3. Test skeleton
+    write_file(
+        skill_dir / "tests" / f"test_{script_name}.py",
+        generate_test_py(spec),
+        "Test skeleton",
+    )
+
+    # 4. Example spec copy (JSON, for reproducibility)
+    # In --edit mode (ask_overwrite=True) always refresh the spec — no prompt.
+    write_file(
+        skill_dir / "examples" / "example_spec.json",
+        json.dumps(spec, indent=2),
+        "Example spec",
+        force=ask_overwrite,
+    )
+
+    # 5. Validate the generated SKILL.md (only in real mode)
+    if not dry_run:
+        skill_md_path = skill_dir / "SKILL.md"
+        if skill_md_path.exists():
+            results = validate_skill_md(skill_md_path)
+            failures = print_validation_report(skill_md_path, results)
+            if failures:
+                print(f"  {DIM}(Fill in the TODO: placeholders to resolve these.){RESET}\n")
+
+    # 6. Update catalog.json + clawbio.py if repo is found
+    catalog_updated   = False
+    clawbio_updated   = False
+    if repo_root and not dry_run:
+        catalog_path  = repo_root / "skills" / "catalog.json"
+        clawbio_path  = repo_root / "clawbio.py"
+        catalog_entry = generate_catalog_entry(spec)
+
+        if catalog_path.exists():
+            catalog_updated = update_catalog_json(catalog_path, catalog_entry)
+        else:
+            print(f"  {DIM}catalog.json not found at {catalog_path} — skipping.{RESET}")
+
+        if clawbio_path.exists():
+            clawbio_updated = patch_clawbio_py(clawbio_path, spec)
+        else:
+            print(f"  {DIM}clawbio.py not found at {clawbio_path} — skipping.{RESET}")
+
+    manifest = {
+        "skill": name,
+        "output_dir": str(skill_dir),
+        "files_written": files_written,
+        "files_skipped": files_skipped,
+        "catalog_updated": catalog_updated,
+        "clawbio_updated": clawbio_updated,
+        "dry_run": dry_run,
+        "generated_at": datetime.now().isoformat(),
+    }
+
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# Report writing
+# ---------------------------------------------------------------------------
+
+def write_skill_builder_report(
+    manifest: dict,
+    output_dir: Path,
+    spec: dict,
+    repo_root: Path | None,
+) -> None:
+    """Write the skill-builder's own report.md + result.json to output_dir."""
+    name      = spec["name"]
+    cli_alias = spec.get("cli_alias") or name.split("-")[0]
+    repro_dir = output_dir / "reproducibility"
+    repro_dir.mkdir(parents=True, exist_ok=True)
+
+    # report.md
+    next_steps = []
+    if not manifest.get("catalog_updated"):
+        next_steps.append(
+            "1. Add the catalog entry: append `catalog_entry.json` to `skills/catalog.json`"
+        )
+    if not manifest.get("clawbio_updated"):
+        next_steps.append(
+            f"2. Add to `clawbio.py` SKILLS dict — see `examples/example_spec.json` for the entry"
+        )
+    next_steps.append(
+        f"3. Fill in all `TODO:` placeholders in `skills/{name}/SKILL.md` and `skills/{name}/{name.replace('-','_')}.py`"
+    )
+    next_steps.append(
+        f"4. Run tests: `python -m pytest skills/{name}/tests/ -v`"
+    )
+    next_steps.append(
+        f"5. Submit PR: `git checkout -b add-{name} && git add skills/{name}/ && git commit -m 'Add {name} skill' && git push`"
+    )
+
+    report_lines = [
+        f"# Skill Builder Report",
+        "",
+        f"**Skill scaffolded**: `{name}`",
+        f"**Generated**: {manifest['generated_at']}",
+        f"**Output directory**: `{manifest['output_dir']}`",
+        "",
+        "## Files Created",
+        "",
+    ]
+    for f in manifest["files_written"]:
+        report_lines.append(f"- `{f}`")
+    if manifest["files_skipped"]:
+        report_lines += ["", "## Files Skipped (already exist)", ""]
+        for f in manifest["files_skipped"]:
+            report_lines.append(f"- `{f}`")
+
+    report_lines += [
+        "",
+        "## Registry Updates",
+        "",
+        f"- catalog.json updated: {'yes' if manifest['catalog_updated'] else 'no'}",
+        f"- clawbio.py updated:   {'yes' if manifest['clawbio_updated'] else 'no'}",
+        "",
+        "## Next Steps",
+        "",
+    ]
+    report_lines += next_steps
+    report_lines += [
+        "",
+        "---",
+        "",
+        "> This report was generated by the **ClawBio Skill Builder**.",
+        "> Skill Builder is itself a ClawBio skill — built with itself.",
+    ]
+
+    (output_dir / "report.md").write_text("\n".join(report_lines), encoding="utf-8")
+    (output_dir / "result.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    cmd_input = spec.get("_source_path", "spec.json")
+    (repro_dir / "commands.sh").write_text(
+        f"#!/bin/bash\n# Reproduced: {manifest['generated_at']}\n"
+        f"python skills/skill-builder/skill_builder.py --input {cmd_input}\n",
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Demo mode
+# ---------------------------------------------------------------------------
+
+def run_demo(output_dir: Path, dry_run: bool = False) -> None:
+    """Scaffold the hello-bioinformatics demo skill."""
+    if not DEMO_SPEC_PATH.exists():
+        print(
+            f"{RED}Demo spec not found at {DEMO_SPEC_PATH}. "
+            f"Ensure demo_spec.json is present alongside skill_builder.py.{RESET}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    spec = load_spec(DEMO_SPEC_PATH)
+    spec["_source_path"] = str(DEMO_SPEC_PATH)
+
+    # Demo always writes into a subdirectory so it's self-contained
+    skill_output_base = output_dir
+    repo_root = find_repo_root()
+
+    manifest = scaffold_skill(spec, skill_output_base, dry_run=dry_run, repo_root=repo_root)
+
+    if not dry_run:
+        write_skill_builder_report(manifest, output_dir, spec, repo_root)
+        print(f"\n  {GREEN}{BOLD}Demo complete!{RESET}")
+        print(f"  Skill directory: {manifest['output_dir']}")
+        print(f"  Report:          {output_dir / 'report.md'}")
+
+
+# ---------------------------------------------------------------------------
+# Agent mode
+# ---------------------------------------------------------------------------
+
+def run_agent(
+    spec: dict,
+    output_base: Path,
+    dry_run: bool = False,
+    repo_root: Path | None = None,
+) -> None:
+    """
+    Machine-readable execution path for LLM / CI callers.
+
+    Scaffolds the skill with all human-readable progress output suppressed,
+    then emits a single JSON object to stdout:
+
+    Success::
+
+        {
+            "status": "ok",
+            "skill": "my-skill",
+            "output_dir": "/abs/path/skills/my-skill",
+            "files_written": ["my-skill/SKILL.md", ...],
+            "files_skipped": [],
+            "catalog_updated": false,
+            "clawbio_updated": false,
+            "validation": {"passed": 13, "failed": 0, "failures": []},
+            "dry_run": false,
+            "generated_at": "2026-03-19T12:00:00",
+            // only present when dry_run=true:
+            "generated_content": {
+                "SKILL.md": "...",
+                "my_skill.py": "...",
+                "tests/test_my_skill.py": "...",
+                "examples/example_spec.json": "..."
+            }
+        }
+
+    Error (spec validation failed — exits non-zero)::
+
+        {"status": "error", "errors": ["name: must be lowercase-hyphen"]}
+    """
+    import io as _io
+
+    script_name = spec["name"].replace("-", "_")
+
+    # ------------------------------------------------------------------
+    # Scaffold with stdout silenced (all decorative print() calls go to /dev/null)
+    # ------------------------------------------------------------------
+    _saved_stdout = sys.stdout
+    sys.stdout = _io.StringIO()
+    try:
+        manifest = scaffold_skill(spec, output_base, dry_run=dry_run, repo_root=repo_root)
+    finally:
+        sys.stdout = _saved_stdout
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+    if dry_run:
+        # No files written — validate the generated content string directly.
+        skill_md_content = generate_skill_md(spec)
+        val_results = validate_skill_md_content(skill_md_content)
+    else:
+        skill_md_path = output_base / spec["name"] / "SKILL.md"
+        val_results = (
+            validate_skill_md(skill_md_path)
+            if skill_md_path.exists()
+            else [("File readable", False, "SKILL.md not found after scaffold")]
+        )
+
+    passed   = sum(1 for _, ok, _ in val_results if ok)
+    failures = [name for name, ok, _ in val_results if not ok]
+    manifest["validation"] = {"passed": passed, "failed": len(failures), "failures": failures}
+    manifest["status"] = "ok"
+
+    # ------------------------------------------------------------------
+    # In dry-run mode, include the generated file contents in the JSON so
+    # the calling agent can inspect them without hitting the filesystem.
+    # ------------------------------------------------------------------
+    if dry_run:
+        manifest["generated_content"] = {
+            "SKILL.md":                        generate_skill_md(spec),
+            f"{script_name}.py":               generate_skill_py(spec),
+            f"tests/test_{script_name}.py":    generate_test_py(spec),
+            "examples/example_spec.json":      json.dumps(spec, indent=2),
+        }
+
+    print(json.dumps(manifest, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Edit mode
+# ---------------------------------------------------------------------------
+
+def edit_skill(skill_dir: Path) -> None:
+    """
+    Re-scaffold an existing skill directory after editing its spec.
+
+    Reads ``<skill_dir>/examples/example_spec.json``, drops directly into
+    the review/edit loop so the user can adjust any field, then calls
+    scaffold_skill() with ask_overwrite=True so existing files can be
+    selectively updated.  The example_spec.json is always refreshed.
+    """
+    spec_path = skill_dir / "examples" / "example_spec.json"
+    if not spec_path.exists():
+        print(
+            f"{RED}No example_spec.json found in {skill_dir / 'examples'}.{RESET}\n"
+            f"  Create one or use --input to scaffold from scratch.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    spec = load_spec(spec_path)
+    skill_name = spec.get("name", skill_dir.name)
+
+    print(f"\n{CYAN}{BOLD}ClawBio Skill Builder — Edit Mode: {skill_name}{RESET}")
+    print(f"{DIM}Review or edit any field, then confirm to re-scaffold.{RESET}\n")
+
+    spec = _run_review_loop(spec)
+
+    # Resolve the output base (parent of skill_dir)
+    output_base = skill_dir.parent
+    repo_root   = find_repo_root()
+
+    manifest = scaffold_skill(
+        spec,
+        output_base,
+        dry_run=False,
+        repo_root=repo_root,
+        ask_overwrite=True,
+    )
+
+    print(f"\n  {GREEN}{BOLD}Edit complete!{RESET}")
+    print(f"  Skill directory: {manifest['output_dir']}")
+
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="ClawBio Skill Builder — scaffold a new ClawBio skill from a spec",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent("""\
+            Examples:
+              python skill_builder.py --input spec.json
+              python skill_builder.py --interactive
+              python skill_builder.py --demo --output /tmp/demo
+              python skill_builder.py --validate-only --input skills/my-skill/SKILL.md
+              python skill_builder.py --input spec.json --dry-run
+              python skill_builder.py --edit skills/my-skill/
+
+              # Agent / LLM pipeline — JSON manifest to stdout, no interactive prompts:
+              python skill_builder.py --agent --input spec.json
+              python skill_builder.py --agent --input spec.json --dry-run
+              echo '{"name":"foo",...}' | python skill_builder.py --agent --input -
+
+            Notes:
+              Interactive mode (--interactive) auto-saves your progress after every
+              field to:
+                ~/.clawbio_skill_builder_draft.json
+              You will be offered the option to resume this draft the next time you
+              run --interactive. To discard it and start fresh, delete the file:
+                rm ~/.clawbio_skill_builder_draft.json
+        """),
+    )
+
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--input",         dest="input_path", metavar="FILE",
+                      help="Path to skill spec (JSON/YAML), SKILL.md (--validate-only), "
+                           "or '-' to read JSON from stdin")
+    mode.add_argument("--interactive",   action="store_true",
+                      help="Collect skill spec interactively")
+    mode.add_argument("--demo",          action="store_true",
+                      help="Scaffold the hello-bioinformatics demo skill")
+    mode.add_argument("--edit",          dest="edit_dir", metavar="DIR",
+                      help="Re-scaffold an existing skill directory (reads examples/example_spec.json)")
+
+    parser.add_argument("--output",      dest="output_dir",  metavar="DIR",
+                        help="Output directory (default: ./generated_skills/ or skills/ in repo)")
+    parser.add_argument("--validate-only", action="store_true",
+                        help="Validate a SKILL.md against the CONTRIBUTING checklist and exit")
+    parser.add_argument("--dry-run",     action="store_true",
+                        help="Print generated content without writing any files")
+    parser.add_argument("--agent",       action="store_true",
+                        help="Machine-readable mode: suppress all progress output and emit a "
+                             "single JSON manifest to stdout. Compatible with --input FILE or "
+                             "--input - (spec JSON read from stdin). Exits non-zero on error.")
+
+    args = parser.parse_args()
+
+    repo_root   = find_repo_root()
+    default_out = (repo_root / "skills") if repo_root else Path("generated_skills")
+
+    # ------------------------------------------------------------------
+    # Validate-only mode (reads a SKILL.md, does not scaffold)
+    # ------------------------------------------------------------------
+    if args.validate_only:
+        if not args.input_path:
+            parser.error("--validate-only requires --input <path/to/SKILL.md>")
+        md_path = Path(args.input_path)
+        if not md_path.exists():
+            print(f"{RED}File not found: {md_path}{RESET}", file=sys.stderr)
+            sys.exit(1)
+        results  = validate_skill_md(md_path)
+        failures = print_validation_report(md_path, results)
+        sys.exit(0 if failures == 0 else 1)
+
+    # ------------------------------------------------------------------
+    # Edit mode
+    # ------------------------------------------------------------------
+    if args.edit_dir:
+        skill_dir = Path(args.edit_dir).resolve()
+        if not skill_dir.is_dir():
+            print(f"{RED}Directory not found: {skill_dir}{RESET}", file=sys.stderr)
+            sys.exit(1)
+        edit_skill(skill_dir)
+        return
+
+    # ------------------------------------------------------------------
+    # Demo mode
+    # ------------------------------------------------------------------
+    if args.demo:
+        out = Path(args.output_dir) if args.output_dir else Path("/tmp/skill_builder_demo")
+        run_demo(out, dry_run=args.dry_run)
+        return
+
+    # ------------------------------------------------------------------
+    # Spec-driven or interactive
+    # ------------------------------------------------------------------
+    if args.interactive:
+        spec = collect_spec_interactive()
+    else:
+        if args.input_path == "-":
+            # Read spec JSON from stdin (agent / pipeline use)
+            try:
+                spec = json.load(sys.stdin)
+            except json.JSONDecodeError as exc:
+                if args.agent:
+                    print(json.dumps({"status": "error", "errors": [f"stdin JSON parse error: {exc}"]}))
+                else:
+                    print(f"{RED}JSON parse error reading from stdin: {exc}{RESET}", file=sys.stderr)
+                sys.exit(1)
+        else:
+            input_path = Path(args.input_path)
+            if not input_path.exists():
+                if args.agent:
+                    print(json.dumps({"status": "error", "errors": [f"spec file not found: {input_path}"]}))
+                else:
+                    print(f"{RED}Spec file not found: {input_path}{RESET}", file=sys.stderr)
+                sys.exit(1)
+            spec = load_spec(input_path)
+            spec["_source_path"] = str(input_path)
+
+    # Validate spec fields
+    errors = validate_spec(spec)
+    if errors:
+        if args.agent:
+            print(json.dumps({"status": "error", "errors": errors}))
+        else:
+            print(f"{RED}{BOLD}Spec validation errors:{RESET}", file=sys.stderr)
+            for err in errors:
+                print(f"  • {err}", file=sys.stderr)
+        sys.exit(1)
+
+    # Resolve output directory
+    if args.output_dir:
+        output_base = Path(args.output_dir)
+    else:
+        output_base = default_out
+
+    # ------------------------------------------------------------------
+    # Agent mode — emit JSON manifest and return
+    # ------------------------------------------------------------------
+    if args.agent:
+        run_agent(spec, output_base, dry_run=args.dry_run, repo_root=repo_root)
+        return
+
+    # Scaffold (human mode)
+    manifest = scaffold_skill(spec, output_base, dry_run=args.dry_run, repo_root=repo_root)
+
+    if not args.dry_run:
+        _clear_draft()  # remove any lingering interactive draft
+
+        # Write skill-builder's own output report into a subdirectory
+        sb_report_dir = output_base / f"_skill_builder_report_{spec['name']}"
+        write_skill_builder_report(manifest, sb_report_dir, spec, repo_root)
+
+        print(f"\n  {GREEN}{BOLD}Scaffold complete!{RESET}")
+        print(f"  Skill directory: {manifest['output_dir']}")
+        if (sb_report_dir / "report.md").exists():
+            print(f"  Builder report:  {sb_report_dir / 'report.md'}")
+        if repo_root:
+            print(f"  Repo root found: {repo_root}")
+        else:
+            print(f"\n  {DIM}Repo root not found — catalog.json and clawbio.py were not updated.")
+            print(f"  To update them manually, run this script from inside the ClawBio repo.{RESET}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/skill-builder/templates/spec_template.json
+++ b/skills/skill-builder/templates/spec_template.json
@@ -1,0 +1,72 @@
+{
+  "_comment": "ClawBio Skill Spec Template — copy this file, fill in every field, then run:",
+  "_usage": "python skills/skill-builder/skill_builder.py --input my_skill_spec.json",
+
+  "name": "my-skill-name",
+  "_name_comment": "REQUIRED. Lowercase letters, digits, hyphens only. e.g. pharmgx-reporter, variant-annotator",
+
+  "description": "One-sentence description of what this skill does for the user.",
+  "_description_comment": "REQUIRED. Keep it under 120 characters. Start with a verb (Analyse, Predict, Generate…).",
+
+  "author": "Your Name",
+  "_author_comment": "REQUIRED. Your name or GitHub handle.",
+
+  "version": "0.1.0",
+  "_version_comment": "Semantic version. Start at 0.1.0 for an MVP.",
+
+  "license": "MIT",
+  "_license_comment": "Must match the ClawBio repo license (MIT).",
+
+  "domain": "genomics",
+  "_domain_comment": "Primary scientific domain. Examples: genomics, metagenomics, proteomics, pharmacogenomics, transcriptomics, epigenomics, bioinformatics.",
+
+  "emoji": "🧬",
+  "_emoji_comment": "Single emoji that represents your skill. Shown in logs and reports.",
+
+  "cli_alias": "myskill",
+  "_cli_alias_comment": "Short alias for `python clawbio.py run <alias>`. Lowercase, no hyphens. e.g. pharmgx, varann, myskill.",
+
+  "tags": ["genomics", "variant-analysis", "clinical"],
+  "_tags_comment": "Free-form list of tags for catalog search. Include domain, data type, and use case.",
+
+  "trigger_keywords": [
+    "analyse variants",
+    "variant annotation",
+    "annotate VCF",
+    "interpret SNPs"
+  ],
+  "_trigger_keywords_comment": "Natural-language phrases that should route the user here. The orchestrator matches these against user queries. Include synonyms and common misspellings.",
+
+  "capabilities": [
+    "Parse VCF/TSV input and validate required columns",
+    "Annotate variants against ClinVar / dbSNP",
+    "Generate a clinical-style markdown report with tier classifications",
+    "Produce a machine-readable result.json and reproducibility bundle"
+  ],
+  "_capabilities_comment": "List 3-6 concrete, testable capabilities. Each maps to a bullet point in SKILL.md Core Capabilities.",
+
+  "input_formats": [
+    {
+      "format": "VCF (Variant Call Format)",
+      "extension": ".vcf",
+      "required_fields": "CHROM, POS, REF, ALT",
+      "example": "demo_variants.vcf"
+    },
+    {
+      "format": "TSV — variant table",
+      "extension": ".tsv",
+      "required_fields": "chrom, pos, ref, alt",
+      "example": "demo_variants.tsv"
+    }
+  ],
+  "_input_formats_comment": "One entry per accepted input format. 'required_fields' is a comma-separated string of mandatory column/field names.",
+
+  "dependencies": {
+    "required": [],
+    "optional": ["pyyaml>=6.0"],
+    "_comment": "List pip package specs (e.g. 'biopython>=1.81'). Keep required[] minimal — prefer stdlib. Optional packages must degrade gracefully."
+  },
+
+  "chaining_partners": ["pharmgx-reporter", "variant-annotator"],
+  "_chaining_partners_comment": "Skill names (not aliases) that this skill commonly chains with. Used to generate the Integration section of SKILL.md."
+}

--- a/skills/skill-builder/tests/test_skill_builder.py
+++ b/skills/skill-builder/tests/test_skill_builder.py
@@ -1,0 +1,899 @@
+"""
+Tests for the ClawBio Skill Builder.
+
+Run:
+    pytest skills/skill-builder/tests/ -v
+or via ClawBio runner:
+    python -m pytest skills/skill-builder/tests/ -v
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the skill importable regardless of working directory
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from skill_builder import (
+    collect_spec_interactive,
+    generate_catalog_entry,
+    generate_skill_md,
+    generate_skill_py,
+    generate_test_py,
+    load_spec,
+    patch_clawbio_py,
+    run_demo,
+    scaffold_skill,
+    update_catalog_json,
+    validate_skill_md,
+    validate_spec,
+    REQUIRED_SECTIONS,
+    DEMO_SPEC_PATH,
+    # interactive / draft helpers
+    _Jump,
+    _ask,
+    _ask_list,
+    _clear_draft,
+    _find_resume_cursor,
+    _load_draft,
+    _NUM_FIELDS,
+    _prompt_field,
+    _run_review_loop,
+    _save_draft,
+    DRAFT_SPEC_PATH,
+)
+import skill_builder as _sb  # used for monkeypatching module-level attributes
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+MINIMAL_SPEC = {
+    "name": "test-skill",
+    "description": "A minimal test skill for unit testing",
+    "author": "Test Author",
+    "version": "0.1.0",
+    "domain": "genomics",
+    "cli_alias": "testskill",
+    "tags": ["test"],
+    "trigger_keywords": ["test skill", "run test"],
+    "capabilities": ["Do something", "Do something else"],
+    "input_formats": [],
+    "dependencies": {"required": [], "optional": []},
+    "chaining_partners": [],
+}
+
+
+@pytest.fixture
+def spec() -> dict:
+    """Return a minimal valid skill spec."""
+    return dict(MINIMAL_SPEC)
+
+
+@pytest.fixture
+def tmp_output(tmp_path: Path) -> Path:
+    """Provide a temporary output directory per test."""
+    return tmp_path / "output"
+
+
+@pytest.fixture
+def demo_spec() -> dict:
+    """Load the real demo_spec.json bundled with the skill."""
+    assert DEMO_SPEC_PATH.exists(), f"demo_spec.json not found at {DEMO_SPEC_PATH}"
+    return json.loads(DEMO_SPEC_PATH.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# validate_spec
+# ---------------------------------------------------------------------------
+
+class TestValidateSpec:
+    def test_valid_minimal_spec(self, spec: dict) -> None:
+        assert validate_spec(spec) == []
+
+    def test_missing_name(self, spec: dict) -> None:
+        del spec["name"]
+        errors = validate_spec(spec)
+        assert any("name" in e for e in errors)
+
+    def test_missing_description(self, spec: dict) -> None:
+        del spec["description"]
+        errors = validate_spec(spec)
+        assert any("description" in e for e in errors)
+
+    def test_missing_author(self, spec: dict) -> None:
+        del spec["author"]
+        errors = validate_spec(spec)
+        assert any("author" in e for e in errors)
+
+    def test_invalid_name_uppercase(self, spec: dict) -> None:
+        spec["name"] = "My-Skill"
+        errors = validate_spec(spec)
+        assert any("name" in e for e in errors)
+
+    def test_invalid_name_spaces(self, spec: dict) -> None:
+        spec["name"] = "my skill"
+        errors = validate_spec(spec)
+        assert any("name" in e for e in errors)
+
+    def test_valid_name_with_digits(self, spec: dict) -> None:
+        spec["name"] = "skill-v2-beta"
+        assert validate_spec(spec) == []
+
+
+# ---------------------------------------------------------------------------
+# generate_skill_md
+# ---------------------------------------------------------------------------
+
+class TestGenerateSkillMd:
+    def test_generates_string(self, spec: dict) -> None:
+        md = generate_skill_md(spec)
+        assert isinstance(md, str)
+        assert len(md) > 500
+
+    def test_yaml_frontmatter_present(self, spec: dict) -> None:
+        md = generate_skill_md(spec)
+        assert md.startswith("---"), "SKILL.md must start with YAML frontmatter"
+
+    def test_required_frontmatter_fields(self, spec: dict) -> None:
+        md = generate_skill_md(spec)
+        for field in ["name:", "description:", "version:", "author:", "license:", "trigger_keywords:"]:
+            assert field in md, f"Missing frontmatter field: {field}"
+
+    def test_all_required_sections_present(self, spec: dict) -> None:
+        import re
+        md = generate_skill_md(spec)
+        for section_name, pattern in REQUIRED_SECTIONS:
+            assert re.search(pattern, md, re.MULTILINE), f"Missing section: {section_name}"
+
+    def test_skill_name_in_content(self, spec: dict) -> None:
+        md = generate_skill_md(spec)
+        assert spec["name"] in md
+
+    def test_trigger_keywords_included(self, spec: dict) -> None:
+        md = generate_skill_md(spec)
+        for kw in spec["trigger_keywords"]:
+            assert kw in md, f"trigger_keyword '{kw}' not found in SKILL.md"
+
+    def test_output_structure_section_correct(self, spec: dict) -> None:
+        md = generate_skill_md(spec)
+        assert "report.md" in md
+        assert "result.json" in md
+        assert "commands.sh" in md
+        assert "environment.yml" in md
+
+
+# ---------------------------------------------------------------------------
+# generate_skill_py
+# ---------------------------------------------------------------------------
+
+class TestGenerateSkillPy:
+    def test_generates_string(self, spec: dict) -> None:
+        py = generate_skill_py(spec)
+        assert isinstance(py, str)
+        assert len(py) > 200
+
+    def test_has_shebang(self, spec: dict) -> None:
+        py = generate_skill_py(spec)
+        assert py.startswith("#!/usr/bin/env python3")
+
+    def test_has_argparse(self, spec: dict) -> None:
+        py = generate_skill_py(spec)
+        assert "argparse" in py
+
+    def test_has_demo_flag(self, spec: dict) -> None:
+        py = generate_skill_py(spec)
+        assert "--demo" in py
+
+    def test_has_input_output_flags(self, spec: dict) -> None:
+        py = generate_skill_py(spec)
+        assert "--input" in py
+        assert "--output" in py
+
+    def test_has_run_function(self, spec: dict) -> None:
+        py = generate_skill_py(spec)
+        assert "def run(" in py
+
+    def test_has_run_demo_function(self, spec: dict) -> None:
+        py = generate_skill_py(spec)
+        assert "def run_demo(" in py
+
+    def test_has_main_guard(self, spec: dict) -> None:
+        py = generate_skill_py(spec)
+        assert 'if __name__ == "__main__"' in py
+
+    def test_output_bundle_code_present(self, spec: dict) -> None:
+        py = generate_skill_py(spec)
+        assert "report.md" in py
+        assert "result.json" in py
+        assert "commands.sh" in py
+        assert "environment.yml" in py
+
+
+# ---------------------------------------------------------------------------
+# generate_test_py
+# ---------------------------------------------------------------------------
+
+class TestGenerateTestPy:
+    def test_generates_string(self, spec: dict) -> None:
+        tpy = generate_test_py(spec)
+        assert isinstance(tpy, str)
+        assert len(tpy) > 100
+
+    def test_has_four_standard_tests(self, spec: dict) -> None:
+        tpy = generate_test_py(spec)
+        assert "def test_demo_runs" in tpy
+        assert "def test_report_generated" in tpy
+        assert "def test_result_json_valid" in tpy
+        assert "def test_reproducibility_bundle" in tpy
+
+    def test_imports_run_and_run_demo(self, spec: dict) -> None:
+        tpy = generate_test_py(spec)
+        assert "from test_skill import run, run_demo" in tpy or "run, run_demo" in tpy
+
+
+# ---------------------------------------------------------------------------
+# generate_catalog_entry
+# ---------------------------------------------------------------------------
+
+class TestGenerateCatalogEntry:
+    def test_entry_has_required_keys(self, spec: dict) -> None:
+        entry = generate_catalog_entry(spec)
+        for key in ["name", "cli_alias", "description", "version", "has_script", "has_tests", "has_demo"]:
+            assert key in entry, f"Missing key in catalog entry: {key}"
+
+    def test_name_matches_spec(self, spec: dict) -> None:
+        entry = generate_catalog_entry(spec)
+        assert entry["name"] == spec["name"]
+
+    def test_cli_alias_matches_spec(self, spec: dict) -> None:
+        entry = generate_catalog_entry(spec)
+        assert entry["cli_alias"] == spec["cli_alias"]
+
+    def test_flags_true(self, spec: dict) -> None:
+        entry = generate_catalog_entry(spec)
+        assert entry["has_script"] is True
+        assert entry["has_tests"] is True
+        assert entry["has_demo"] is True
+
+
+# ---------------------------------------------------------------------------
+# update_catalog_json
+# ---------------------------------------------------------------------------
+
+class TestUpdateCatalogJson:
+    def _make_catalog(self, tmp_path: Path, skills: list[dict] | None = None) -> Path:
+        p = tmp_path / "catalog.json"
+        p.write_text(
+            json.dumps({"skill_count": len(skills or []), "skills": skills or []}),
+            encoding="utf-8",
+        )
+        return p
+
+    def test_adds_new_skill(self, spec: dict, tmp_path: Path) -> None:
+        catalog = self._make_catalog(tmp_path)
+        entry = generate_catalog_entry(spec)
+        result = update_catalog_json(catalog, entry)
+        assert result is True
+        data = json.loads(catalog.read_text())
+        assert any(s["name"] == spec["name"] for s in data["skills"])
+
+    def test_skill_count_updated(self, spec: dict, tmp_path: Path) -> None:
+        catalog = self._make_catalog(tmp_path)
+        entry = generate_catalog_entry(spec)
+        update_catalog_json(catalog, entry)
+        data = json.loads(catalog.read_text())
+        assert data["skill_count"] == 1
+
+    def test_duplicate_skipped(self, spec: dict, tmp_path: Path) -> None:
+        entry = generate_catalog_entry(spec)
+        catalog = self._make_catalog(tmp_path, skills=[entry])
+        result = update_catalog_json(catalog, entry)
+        assert result is False
+        data = json.loads(catalog.read_text())
+        assert data["skill_count"] == 1
+
+    def test_invalid_json_returns_false(self, spec: dict, tmp_path: Path) -> None:
+        catalog = tmp_path / "catalog.json"
+        catalog.write_text("NOT JSON", encoding="utf-8")
+        entry = generate_catalog_entry(spec)
+        result = update_catalog_json(catalog, entry)
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# patch_clawbio_py
+# ---------------------------------------------------------------------------
+
+class TestPatchClawbioPy:
+    _ANCHOR = "# Skills that run in the full-profile pipeline"
+
+    def _make_clawbio(self, tmp_path: Path, already_has_alias: bool = False) -> Path:
+        p = tmp_path / "clawbio.py"
+        extra = '    "testskill": {"script": "x"},\n' if already_has_alias else ""
+        content = (
+            "SKILLS_DIR = Path('skills')\n"
+            "SKILLS = {\n"
+            f"{extra}"
+            f"    {self._ANCHOR}\n"
+            "}\n"
+        )
+        p.write_text(content, encoding="utf-8")
+        return p
+
+    def test_inserts_entry(self, spec: dict, tmp_path: Path) -> None:
+        clawbio = self._make_clawbio(tmp_path)
+        result = patch_clawbio_py(clawbio, spec)
+        assert result is True
+        source = clawbio.read_text()
+        assert '"testskill"' in source
+
+    def test_anchor_still_present(self, spec: dict, tmp_path: Path) -> None:
+        clawbio = self._make_clawbio(tmp_path)
+        patch_clawbio_py(clawbio, spec)
+        assert self._ANCHOR in clawbio.read_text()
+
+    def test_duplicate_alias_skipped(self, spec: dict, tmp_path: Path) -> None:
+        clawbio = self._make_clawbio(tmp_path, already_has_alias=True)
+        result = patch_clawbio_py(clawbio, spec)
+        assert result is False
+
+    def test_missing_anchor_returns_false(self, spec: dict, tmp_path: Path) -> None:
+        clawbio = tmp_path / "clawbio.py"
+        clawbio.write_text("SKILLS = {}\n", encoding="utf-8")
+        result = patch_clawbio_py(clawbio, spec)
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# validate_skill_md
+# ---------------------------------------------------------------------------
+
+class TestValidateSkillMd:
+    def test_generated_md_passes_all_checks(self, spec: dict, tmp_path: Path) -> None:
+        md_path = tmp_path / "SKILL.md"
+        md_path.write_text(generate_skill_md(spec), encoding="utf-8")
+        results = validate_skill_md(md_path)
+        failures = [(name, detail) for name, ok, detail in results if not ok]
+        assert failures == [], f"Validation failures: {failures}"
+
+    def test_empty_file_fails_all(self, tmp_path: Path) -> None:
+        md_path = tmp_path / "SKILL.md"
+        md_path.write_text("", encoding="utf-8")
+        results = validate_skill_md(md_path)
+        failures = [name for name, ok, _ in results if not ok]
+        assert len(failures) > 0
+
+    def test_missing_file_returns_error(self, tmp_path: Path) -> None:
+        md_path = tmp_path / "NONEXISTENT.md"
+        results = validate_skill_md(md_path)
+        assert len(results) == 1
+        _, ok, _ = results[0]
+        assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# scaffold_skill (integration)
+# ---------------------------------------------------------------------------
+
+class TestScaffoldSkill:
+    def test_creates_expected_files(self, spec: dict, tmp_output: Path) -> None:
+        manifest = scaffold_skill(spec, tmp_output, dry_run=False, repo_root=None)
+        skill_dir = tmp_output / spec["name"]
+        assert (skill_dir / "SKILL.md").exists()
+        assert (skill_dir / f"{spec['name'].replace('-','_')}.py").exists()
+        assert (skill_dir / "tests" / f"test_{spec['name'].replace('-','_')}.py").exists()
+        assert (skill_dir / "examples" / "example_spec.json").exists()
+
+    def test_manifest_has_expected_keys(self, spec: dict, tmp_output: Path) -> None:
+        manifest = scaffold_skill(spec, tmp_output, dry_run=False, repo_root=None)
+        for key in ["skill", "output_dir", "files_written", "files_skipped", "generated_at"]:
+            assert key in manifest, f"Manifest missing key: {key}"
+
+    def test_dry_run_does_not_write_files(self, spec: dict, tmp_output: Path) -> None:
+        scaffold_skill(spec, tmp_output, dry_run=True, repo_root=None)
+        skill_dir = tmp_output / spec["name"]
+        assert not skill_dir.exists(), "dry-run should not write any files"
+
+    def test_idempotent_second_run_skips(self, spec: dict, tmp_output: Path) -> None:
+        scaffold_skill(spec, tmp_output, dry_run=False, repo_root=None)
+        manifest2 = scaffold_skill(spec, tmp_output, dry_run=False, repo_root=None)
+        assert len(manifest2["files_skipped"]) > 0, "Second run should skip already-existing files"
+
+
+# ---------------------------------------------------------------------------
+# load_spec
+# ---------------------------------------------------------------------------
+
+class TestLoadSpec:
+    def test_load_json(self, spec: dict, tmp_path: Path) -> None:
+        p = tmp_path / "spec.json"
+        p.write_text(json.dumps(spec), encoding="utf-8")
+        loaded = load_spec(p)
+        assert loaded["name"] == spec["name"]
+
+    def test_load_invalid_json_exits(self, tmp_path: Path) -> None:
+        p = tmp_path / "spec.json"
+        p.write_text("{bad json", encoding="utf-8")
+        with pytest.raises(SystemExit):
+            load_spec(p)
+
+
+# ---------------------------------------------------------------------------
+# Demo spec sanity checks
+# ---------------------------------------------------------------------------
+
+class TestDemoSpec:
+    def test_demo_spec_exists(self) -> None:
+        assert DEMO_SPEC_PATH.exists(), f"demo_spec.json not found at {DEMO_SPEC_PATH}"
+
+    def test_demo_spec_is_valid_json(self) -> None:
+        data = json.loads(DEMO_SPEC_PATH.read_text(encoding="utf-8"))
+        assert isinstance(data, dict)
+
+    def test_demo_spec_passes_validation(self, demo_spec: dict) -> None:
+        errors = validate_spec(demo_spec)
+        assert errors == [], f"demo_spec.json validation errors: {errors}"
+
+    def test_demo_spec_has_trigger_keywords(self, demo_spec: dict) -> None:
+        assert len(demo_spec.get("trigger_keywords", [])) > 0
+
+
+# ---------------------------------------------------------------------------
+# run_demo (end-to-end)
+# ---------------------------------------------------------------------------
+
+class TestRunDemo:
+    def test_demo_completes(self, tmp_output: Path) -> None:
+        """run_demo() should complete without raising an exception."""
+        run_demo(tmp_output, dry_run=False)
+
+    def test_demo_creates_skill_directory(self, tmp_output: Path) -> None:
+        run_demo(tmp_output, dry_run=False)
+        skill_name = json.loads(DEMO_SPEC_PATH.read_text())["name"]
+        assert (tmp_output / skill_name).is_dir()
+
+    def test_demo_creates_report_md(self, tmp_output: Path) -> None:
+        run_demo(tmp_output, dry_run=False)
+        assert (tmp_output / "report.md").exists()
+
+    def test_demo_creates_result_json(self, tmp_output: Path) -> None:
+        run_demo(tmp_output, dry_run=False)
+        result_file = tmp_output / "result.json"
+        assert result_file.exists()
+        data = json.loads(result_file.read_text())
+        assert isinstance(data, dict)
+
+    def test_demo_creates_reproducibility_bundle(self, tmp_output: Path) -> None:
+        run_demo(tmp_output, dry_run=False)
+        repro = tmp_output / "reproducibility"
+        assert (repro / "commands.sh").exists()
+
+    def test_demo_dry_run_no_files(self, tmp_output: Path) -> None:
+        run_demo(tmp_output, dry_run=True)
+        skill_name = json.loads(DEMO_SPEC_PATH.read_text())["name"]
+        assert not (tmp_output / skill_name).exists(), "dry-run should not create files"
+
+
+# ---------------------------------------------------------------------------
+# _Jump
+# ---------------------------------------------------------------------------
+
+class TestJump:
+    def test_raise_and_catch(self) -> None:
+        with pytest.raises(_Jump):
+            raise _Jump(3)
+
+    def test_target_attribute(self) -> None:
+        j = _Jump(5)
+        assert j.target == 5
+
+    def test_zero_target(self) -> None:
+        j = _Jump(0)
+        assert j.target == 0
+
+    def test_is_exception_subclass(self) -> None:
+        assert issubclass(_Jump, Exception)
+
+
+# ---------------------------------------------------------------------------
+# _save_draft / _load_draft / _clear_draft
+# ---------------------------------------------------------------------------
+
+class TestDraft:
+    @pytest.fixture(autouse=True)
+    def _patch_draft_path(self, tmp_path: Path, monkeypatch) -> None:
+        """Redirect DRAFT_SPEC_PATH to a temp file for every test in this class."""
+        monkeypatch.setattr(_sb, "DRAFT_SPEC_PATH", tmp_path / "draft.json")
+
+    def test_save_and_load_roundtrip(self, spec: dict) -> None:
+        _save_draft(spec)
+        loaded = _load_draft()
+        assert loaded == spec
+
+    def test_load_returns_none_when_no_file(self) -> None:
+        result = _load_draft()
+        assert result is None
+
+    def test_save_creates_file(self, spec: dict) -> None:
+        _save_draft(spec)
+        assert _sb.DRAFT_SPEC_PATH.exists()
+
+    def test_clear_removes_file(self, spec: dict) -> None:
+        _save_draft(spec)
+        assert _sb.DRAFT_SPEC_PATH.exists()
+        _clear_draft()
+        assert not _sb.DRAFT_SPEC_PATH.exists()
+
+    def test_clear_is_safe_when_no_file(self) -> None:
+        _clear_draft()  # must not raise
+
+    def test_saved_draft_is_valid_json(self, spec: dict) -> None:
+        _save_draft(spec)
+        raw = _sb.DRAFT_SPEC_PATH.read_text(encoding="utf-8")
+        assert json.loads(raw) == spec
+
+
+# ---------------------------------------------------------------------------
+# _find_resume_cursor
+# ---------------------------------------------------------------------------
+
+class TestFindResumeCursor:
+    def test_empty_spec_returns_zero(self) -> None:
+        assert _find_resume_cursor({}) == 0
+
+    def test_name_missing_returns_zero(self) -> None:
+        assert _find_resume_cursor({"description": "foo"}) == 0
+
+    def test_name_filled_description_missing_returns_one(self) -> None:
+        assert _find_resume_cursor({"name": "foo"}) == 1
+
+    def test_name_description_filled_author_missing_returns_two(self) -> None:
+        assert _find_resume_cursor({"name": "foo", "description": "bar"}) == 2
+
+    def test_all_str_required_filled_no_lists_returns_five(self) -> None:
+        # name(0), description(1), author(2) filled → next required check is capabilities(5, list)
+        s = {"name": "foo", "description": "bar", "author": "baz"}
+        assert _find_resume_cursor(s) == 5
+
+    def test_capabilities_empty_returns_five(self) -> None:
+        s = {"name": "foo", "description": "bar", "author": "baz", "capabilities": []}
+        assert _find_resume_cursor(s) == 5
+
+    def test_all_required_fields_filled_returns_num_fields(self) -> None:
+        s = {
+            "name": "foo",
+            "description": "bar",
+            "author": "baz",
+            "capabilities": ["cap1"],
+            "trigger_keywords": ["kw"],
+            "tags": ["t"],
+        }
+        assert _find_resume_cursor(s) == _NUM_FIELDS
+
+    def test_num_fields_is_ten(self) -> None:
+        assert _NUM_FIELDS == 10
+
+
+# ---------------------------------------------------------------------------
+# _ask
+# ---------------------------------------------------------------------------
+
+class TestAsk:
+    def test_returns_typed_value(self, monkeypatch) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "hello")
+        assert _ask("Label") == "hello"
+
+    def test_default_used_on_empty_input(self, monkeypatch) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "")
+        assert _ask("Label", default="fallback") == "fallback"
+
+    def test_required_rejects_empty_then_accepts_value(self, monkeypatch) -> None:
+        responses = iter(["", "valid"])
+        monkeypatch.setattr("builtins.input", lambda _: next(responses))
+        assert _ask("Label", required=True) == "valid"
+
+    def test_back_raises_jump_with_target_zero(self, monkeypatch) -> None:
+        # field_num=1 → max(0, 1-2) = 0
+        monkeypatch.setattr("builtins.input", lambda _: "!back")
+        with pytest.raises(_Jump) as exc:
+            _ask("Label", field_num=1)
+        assert exc.value.target == 0
+
+    def test_numeric_jump_raises_jump(self, monkeypatch) -> None:
+        # !3 → target = 3-1 = 2
+        monkeypatch.setattr("builtins.input", lambda _: "!3")
+        with pytest.raises(_Jump) as exc:
+            _ask("Label", field_num=1)
+        assert exc.value.target == 2
+
+    def test_out_of_range_jump_loops_then_returns(self, monkeypatch) -> None:
+        # !99 is out of range → error printed, loop continues; next returns "ok"
+        responses = iter(["!99", "ok"])
+        monkeypatch.setattr("builtins.input", lambda _: next(responses))
+        assert _ask("Label", field_num=1) == "ok"
+
+    def test_unknown_bang_command_loops(self, monkeypatch) -> None:
+        responses = iter(["!notacommand", "ok"])
+        monkeypatch.setattr("builtins.input", lambda _: next(responses))
+        assert _ask("Label") == "ok"
+
+
+# ---------------------------------------------------------------------------
+# _ask_list
+# ---------------------------------------------------------------------------
+
+class TestAskList:
+    def test_collects_items_until_blank(self, monkeypatch) -> None:
+        responses = iter(["alpha", "beta", ""])
+        monkeypatch.setattr("builtins.input", lambda _: next(responses))
+        result = _ask_list("Items", field_num=1)
+        assert result == ["alpha", "beta"]
+
+    def test_empty_input_returns_empty_list(self, monkeypatch) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "")
+        assert _ask_list("Items") == []
+
+    def test_back_raises_jump(self, monkeypatch) -> None:
+        # field_num=1 → max(0, 1-2) = 0
+        monkeypatch.setattr("builtins.input", lambda _: "!back")
+        with pytest.raises(_Jump) as exc:
+            _ask_list("Items", field_num=1)
+        assert exc.value.target == 0
+
+    def test_numeric_jump_raises_jump(self, monkeypatch) -> None:
+        # !4 → target = 4-1 = 3
+        monkeypatch.setattr("builtins.input", lambda _: "!4")
+        with pytest.raises(_Jump) as exc:
+            _ask_list("Items", field_num=2)
+        assert exc.value.target == 3
+
+    def test_single_item_list(self, monkeypatch) -> None:
+        responses = iter(["only-item", ""])
+        monkeypatch.setattr("builtins.input", lambda _: next(responses))
+        assert _ask_list("Items") == ["only-item"]
+
+
+# ---------------------------------------------------------------------------
+# _prompt_field
+# ---------------------------------------------------------------------------
+
+class TestPromptField:
+    def test_deps_raw_parsed_into_dependencies_required(self, spec: dict, monkeypatch) -> None:
+        # Index 8 = _deps_raw (str kind) → stored into spec["dependencies"]["required"]
+        monkeypatch.setattr("builtins.input", lambda _: "pysam>=0.22, biopython")
+        result = _prompt_field(spec, 8)
+        assert result["dependencies"]["required"] == ["pysam>=0.22", "biopython"]
+
+    def test_deps_raw_empty_gives_empty_required_list(self, spec: dict, monkeypatch) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "")
+        result = _prompt_field(spec, 8)
+        assert result["dependencies"]["required"] == []
+
+    def test_chaining_partners_parsed_into_list(self, spec: dict, monkeypatch) -> None:
+        # Index 9 = chaining_partners (str kind) → stored as list
+        monkeypatch.setattr("builtins.input", lambda _: "fastqc, multiqc")
+        result = _prompt_field(spec, 9)
+        assert result["chaining_partners"] == ["fastqc", "multiqc"]
+
+    def test_chaining_partners_empty_gives_empty_list(self, spec: dict, monkeypatch) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "")
+        result = _prompt_field(spec, 9)
+        assert result["chaining_partners"] == []
+
+    def test_deps_raw_preserves_optional_deps(self, spec: dict, monkeypatch) -> None:
+        spec["dependencies"] = {"required": [], "optional": ["matplotlib"]}
+        monkeypatch.setattr("builtins.input", lambda _: "numpy")
+        result = _prompt_field(spec, 8)
+        assert result["dependencies"]["optional"] == ["matplotlib"]
+        assert result["dependencies"]["required"] == ["numpy"]
+
+
+# ---------------------------------------------------------------------------
+# _run_review_loop
+# ---------------------------------------------------------------------------
+
+class TestRunReviewLoop:
+    @pytest.fixture(autouse=True)
+    def _patch_draft_path(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr(_sb, "DRAFT_SPEC_PATH", tmp_path / "draft.json")
+
+    def test_y_confirms_and_returns_spec(self, spec: dict, monkeypatch) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "Y")
+        result = _run_review_loop(spec)
+        assert result["name"] == spec["name"]
+
+    def test_empty_input_confirms(self, spec: dict, monkeypatch) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "")
+        result = _run_review_loop(spec)
+        assert result["name"] == spec["name"]
+
+    def test_yes_string_confirms(self, spec: dict, monkeypatch) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "yes")
+        result = _run_review_loop(spec)
+        assert result["name"] == spec["name"]
+
+    def test_n_aborts_with_sys_exit_zero(self, spec: dict, monkeypatch) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "n")
+        with pytest.raises(SystemExit) as exc_info:
+            _run_review_loop(spec)
+        assert exc_info.value.code == 0
+
+    def test_abort_keyword_exits(self, spec: dict, monkeypatch) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "abort")
+        with pytest.raises(SystemExit) as exc_info:
+            _run_review_loop(spec)
+        assert exc_info.value.code == 0
+
+    def test_invalid_choice_loops_then_confirm(self, spec: dict, monkeypatch) -> None:
+        responses = iter(["what?", "Y"])
+        monkeypatch.setattr("builtins.input", lambda _: next(responses))
+        result = _run_review_loop(spec)
+        assert result["name"] == spec["name"]
+
+    def test_field_number_re_prompts_then_confirm(self, spec: dict, monkeypatch) -> None:
+        # "1" → edit field 0 (name) → type new name → "Y" → return updated spec
+        responses = iter(["1", "new-name", "Y"])
+        monkeypatch.setattr("builtins.input", lambda _: next(responses))
+        result = _run_review_loop(spec)
+        assert result["name"] == "new-name"
+
+
+# ---------------------------------------------------------------------------
+# scaffold_skill — edit mode (ask_overwrite=True)
+# ---------------------------------------------------------------------------
+
+class TestScaffoldSkillEditMode:
+    def test_overwrite_yes_updates_all_files(self, spec: dict, tmp_path: Path, monkeypatch) -> None:
+        output = tmp_path / "out"
+        # First run: create files fresh
+        scaffold_skill(spec, output, dry_run=False, repo_root=None)
+        # Second run with ask_overwrite=True, answer "y" to all overwrite prompts
+        monkeypatch.setattr("builtins.input", lambda _: "y")
+        manifest = scaffold_skill(spec, output, dry_run=False, repo_root=None, ask_overwrite=True)
+        # SKILL.md, .py, test_.py all "updated"; example_spec.json force-refreshed → 4 files
+        assert len(manifest["files_skipped"]) == 0
+        assert any("SKILL.md" in f for f in manifest["files_written"])
+
+    def test_overwrite_no_skips_existing_files(self, spec: dict, tmp_path: Path, monkeypatch) -> None:
+        output = tmp_path / "out"
+        scaffold_skill(spec, output, dry_run=False, repo_root=None)
+        # Answer "n" to all overwrite prompts
+        monkeypatch.setattr("builtins.input", lambda _: "n")
+        manifest = scaffold_skill(spec, output, dry_run=False, repo_root=None, ask_overwrite=True)
+        # SKILL.md, .py, test_.py all skipped
+        assert len(manifest["files_skipped"]) == 3
+        # example_spec.json is always force-refreshed (no prompt, always written)
+        assert any("example_spec.json" in f for f in manifest["files_written"])
+
+    def test_example_spec_content_is_current_spec(self, spec: dict, tmp_path: Path, monkeypatch) -> None:
+        output = tmp_path / "out"
+        scaffold_skill(spec, output, dry_run=False, repo_root=None)
+        # Mutate the spec and run in edit mode
+        spec["description"] = "Updated description for edit test"
+        monkeypatch.setattr("builtins.input", lambda _: "n")
+        scaffold_skill(spec, output, dry_run=False, repo_root=None, ask_overwrite=True)
+        example_path = output / spec["name"] / "examples" / "example_spec.json"
+        content = json.loads(example_path.read_text(encoding="utf-8"))
+        assert content["description"] == "Updated description for edit test"
+
+
+# ---------------------------------------------------------------------------
+# Agent mode tests
+# ---------------------------------------------------------------------------
+
+# Paths used by all agent tests — use sys.executable so the path is always
+# valid on whatever OS/environment pytest is running under.
+_PYTHON = sys.executable
+_SKILL_BUILDER_PY = str(Path(__file__).resolve().parent.parent / "skill_builder.py")
+
+_AGENT_SPEC = {
+    "name": "agent-test-skill",
+    "description": "A skill created by the agent mode test suite",
+    "author": "Test Author",
+    "version": "0.1.0",
+    "domain": "genomics",
+    "cli_alias": "agenttest",
+    "tags": ["agent", "test"],
+    "trigger_keywords": ["agent test", "run agent"],
+    "capabilities": ["Do something via agent", "Do something else via agent"],
+    "input_formats": [],
+    "dependencies": {"required": [], "optional": []},
+    "chaining_partners": [],
+}
+
+
+@pytest.fixture
+def agent_spec_file(tmp_path: Path) -> Path:
+    """Write the agent spec to a temp JSON file and return the path."""
+    spec_path = tmp_path / "agent_spec.json"
+    spec_path.write_text(json.dumps(_AGENT_SPEC), encoding="utf-8")
+    return spec_path
+
+
+class TestAgentMode:
+    """End-to-end tests for --agent mode via subprocess (full CLI path)."""
+
+    def _run(self, args: list[str], *, input_text: str | None = None, tmp_path: Path) -> subprocess.CompletedProcess:
+        """Helper: run skill_builder.py with the given extra args and capture output."""
+        cmd = [_PYTHON, _SKILL_BUILDER_PY] + args + ["--output", str(tmp_path / "out")]
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            input=input_text,
+        )
+
+    def test_agent_valid_spec_exits_zero(self, agent_spec_file: Path, tmp_path: Path) -> None:
+        result = self._run(["--agent", "--input", str(agent_spec_file)], tmp_path=tmp_path)
+        assert result.returncode == 0, f"Expected exit 0, got {result.returncode}.\nstderr: {result.stderr}"
+
+    def test_agent_stdout_is_valid_json(self, agent_spec_file: Path, tmp_path: Path) -> None:
+        result = self._run(["--agent", "--input", str(agent_spec_file)], tmp_path=tmp_path)
+        try:
+            data = json.loads(result.stdout)
+            assert isinstance(data, dict)
+        except json.JSONDecodeError as exc:
+            pytest.fail(f"stdout was not valid JSON: {exc}\nstdout: {result.stdout!r}")
+
+    def test_agent_status_ok(self, agent_spec_file: Path, tmp_path: Path) -> None:
+        result = self._run(["--agent", "--input", str(agent_spec_file)], tmp_path=tmp_path)
+        data = json.loads(result.stdout)
+        assert data["status"] == "ok", f"Expected status 'ok', got: {data.get('status')!r}"
+
+    def test_agent_manifest_keys(self, agent_spec_file: Path, tmp_path: Path) -> None:
+        result = self._run(["--agent", "--input", str(agent_spec_file)], tmp_path=tmp_path)
+        data = json.loads(result.stdout)
+        required_keys = {"skill", "output_dir", "files_written", "files_skipped", "validation", "generated_at"}
+        missing = required_keys - data.keys()
+        assert not missing, f"Manifest missing keys: {missing}"
+
+    def test_agent_validation_all_pass(self, agent_spec_file: Path, tmp_path: Path) -> None:
+        result = self._run(["--agent", "--input", str(agent_spec_file)], tmp_path=tmp_path)
+        data = json.loads(result.stdout)
+        val = data["validation"]
+        assert val["failed"] == 0, f"Expected 0 failures, got: {val['failures']}"
+        assert val["passed"] == 13, f"Expected 13 passed, got: {val['passed']}"
+
+    def test_agent_invalid_spec_exits_nonzero(self, tmp_path: Path) -> None:
+        # Spec missing required 'name' field
+        bad_spec = {k: v for k, v in _AGENT_SPEC.items() if k != "name"}
+        bad_spec_file = tmp_path / "bad_spec.json"
+        bad_spec_file.write_text(json.dumps(bad_spec), encoding="utf-8")
+        result = self._run(["--agent", "--input", str(bad_spec_file)], tmp_path=tmp_path)
+        assert result.returncode != 0, "Expected non-zero exit for invalid spec"
+        data = json.loads(result.stdout)
+        assert data["status"] == "error", f"Expected status 'error', got: {data.get('status')!r}"
+        assert len(data["errors"]) > 0, "Expected at least one error message"
+
+    def test_agent_dry_run_includes_generated_content(self, agent_spec_file: Path, tmp_path: Path) -> None:
+        result = self._run(["--agent", "--dry-run", "--input", str(agent_spec_file)], tmp_path=tmp_path)
+        assert result.returncode == 0, f"Exit {result.returncode}.\nstderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert data.get("dry_run") is True, "Expected dry_run=true in manifest"
+        assert "generated_content" in data, "Expected 'generated_content' key in dry-run manifest"
+        script_name = _AGENT_SPEC["name"].replace("-", "_")
+        expected_keys = {
+            "SKILL.md",
+            f"{script_name}.py",
+            f"tests/test_{script_name}.py",
+            "examples/example_spec.json",
+        }
+        missing = expected_keys - data["generated_content"].keys()
+        assert not missing, f"generated_content missing keys: {missing}"
+        # No files should be written to disk in dry-run mode
+        skill_dir = tmp_path / "out" / _AGENT_SPEC["name"]
+        assert not skill_dir.exists(), f"skill_dir should not exist in dry-run, but found: {skill_dir}"
+
+    def test_agent_stdin_pipe(self, tmp_path: Path) -> None:
+        spec_json = json.dumps(_AGENT_SPEC)
+        result = self._run(["--agent", "--input", "-"], input_text=spec_json, tmp_path=tmp_path)
+        assert result.returncode == 0, f"Exit {result.returncode}.\nstderr: {result.stderr}"
+        data = json.loads(result.stdout)
+        assert data["status"] == "ok", f"Expected status 'ok', got: {data.get('status')!r}"


### PR DESCRIPTION
## Summary

Adds the `skill-builder` skill — a meta developer tool that scaffolds new ClawBio skills from a JSON/YAML spec or interactively.

### What it does
- Generates `SKILL.md`, Python skeleton, pytest test suite, `demo_spec.json`, and `templates/spec_template.json` for any new skill
- Supports `--interactive` mode, `--agent` mode (structured JSON output for AI agents), `--dry-run`, `--edit` (post-generation SKILL.md editing), and `--validate-only`
- Auto-registers the new skill in `skills/catalog.json` and `clawbio.py` on creation
- 110 tests passing (102 unit + 8 agent-mode integration tests)

### Files changed
| File | Change |
|---|---|
| `skills/skill-builder/SKILL.md` | New — skill spec, 13/13 validation |
| `skills/skill-builder/skill_builder.py` | New — main implementation |
| `skills/skill-builder/demo_spec.json` | New — demo spec for `--demo` mode |
| `skills/skill-builder/templates/spec_template.json` | New — blank spec template |
| `skills/skill-builder/tests/test_skill_builder.py` | New — 110 pytest tests |
| `skills/catalog.json` | Modified — added entry, `skill_count` 28 → 29 |
| `clawbio.py` | Modified — added `"skill-builder"` to `SKILLS` dict |

### Author
Mj

### Hackathon submission
Built for the ClawBio hackathon.