### PR TITLE
 feat: add protocols.io skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,11 @@ When the user asks a question, match it to a skill and act:
 | UK Biobank, UKB fields, "what UKB variables measure X", biobank schema search, UKB field lookup, data showcase | `skills/ukb-navigator/` | Run `ukb_navigator.py` |
 | Galaxy, usegalaxy, tool shed, bioblend, "run on galaxy", galaxy tool, galaxy workflow, NGS pipeline | `skills/galaxy-bridge/` | Run `galaxy_bridge.py` |
 | Bulk RNA-seq, pseudo-bulk, differential expression, DESeq2, PyDESeq2, contrast, volcano plot | `skills/rnaseq-de/` | Run `rnaseq_de.py` |
+| protocols.io, protocol search, lab protocol, scientific methods, protocol DOI, protocol steps | `skills/protocols-io/` | Run `protocols_io.py` |
 
 ## How to Use a Skill
 
-### Skills with Python scripts (pharmgx-reporter, equity-scorer, nutrigx_advisor, scrna-orchestrator, bio-orchestrator, clinpgx, gwas-prs, gwas-lookup, profile-report, ukb-navigator, galaxy-bridge, rnaseq-de, methylation-clock)
+### Skills with Python scripts (pharmgx-reporter, equity-scorer, nutrigx_advisor, scrna-orchestrator, bio-orchestrator, clinpgx, gwas-prs, gwas-lookup, profile-report, ukb-navigator, galaxy-bridge, rnaseq-de, methylation-clock, protocols-io)
 1. Read the skill's `SKILL.md` for domain context
 2. Run the Python script with correct CLI arguments (see below)
 3. Show the user the output — open any generated figures and explain results
@@ -125,6 +126,13 @@ python skills/bio-orchestrator/orchestrator.py \
 python skills/rnaseq-de/rnaseq_de.py \
   --counts <counts_csv_or_tsv> --metadata <metadata_csv_or_tsv> \
   --formula "~ batch + condition" --contrast "condition,treated,control" --output <report_dir>
+
+# Protocols.io bridge — search, retrieve, authenticate
+python skills/protocols-io/protocols_io.py --login
+python skills/protocols-io/protocols_io.py --search "CRISPR gene editing"
+python skills/protocols-io/protocols_io.py --protocol <id_or_uri_or_doi>
+python skills/protocols-io/protocols_io.py --steps <id_or_uri>
+python skills/protocols-io/protocols_io.py --demo
 ```
 
 ## Demo Data
@@ -150,6 +158,7 @@ For instant demos when the user has no data:
 | Profile report demo (full 4-skill profile) | `--demo` flag | profile-report |
 | UKB Navigator demo (blood pressure, pre-cached) | `--demo` flag | ukb-navigator |
 | Galaxy Bridge demo (FastQC, offline) | `--demo` flag | galaxy-bridge |
+| Protocols.io demo (RNA extraction, pre-cached) | `--demo` flag | protocols-io |
 
 ### Demo Commands
 
@@ -204,6 +213,12 @@ python skills/bio-orchestrator/orchestrator.py --list-skills
 
 # RNA-seq DE demo
 python skills/rnaseq-de/rnaseq_de.py --demo --output /tmp/rnaseq_de_demo
+
+# Protocols.io demo
+python skills/protocols-io/protocols_io.py --demo
+
+# Protocols.io search
+python skills/protocols-io/protocols_io.py --search "RNA extraction"
 ```
 
 ## Contributing — New Skill Workflow

--- a/clawbio.py
+++ b/clawbio.py
@@ -473,6 +473,23 @@ SKILLS = {
         },
         "accepts_genotypes": False,
     },
+    "protocols-io": {
+        "script": SKILLS_DIR / "protocols-io" / "protocols_io.py",
+        "demo_args": ["--demo"],
+        "description": "protocols.io bridge — search, browse, and retrieve scientific protocols via REST API",
+        "allowed_extra_flags": {
+            "--login",
+            "--search",
+            "--protocol",
+            "--steps",
+            "--dump",
+            "--page-size",
+            "--page",
+            "--filter",
+        },
+        "no_input_required": True,
+        "accepts_genotypes": False,
+    },
 }
 
 # Skills that run in the full-profile pipeline (order matters)

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,5 +18,6 @@ testpaths =
     skills/illumina-bridge/tests
     skills/rnaseq-de/tests
     skills/methylation-clock/tests
+    skills/protocols-io/tests
 python_files = test_*.py
 python_functions = test_*

--- a/skills/protocols-io/SKILL.md
+++ b/skills/protocols-io/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: protocols-io
+description: >-
+  Search, browse, and retrieve scientific protocols from protocols.io via REST API.
+  Client token authentication for private protocols. Use when user mentions protocols.io,
+  lab protocols, DOI lookup, protocol search, protocol steps, or scientific methods.
+version: 0.2.0
+author: ClawBio Contributors
+license: MIT
+tags: [protocols, lab-methods, reproducibility, protocols-io, scientific-methods, DOI]
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - python3
+      env: []
+      config: []
+    always: false
+    emoji: "🧪"
+    homepage: https://www.protocols.io
+    os: [darwin, linux]
+    install:
+      - kind: pip
+        package: requests
+        bins: []
+    trigger_keywords:
+      - protocols.io
+      - protocol search
+      - lab protocol
+      - scientific protocol
+      - protocol steps
+      - protocol DOI
+      - methods repository
+---
+
+# 🧪 Protocols.io Bridge
+
+You are **Protocols.io Bridge**, a specialised ClawBio agent for discovering and retrieving scientific protocols from [protocols.io](https://www.protocols.io). Your role is to search, browse, and fetch full protocol details — including steps, reagents, and metadata — via the protocols.io REST API.
+
+## Why This Exists
+
+- **Without it**: Users must manually browse protocols.io, copy-paste steps, and cannot programmatically access their private protocols
+- **With it**: Search 200,000+ published protocols by keyword, retrieve full step-by-step methods, and access private/shared protocols — all from the CLI
+- **Why ClawBio**: Grounded in the real protocols.io API v3/v4; protocols have DOIs and version history for reproducibility
+
+## Core Capabilities
+
+1. **Client token authentication** — Paste your access token from protocols.io/developers; it is verified and saved locally for reuse
+2. **Protocol search** — Search public (and private, when authenticated) protocols by keyword with pagination and sorting
+3. **Protocol retrieval** — Fetch full protocol details including steps, reagents, materials, authors, and DOI
+4. **Step extraction** — Retrieve protocol steps in markdown format for immediate use
+5. **Demo mode** — Pre-cached search results for offline demonstration
+
+## Input Formats
+
+| Format | Extension | Required Fields | Example |
+|--------|-----------|----------------|---------|
+| Search query | CLI arg | `--search <keywords>` | `--search "RNA extraction"` |
+| Protocol ID | CLI arg | `--protocol <id_or_uri>` | `--protocol 30756` |
+| DOI | CLI arg | `--protocol <doi>` | `--protocol "10.17504/protocols.io.baaciaaw"` |
+
+## Workflow
+
+When the user asks about scientific protocols or protocols.io:
+
+1. **Authenticate** (if needed): Check for saved token; if absent or expired, prompt user to paste one
+2. **Search/Retrieve**: Execute the requested operation against the protocols.io API
+3. **Format**: Render results as a markdown report with protocol metadata, steps, and reagents
+4. **Output**: Print to terminal, optionally save as markdown with `--dump`
+
+## CLI Reference
+
+```bash
+# Authenticate (paste your access token, one-time setup)
+python skills/protocols-io/protocols_io.py --login
+
+# Search protocols by keyword
+python skills/protocols-io/protocols_io.py --search "CRISPR gene editing"
+
+# Retrieve a protocol by ID, URI, or DOI
+python skills/protocols-io/protocols_io.py --protocol 30756
+
+# Get protocol steps only
+python skills/protocols-io/protocols_io.py --steps 30756
+
+# Save output as markdown file
+python skills/protocols-io/protocols_io.py --search "RNA extraction" --dump
+
+# Demo mode (offline, pre-cached)
+python skills/protocols-io/protocols_io.py --demo
+
+# Via ClawBio runner
+python clawbio.py run protocols-io --demo
+python clawbio.py run protocols-io --search "RNA extraction"
+```
+
+## Authentication
+
+1. Go to [protocols.io/developers](https://www.protocols.io/developers)
+2. Log in, find **Your Applications**, and copy your **Access Token**
+3. Run `python skills/protocols-io/protocols_io.py --login` and paste the token
+4. Done — token is saved to `~/.clawbio/protocols_io_tokens.json`
+
+If you skip `--login` and go straight to `--search`, you'll be prompted to paste a token inline.
+
+**Token resolution order**: `PROTOCOLS_IO_ACCESS_TOKEN` env var > saved tokens file > interactive prompt.
+
+## Demo
+
+```bash
+python skills/protocols-io/protocols_io.py --demo
+```
+
+Expected output: a search results report for "RNA extraction" with 5 pre-cached protocol summaries, plus full detail for one protocol including steps and reagents.
+
+## Algorithm / Methodology
+
+1. **Token management**: Load token from `~/.clawbio/protocols_io_tokens.json`; if expired (status 1219), prompt user to run `--login` again
+2. **Search**: `GET /api/v3/protocols?filter=public&key=<query>&order_field=relevance&page_size=10` — parse paginated results
+3. **Retrieve**: `GET /api/v4/protocols/<id>?content_format=markdown` — returns full protocol with steps rendered as markdown
+4. **Steps**: `GET /api/v4/protocols/<id>/steps?content_format=markdown` — returns ordered step list
+
+**Rate limits**: 100 requests/minute per user; over the limit the API returns HTTP 429. This client applies a sliding-window throttle and retries on 429 using `Retry-After` (capped, up to 3 retries). The `/view/[protocol-uri].pdf` endpoint is stricter (5/min signed-in, 3/min signed-out by IP); this skill does not use PDF export.
+
+## Example Queries
+
+- "Search protocols.io for RNA extraction protocols"
+- "Show me the steps for protocol 30756"
+- "Find CRISPR protocols on protocols.io"
+- "Get the protocol with DOI 10.17504/protocols.io.baaciaaw"
+- "Log in to protocols.io to access my private protocols"
+
+## Output Structure
+
+Output is printed to the terminal. With `--dump`, a markdown file is saved to the current directory with an auto-generated filename based on the query or protocol title.
+
+## Dependencies
+
+**Required** (in `requirements.txt`):
+- `requests` >= 2.28 — HTTP client for API calls
+
+**Optional**:
+- A protocols.io developer account for private protocol access (public search works without it)
+
+## Safety
+
+- **Local-first**: Tokens stored locally at `~/.clawbio/protocols_io_tokens.json`; no data uploaded
+- **Disclaimer**: Every report includes the ClawBio medical disclaimer
+- **No credential leakage**: Client secret and tokens never appear in reports or logs
+- **Read-only by default**: The skill only reads protocols; no create/edit/delete operations
+- **Rate-limit aware**: Client-side 100 req/min sliding window; automatic back-off on HTTP 429
+
+## Integration with Bio Orchestrator
+
+**Trigger conditions** — the orchestrator routes here when:
+- User mentions "protocols.io", "protocol search", "lab protocol", "scientific protocol", "DOI lookup"
+- User provides a protocols.io URL or DOI
+
+**Chaining partners**:
+- `lit-synthesizer`: Cross-reference protocol citations with PubMed literature
+- `labstep`: Import protocols.io methods into Labstep experiments
+- `repro-enforcer`: Verify reproducibility of protocols.io methods
+
+## Citations
+
+- [protocols.io](https://www.protocols.io) — Open access repository for scientific methods
+- [protocols.io API v3 Documentation](https://apidocs.protocols.io/) — REST API reference
+- Teytelman et al. (2016) "protocols.io: Virtual Communities for Protocol Development and Discussion" *PLOS Biology*

--- a/skills/protocols-io/demo/demo_protocol.json
+++ b/skills/protocols-io/demo/demo_protocol.json
@@ -1,0 +1,43 @@
+{
+  "payload": {
+    "id": 12001,
+    "title": "Total RNA Extraction from Tissue (TRIzol)",
+    "uri": "total-rna-extraction-trizol-demo",
+    "doi": "dx.doi.org/10.17504/protocols.io.demo1",
+    "published_on": 1600000000,
+    "created_on": 1599000000,
+    "public": true,
+    "creator": {"name": "Demo Researcher", "username": "demo-researcher"},
+    "authors": [
+      {"name": "Demo Researcher", "affiliation": "ClawBio University"}
+    ],
+    "description": "A standard TRIzol-based total RNA extraction protocol suitable for most tissue types. Yields high-quality RNA for downstream RT-qPCR, RNA-seq, and microarray analysis.",
+    "guidelines": "Work in an RNase-free environment. Use filter tips throughout.",
+    "before_start": "Pre-chill centrifuge to 4\u00b0C. Prepare 75% ethanol with DEPC-treated water.",
+    "warning": "TRIzol contains phenol and guanidine isothiocyanate \u2014 use in a fume hood.",
+    "materials": [
+      {"name": "TRIzol Reagent", "vendor": {"name": "Thermo Fisher"}, "sku": "15596026"},
+      {"name": "Chloroform", "vendor": {"name": "Sigma-Aldrich"}, "sku": "C2432"},
+      {"name": "Isopropanol", "vendor": {"name": "Sigma-Aldrich"}, "sku": "I9516"},
+      {"name": "75% Ethanol (DEPC-treated)", "vendor": {"name": "In-house"}, "sku": ""},
+      {"name": "DEPC-treated water", "vendor": {"name": "Thermo Fisher"}, "sku": "AM9920"}
+    ],
+    "stats": {
+      "number_of_views": 4520,
+      "number_of_steps": 8,
+      "number_of_exports": 312,
+      "number_of_votes": 18
+    },
+    "steps": [
+      {"step": "Homogenise 50\u2013100 mg tissue in 1 mL TRIzol Reagent using a tissue homogeniser. Pipette up and down until fully lysed."},
+      {"step": "Incubate homogenate at room temperature for 5 minutes to permit complete dissociation of nucleoprotein complexes."},
+      {"step": "Add 200 \u00b5L chloroform per 1 mL TRIzol. Cap securely and shake vigorously for 15 seconds. Incubate 2\u20133 minutes at RT."},
+      {"step": "Centrifuge at 12,000 \u00d7 g for 15 minutes at 4\u00b0C. The mixture separates into a lower red phenol-chloroform phase, an interphase, and a colourless upper aqueous phase containing RNA."},
+      {"step": "Transfer the aqueous phase (~500 \u00b5L) to a fresh RNase-free tube. Avoid disturbing the interphase."},
+      {"step": "Add 500 \u00b5L isopropanol. Mix by inversion and incubate 10 minutes at RT. Centrifuge 12,000 \u00d7 g for 10 minutes at 4\u00b0C. RNA pellet should be visible."},
+      {"step": "Discard supernatant. Wash pellet with 1 mL 75% ethanol. Vortex briefly, centrifuge 7,500 \u00d7 g for 5 minutes at 4\u00b0C. Repeat wash once."},
+      {"step": "Air-dry pellet for 5\u201310 minutes (do not over-dry). Resuspend in 30\u201350 \u00b5L DEPC-treated water. Incubate 55\u00b0C for 10 minutes to dissolve. Quantify by NanoDrop; expect A260/A280 \u2265 1.8."}
+    ]
+  },
+  "status_code": 0
+}

--- a/skills/protocols-io/demo/demo_search_results.json
+++ b/skills/protocols-io/demo/demo_search_results.json
@@ -1,0 +1,65 @@
+{
+  "items": [
+    {
+      "id": 30756,
+      "title": "Tree Mapping for Leaf Collection (Megantic Only)",
+      "uri": "tree-mapping-for-leaf-collection-megantic-only-baaciaaw",
+      "doi": "dx.doi.org/10.17504/protocols.io.baaciaaw",
+      "published_on": 1586383032,
+      "created_on": 1575912496,
+      "number_of_steps": 11,
+      "creator": {"name": "Vellend Cabo", "username": "vellend-cabo"},
+      "public": true
+    },
+    {
+      "id": 8503,
+      "title": "Gene calling with Prodigal",
+      "uri": "gene-calling-with-prodigal-kixcufn",
+      "doi": "dx.doi.org/10.17504/protocols.io.kixcufn",
+      "published_on": 1509493090,
+      "created_on": 1509493000,
+      "number_of_steps": 3,
+      "creator": {"name": "Matt Sullivan Lab", "username": "matt-sullivan"},
+      "public": true
+    },
+    {
+      "id": 872,
+      "title": "Lysis Buffer (20 mL)",
+      "uri": "lysis-buffer-20-ml-c4gytv",
+      "doi": "dx.doi.org/10.17504/protocols.io.c4gytv",
+      "published_on": 1487372466,
+      "created_on": 1434670606,
+      "number_of_steps": 3,
+      "creator": {"name": "Celina Gomez", "username": "celina-gomez"},
+      "public": true
+    },
+    {
+      "id": 12001,
+      "title": "Total RNA Extraction from Tissue (TRIzol)",
+      "uri": "total-rna-extraction-trizol-demo",
+      "doi": "dx.doi.org/10.17504/protocols.io.demo1",
+      "published_on": 1600000000,
+      "created_on": 1599000000,
+      "number_of_steps": 8,
+      "creator": {"name": "Demo Researcher", "username": "demo-researcher"},
+      "public": true
+    },
+    {
+      "id": 15002,
+      "title": "RNA Quality Assessment with Bioanalyzer",
+      "uri": "rna-quality-bioanalyzer-demo",
+      "doi": "dx.doi.org/10.17504/protocols.io.demo2",
+      "published_on": 1610000000,
+      "created_on": 1609000000,
+      "number_of_steps": 5,
+      "creator": {"name": "QC Specialist", "username": "qc-specialist"},
+      "public": true
+    }
+  ],
+  "pagination": {
+    "current_page": 1,
+    "total_pages": 1,
+    "total_results": 5,
+    "page_size": 10
+  }
+}

--- a/skills/protocols-io/protocols_io.py
+++ b/skills/protocols-io/protocols_io.py
@@ -1,0 +1,619 @@
+#!/usr/bin/env python3
+"""
+protocols_io.py — protocols.io bridge for ClawBio
+===================================================
+Search, browse, and retrieve scientific protocols from protocols.io
+via REST API with client token authentication.
+
+Usage:
+    python protocols_io.py --login
+    python protocols_io.py --search "RNA extraction"
+    python protocols_io.py --protocol 30756
+    python protocols_io.py --steps 30756
+    python protocols_io.py --demo
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import getpass
+import itertools
+import json
+import os
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    import requests
+except ImportError:
+    print("ERROR: requests not installed. Run: pip install requests", file=sys.stderr)
+    sys.exit(1)
+
+
+class Spinner:
+    """Animated terminal spinner that runs in a background thread."""
+
+    FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+
+    def __init__(self, message: str = ""):
+        self._message = message
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def _spin(self):
+        for frame in itertools.cycle(self.FRAMES):
+            if self._stop.is_set():
+                break
+            sys.stderr.write(f"\r  {frame} {self._message}")
+            sys.stderr.flush()
+            time.sleep(0.08)
+        sys.stderr.write(f"\r  ✓ {self._message}\n")
+        sys.stderr.flush()
+
+    def __enter__(self):
+        self._thread = threading.Thread(target=self._spin, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_):
+        self._stop.set()
+        if self._thread:
+            self._thread.join()
+
+SKILL_DIR = Path(__file__).resolve().parent
+DEMO_DIR = SKILL_DIR / "demo"
+CONFIG_DIR = Path.home() / ".clawbio"
+TOKEN_FILE = CONFIG_DIR / "protocols_io_tokens.json"
+
+API_V3 = "https://www.protocols.io/api/v3"
+API_V4 = "https://www.protocols.io/api/v4"
+RATE_LIMIT = 100  # requests per 60-second window (protocols.io API)
+RATE_WINDOW = 60.0
+MAX_RETRIES_429 = 3
+
+DISCLAIMER = (
+    "*ClawBio is a research and educational tool. It is not a medical device "
+    "and does not provide clinical diagnoses. Consult a healthcare professional "
+    "before making any medical decisions.*"
+)
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting (100 requests / minute; 429 retry with Retry-After)
+# ---------------------------------------------------------------------------
+
+
+class _RateLimiter:
+    """Thread-safe sliding-window limiter for outbound API GETs."""
+
+    def __init__(self, max_calls: int = RATE_LIMIT, window: float = RATE_WINDOW):
+        self._max = max_calls
+        self._window = window
+        self._timestamps: collections.deque[float] = collections.deque()
+        self._lock = threading.Lock()
+
+    def wait(self) -> None:
+        with self._lock:
+            now = time.monotonic()
+            while self._timestamps and self._timestamps[0] <= now - self._window:
+                self._timestamps.popleft()
+            if len(self._timestamps) >= self._max:
+                sleep_for = self._timestamps[0] - (now - self._window)
+                if sleep_for > 0:
+                    print(f"  Rate limit (client) — waiting {sleep_for:.1f}s", file=sys.stderr)
+                    time.sleep(sleep_for)
+            self._timestamps.append(time.monotonic())
+
+
+_rate_limiter = _RateLimiter()
+
+
+# ---------------------------------------------------------------------------
+# Token management
+# ---------------------------------------------------------------------------
+
+
+def load_tokens() -> dict | None:
+    """Load saved access token from disk."""
+    if TOKEN_FILE.exists():
+        try:
+            data = json.loads(TOKEN_FILE.read_text(encoding="utf-8"))
+            if data.get("access_token"):
+                return data
+        except (json.JSONDecodeError, KeyError):
+            pass
+    return None
+
+
+def save_tokens(tokens: dict) -> None:
+    """Persist access token to disk."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    tokens["saved_at"] = datetime.now(timezone.utc).isoformat()
+    TOKEN_FILE.write_text(json.dumps(tokens, indent=2), encoding="utf-8")
+    TOKEN_FILE.chmod(0o600)
+    print(f"  Token saved to {TOKEN_FILE}")
+
+
+def get_access_token() -> str | None:
+    """Resolve access token from env var or saved file."""
+    env_token = os.environ.get("PROTOCOLS_IO_ACCESS_TOKEN")
+    if env_token:
+        return env_token
+    tokens = load_tokens()
+    if tokens and tokens.get("access_token"):
+        return tokens["access_token"]
+    return None
+
+
+def token_login() -> str | None:
+    """
+    Login by pasting a client access token from protocols.io/developers.
+    Verifies the token against the API and saves it locally.
+    """
+    print("\n  Paste your access token from https://www.protocols.io/developers")
+    print("  (Log in → Your Applications → copy the 'Access Token')\n")
+    token = getpass.getpass("  Access Token: ").strip()
+
+    if not token:
+        print("ERROR: No token provided.", file=sys.stderr)
+        return None
+
+    print("  Verifying token...")
+    try:
+        resp = requests.get(
+            f"{API_V3}/session/profile",
+            headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+            timeout=30,
+        )
+        data = resp.json()
+    except Exception as e:
+        print(f"ERROR: Could not verify token: {e}", file=sys.stderr)
+        return None
+
+    if resp.status_code != 200 or data.get("status_code") != 0:
+        print(f"ERROR: Token rejected by protocols.io: {data.get('error_message', resp.text[:200])}", file=sys.stderr)
+        return None
+
+    save_tokens({"access_token": token, "token_type": "bearer"})
+    user = data.get("user", {})
+    print(f"  Logged in as: {user.get('name', 'unknown')} (@{user.get('username', '?')})")
+    return token
+
+
+# ---------------------------------------------------------------------------
+# API helpers
+# ---------------------------------------------------------------------------
+
+
+def _headers(token: str | None = None) -> dict:
+    """Build request headers with Bearer auth."""
+    t = token or get_access_token()
+    h = {"Accept": "application/json"}
+    if t:
+        h["Authorization"] = f"Bearer {t}"
+    return h
+
+
+def _api_get(url: str, params: dict | None = None, token: str | None = None) -> dict | None:
+    """GET with client-side rate limiting and 429 handling (Retry-After)."""
+    hdrs = _headers(token)
+
+    for attempt in range(1, MAX_RETRIES_429 + 1):
+        _rate_limiter.wait()
+
+        try:
+            resp = requests.get(url, headers=hdrs, params=params, timeout=30)
+        except requests.RequestException as e:
+            print(f"ERROR: Request failed: {e}", file=sys.stderr)
+            return None
+
+        if resp.status_code == 429:
+            try:
+                retry_after = int(resp.headers.get("Retry-After", "10"))
+            except (TypeError, ValueError):
+                retry_after = 10
+            retry_after = max(1, min(retry_after, 120))
+            print(
+                f"  HTTP 429 Too Many Requests — retry in {retry_after}s "
+                f"({attempt}/{MAX_RETRIES_429})",
+                file=sys.stderr,
+            )
+            time.sleep(retry_after)
+            continue
+
+        try:
+            data = resp.json()
+        except (ValueError, requests.exceptions.JSONDecodeError):
+            print(f"ERROR: Non-JSON response (HTTP {resp.status_code}): {resp.text[:200]}", file=sys.stderr)
+            return None
+
+        if data.get("status_code") == 1219:
+            print("ERROR: Token expired. Run --login again to paste a new token.", file=sys.stderr)
+            return None
+
+        if resp.status_code != 200:
+            msg = data.get("error_message", resp.text[:200]) if isinstance(data, dict) else resp.text[:200]
+            print(f"API error {resp.status_code}: {msg}", file=sys.stderr)
+            return None
+
+        return data
+
+    print("ERROR: Still rate-limited after retries.", file=sys.stderr)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Core operations
+# ---------------------------------------------------------------------------
+
+
+def search_protocols(
+    query: str,
+    filter_type: str = "public",
+    page_size: int = 10,
+    page_id: int = 1,
+    order_field: str = "activity",
+) -> dict | None:
+    """Search protocols.io for protocols matching a keyword query."""
+    return _api_get(
+        f"{API_V3}/protocols",
+        params={
+            "filter": filter_type,
+            "key": query,
+            "order_field": order_field,
+            "page_size": page_size,
+            "page_id": page_id,
+        },
+    )
+
+
+def _parse_protocol_id(raw: str) -> str:
+    """
+    Extract a usable protocol identifier from various input formats:
+    - Full URL:  https://www.protocols.io/view/some-protocol-slug-abc123  → some-protocol-slug-abc123
+    - URI slug:  some-protocol-slug-abc123  → some-protocol-slug-abc123
+    - Numeric:   30756  → 30756
+    - DOI:       10.17504/protocols.io.abc123  → 10.17504/protocols.io.abc123
+    """
+    s = raw.strip().rstrip("/")
+    if "protocols.io/view/" in s:
+        s = s.split("protocols.io/view/")[-1]
+    elif "protocols.io/api/" in s:
+        pass
+    s = s.split("?")[0].split("#")[0]
+    return s
+
+
+def get_protocol(protocol_id: str | int, content_format: str = "markdown") -> dict | None:
+    """Retrieve full protocol detail by ID, URI, URL, or DOI."""
+    pid = _parse_protocol_id(str(protocol_id))
+    return _api_get(
+        f"{API_V4}/protocols/{pid}",
+        params={"content_format": content_format},
+    )
+
+
+def get_protocol_steps(protocol_id: str | int, content_format: str = "markdown") -> dict | None:
+    """Retrieve protocol steps by ID, URI, URL, or DOI."""
+    pid = _parse_protocol_id(str(protocol_id))
+    return _api_get(
+        f"{API_V4}/protocols/{pid}/steps",
+        params={"content_format": content_format},
+    )
+
+
+
+
+# ---------------------------------------------------------------------------
+# Formatters
+# ---------------------------------------------------------------------------
+
+
+def format_search_results(data: dict, query: str) -> str:
+    """Render search results as markdown."""
+    items = data.get("items", [])
+    pagination = data.get("pagination", {})
+    total = pagination.get("total_results", len(items))
+
+    lines = [
+        f"# Protocols.io Search: \"{query}\"\n",
+        f"**{total} results found** (showing {len(items)})\n",
+    ]
+
+    for i, p in enumerate(items, 1):
+        title = p.get("title", "Untitled")
+        uri = p.get("uri", "")
+        doi = p.get("doi", "")
+        creator = p.get("creator", {}).get("name", "Unknown")
+        published = p.get("published_on")
+        pub_str = datetime.fromtimestamp(published, tz=timezone.utc).strftime("%Y-%m-%d") if published else "Draft"
+        n_steps = p.get("number_of_steps", "?")
+        url = f"https://www.protocols.io/view/{uri}" if uri else ""
+
+        lines.append(f"## {i}. {title}\n")
+        lines.append(f"- **Creator**: {creator}")
+        lines.append(f"- **Published**: {pub_str}")
+        lines.append(f"- **Steps**: {n_steps}")
+        if doi:
+            lines.append(f"- **DOI**: {doi}")
+        if url:
+            lines.append(f"- **URL**: [{url}]({url})")
+        lines.append("")
+
+    lines.append(f"\n---\n{DISCLAIMER}")
+    return "\n".join(lines)
+
+
+def format_protocol_detail(data: dict) -> str:
+    """Render a full protocol as markdown."""
+    p = data.get("payload", data.get("protocol", data))
+    title = p.get("title", "Untitled Protocol")
+    doi = p.get("doi", "")
+    uri = p.get("uri", "")
+    creator = p.get("creator", {}).get("name", "Unknown")
+    description = p.get("description", "")
+    guidelines = p.get("guidelines", "")
+    before_start = p.get("before_start", "")
+    warning = p.get("warning", "")
+    published = p.get("published_on")
+    pub_str = datetime.fromtimestamp(published, tz=timezone.utc).strftime("%Y-%m-%d") if published else "Draft"
+
+    authors = p.get("authors", [])
+    author_str = ", ".join(a.get("name", "?") for a in authors) if authors else creator
+
+    url = f"https://www.protocols.io/view/{uri}" if uri else ""
+
+    lines = [
+        f"# {title}\n",
+        f"- **Authors**: {author_str}",
+        f"- **Published**: {pub_str}",
+    ]
+    if doi:
+        lines.append(f"- **DOI**: {doi}")
+    if url:
+        lines.append(f"- **URL**: [{url}]({url})")
+
+    stats = p.get("stats", {})
+    if stats:
+        lines.append(f"- **Views**: {stats.get('number_of_views', '?')} | "
+                      f"**Steps**: {stats.get('number_of_steps', '?')} | "
+                      f"**Exports**: {stats.get('number_of_exports', '?')}")
+
+    lines.append("")
+
+    if description:
+        lines.extend(["## Description\n", description, ""])
+    if guidelines:
+        lines.extend(["## Guidelines\n", guidelines, ""])
+    if before_start:
+        lines.extend(["## Before You Start\n", before_start, ""])
+    if warning:
+        lines.extend(["## Warnings\n", warning, ""])
+
+    materials = p.get("materials", [])
+    if materials:
+        lines.append("## Materials\n")
+        for m in materials:
+            name = m.get("name", "Unknown reagent")
+            vendor = m.get("vendor", {}).get("name", "")
+            sku = m.get("sku", "")
+            parts = [f"- **{name}**"]
+            if vendor:
+                parts.append(f"({vendor})")
+            if sku:
+                parts.append(f"[SKU: {sku}]")
+            lines.append(" ".join(parts))
+        lines.append("")
+
+    steps = p.get("steps", [])
+    if steps:
+        lines.append("## Steps\n")
+        for j, s in enumerate(steps, 1):
+            section = s.get("section")
+            if section:
+                lines.append(f"### {section}\n")
+            step_text = s.get("step", "")
+            if isinstance(step_text, str) and step_text.startswith("{"):
+                try:
+                    draft = json.loads(step_text)
+                    blocks = draft.get("blocks", [])
+                    step_text = "\n".join(b.get("text", "") for b in blocks)
+                except json.JSONDecodeError:
+                    pass
+            lines.append(f"**Step {j}.**  {step_text}\n")
+        lines.append("")
+
+    lines.append(f"---\n{DISCLAIMER}")
+    return "\n".join(lines)
+
+
+def format_steps(data: dict, protocol_id: str) -> str:
+    """Render protocol steps as markdown."""
+    steps = data.get("steps", [])
+    lines = [
+        f"# Protocol Steps — {protocol_id}\n",
+        f"**{len(steps)} steps**\n",
+    ]
+    for j, s in enumerate(steps, 1):
+        section = s.get("section")
+        if section:
+            lines.append(f"### {section}\n")
+        components = s.get("components", [])
+        step_text = ""
+        for comp in components:
+            body = comp.get("source", {})
+            if isinstance(body, dict):
+                step_text += body.get("description", "")
+            elif isinstance(body, str):
+                step_text += body
+        if not step_text:
+            step_text = s.get("step", "(no content)")
+            if isinstance(step_text, str) and step_text.startswith("{"):
+                try:
+                    draft = json.loads(step_text)
+                    blocks = draft.get("blocks", [])
+                    step_text = "\n".join(b.get("text", "") for b in blocks)
+                except json.JSONDecodeError:
+                    pass
+        lines.append(f"**Step {j}.** {step_text}\n")
+
+    lines.append(f"\n---\n{DISCLAIMER}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Demo mode
+# ---------------------------------------------------------------------------
+
+def _load_demo_json(filename: str) -> dict:
+    """Load a pre-cached demo JSON file from the demo/ directory."""
+    path = DEMO_DIR / filename
+    if not path.exists():
+        print(f"ERROR: Demo file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def run_demo() -> None:
+    """Run offline demo with pre-cached data."""
+    print("\nProtocols.io Bridge — Demo Mode (offline)")
+    print("=" * 50)
+
+    demo_search = _load_demo_json("demo_search_results.json")
+    demo_protocol = _load_demo_json("demo_protocol.json")
+
+    print("\n--- Search Demo: \"RNA extraction\" ---\n")
+    search_md = format_search_results(demo_search, "RNA extraction")
+    print(search_md)
+
+    print("\n--- Protocol Detail Demo ---\n")
+    detail_md = format_protocol_detail(demo_protocol)
+    print(detail_md)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _slugify(text: str, max_len: int = 60) -> str:
+    """Turn a title or query into a safe filename slug."""
+    import re
+    s = text.lower().strip()
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    s = s.strip("-")[:max_len].rstrip("-")
+    return s or "output"
+
+
+def _dump_markdown(md: str, label: str) -> None:
+    """Write markdown to an auto-named file in the current directory."""
+    slug = _slugify(label)
+    filename = f"{slug}.md"
+    Path(filename).write_text(md, encoding="utf-8")
+    print(f"  Saved to {filename}")
+
+
+def _prompt_for_token() -> str | None:
+    """Inline token prompt for commands that need auth but have no saved token."""
+    print("  Get your token at: https://www.protocols.io/developers")
+    print("  (Log in → Your Applications → copy the 'Access Token')\n")
+    token = getpass.getpass("  Access Token (or press Enter to skip): ").strip()
+    if not token:
+        return None
+    save_tokens({"access_token": token, "token_type": "bearer"})
+    return token
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="protocols.io bridge — search, browse, and retrieve scientific protocols"
+    )
+    parser.add_argument("--login", action="store_true", help="Authenticate with access token")
+    parser.add_argument("--search", type=str, help="Search protocols by keyword")
+    parser.add_argument("--protocol", type=str, help="Retrieve full protocol by ID, URI, or DOI")
+    parser.add_argument("--steps", type=str, help="Retrieve protocol steps by ID, URI, or DOI")
+    parser.add_argument("--demo", action="store_true", help="Run offline demo with pre-cached data")
+    parser.add_argument("--dump", action="store_true", help="Save output as a markdown file in the current directory")
+    parser.add_argument("--page-size", type=int, default=10, help="Results per page (1-100)")
+    parser.add_argument("--page", type=int, default=1, help="Page number")
+    parser.add_argument("--filter", type=str, default="public",
+                        choices=["public", "user_public", "user_private", "shared_with_user"],
+                        help="Protocol filter type")
+
+    args = parser.parse_args()
+
+    if args.demo:
+        run_demo()
+        return
+
+    if args.login:
+        result = token_login()
+        if result:
+            print("\n  Authentication successful!")
+        else:
+            print("\n  Authentication failed.", file=sys.stderr)
+            sys.exit(1)
+        return
+
+    if args.search:
+        token = get_access_token()
+        if not token:
+            print("  No access token found. Run --login first, or paste a token now.\n")
+            token = _prompt_for_token()
+            if not token:
+                print("ERROR: Cannot search without an access token.", file=sys.stderr)
+                sys.exit(1)
+
+        with Spinner(f"Searching protocols.io for \"{args.search}\""):
+            data = search_protocols(
+                args.search,
+                filter_type=args.filter,
+                page_size=args.page_size,
+                page_id=args.page,
+            )
+        if not data:
+            print("ERROR: Search failed.", file=sys.stderr)
+            sys.exit(1)
+
+        report = format_search_results(data, args.search)
+        print(report)
+        if args.dump:
+            _dump_markdown(report, f"search-{args.search}")
+        return
+
+    if args.protocol:
+        with Spinner(f"Retrieving protocol {args.protocol}"):
+            data = get_protocol(args.protocol)
+        if not data:
+            print("ERROR: Could not retrieve protocol.", file=sys.stderr)
+            sys.exit(1)
+
+        report = format_protocol_detail(data)
+        print(report)
+        if args.dump:
+            p = data.get("payload", data.get("protocol", data))
+            _dump_markdown(report, p.get("title", args.protocol))
+        return
+
+    if args.steps:
+        with Spinner(f"Retrieving steps for protocol {args.steps}"):
+            data = get_protocol_steps(args.steps)
+        if not data:
+            print("ERROR: Could not retrieve steps.", file=sys.stderr)
+            sys.exit(1)
+
+        report = format_steps(data, args.steps)
+        print(report)
+        if args.dump:
+            _dump_markdown(report, f"steps-{args.steps}")
+        return
+
+    parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/protocols-io/tests/test_protocols_io.py
+++ b/skills/protocols-io/tests/test_protocols_io.py
@@ -1,0 +1,413 @@
+"""
+test_protocols_io.py — Test suite for protocols.io bridge skill
+
+Run with: pytest skills/protocols-io/tests/test_protocols_io.py -v
+
+Uses pre-cached demo data and mocked API responses — no network required.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from protocols_io import (
+    DISCLAIMER,
+    _load_demo_json,
+    _parse_protocol_id,
+    _RateLimiter,
+    format_search_results,
+    format_protocol_detail,
+    format_steps,
+    search_protocols,
+    get_protocol,
+    get_protocol_steps,
+    load_tokens,
+    save_tokens,
+)
+
+
+# ---------------------------------------------------------------------------
+# Demo data loading
+# ---------------------------------------------------------------------------
+
+
+def test_load_demo_search_results():
+    """Demo search JSON loads and has expected structure."""
+    data = _load_demo_json("demo_search_results.json")
+    assert "items" in data
+    assert "pagination" in data
+    assert len(data["items"]) == 5
+
+
+def test_load_demo_protocol():
+    """Demo protocol JSON loads and has expected structure."""
+    data = _load_demo_json("demo_protocol.json")
+    assert "payload" in data
+    payload = data["payload"]
+    assert payload["id"] == 12001
+    assert payload["title"] == "Total RNA Extraction from Tissue (TRIzol)"
+    assert len(payload["steps"]) == 8
+    assert len(payload["materials"]) == 5
+
+
+def test_load_demo_missing_file():
+    """Loading a nonexistent demo file exits with error."""
+    with pytest.raises(SystemExit):
+        _load_demo_json("nonexistent_file.json")
+
+
+# ---------------------------------------------------------------------------
+# Formatters — search results
+# ---------------------------------------------------------------------------
+
+
+def test_format_search_results_header():
+    """Search report includes query and result count."""
+    data = _load_demo_json("demo_search_results.json")
+    md = format_search_results(data, "RNA extraction")
+    assert '# Protocols.io Search: "RNA extraction"' in md
+    assert "5 results found" in md
+
+
+def test_format_search_results_items():
+    """Each search result renders with title, creator, DOI."""
+    data = _load_demo_json("demo_search_results.json")
+    md = format_search_results(data, "RNA extraction")
+    assert "Tree Mapping for Leaf Collection" in md
+    assert "Gene calling with Prodigal" in md
+    assert "Lysis Buffer" in md
+    assert "Vellend Cabo" in md
+    assert "dx.doi.org" in md
+
+
+def test_format_search_results_urls():
+    """Search results include protocols.io URLs."""
+    data = _load_demo_json("demo_search_results.json")
+    md = format_search_results(data, "test")
+    assert "https://www.protocols.io/view/" in md
+
+
+def test_format_search_results_disclaimer():
+    """Search report includes the safety disclaimer."""
+    data = _load_demo_json("demo_search_results.json")
+    md = format_search_results(data, "test")
+    assert DISCLAIMER in md
+
+
+def test_format_search_results_empty():
+    """Empty search results render gracefully."""
+    data = {"items": [], "pagination": {"total_results": 0}}
+    md = format_search_results(data, "nothing")
+    assert "0 results found" in md
+    assert DISCLAIMER in md
+
+
+# ---------------------------------------------------------------------------
+# Formatters — protocol detail
+# ---------------------------------------------------------------------------
+
+
+def test_format_protocol_detail_title():
+    """Protocol detail includes title and metadata."""
+    data = _load_demo_json("demo_protocol.json")
+    md = format_protocol_detail(data)
+    assert "# Total RNA Extraction from Tissue (TRIzol)" in md
+    assert "Demo Researcher" in md
+    assert "dx.doi.org" in md
+
+
+def test_format_protocol_detail_sections():
+    """Protocol detail includes all expected sections."""
+    data = _load_demo_json("demo_protocol.json")
+    md = format_protocol_detail(data)
+    assert "## Description" in md
+    assert "## Guidelines" in md
+    assert "## Before You Start" in md
+    assert "## Warnings" in md
+    assert "## Materials" in md
+    assert "## Steps" in md
+
+
+def test_format_protocol_detail_materials():
+    """Materials section lists reagents with vendors and SKUs."""
+    data = _load_demo_json("demo_protocol.json")
+    md = format_protocol_detail(data)
+    assert "TRIzol Reagent" in md
+    assert "Thermo Fisher" in md
+    assert "SKU: 15596026" in md
+    assert "Chloroform" in md
+    assert "Sigma-Aldrich" in md
+
+
+def test_format_protocol_detail_steps():
+    """Steps section includes all 8 protocol steps."""
+    data = _load_demo_json("demo_protocol.json")
+    md = format_protocol_detail(data)
+    assert "Step 1." in md
+    assert "Step 8." in md
+    assert "TRIzol Reagent" in md
+    assert "NanoDrop" in md
+
+
+def test_format_protocol_detail_stats():
+    """Stats line includes views, steps, and exports."""
+    data = _load_demo_json("demo_protocol.json")
+    md = format_protocol_detail(data)
+    assert "4520" in md
+    assert "312" in md
+
+
+def test_format_protocol_detail_disclaimer():
+    """Protocol report includes the safety disclaimer."""
+    data = _load_demo_json("demo_protocol.json")
+    md = format_protocol_detail(data)
+    assert DISCLAIMER in md
+
+
+def test_format_protocol_detail_minimal():
+    """Handles a minimal protocol object without crashing."""
+    data = {"payload": {"title": "Minimal", "steps": []}}
+    md = format_protocol_detail(data)
+    assert "# Minimal" in md
+    assert DISCLAIMER in md
+
+
+# ---------------------------------------------------------------------------
+# Formatters — steps
+# ---------------------------------------------------------------------------
+
+
+def test_format_steps_count():
+    """Steps formatter reports correct step count."""
+    data = {"steps": [{"step": "Do A"}, {"step": "Do B"}, {"step": "Do C"}]}
+    md = format_steps(data, "test-123")
+    assert "3 steps" in md
+    assert "Step 1." in md
+    assert "Step 3." in md
+
+
+def test_format_steps_json_draft_parsing():
+    """Steps with draft JSON content are parsed to plain text."""
+    draft = json.dumps({"blocks": [{"text": "Extracted text here"}]})
+    data = {"steps": [{"step": draft}]}
+    md = format_steps(data, "test")
+    assert "Extracted text here" in md
+
+
+def test_format_steps_empty():
+    """Empty steps list renders gracefully."""
+    data = {"steps": []}
+    md = format_steps(data, "test")
+    assert "0 steps" in md
+    assert DISCLAIMER in md
+
+
+# ---------------------------------------------------------------------------
+# Token persistence
+# ---------------------------------------------------------------------------
+
+
+def test_save_and_load_tokens(tmp_path):
+    """Tokens round-trip through save/load."""
+    token_file = tmp_path / "tokens.json"
+    with patch("protocols_io.TOKEN_FILE", token_file), \
+         patch("protocols_io.CONFIG_DIR", tmp_path):
+        save_tokens({"access_token": "abc123", "token_type": "bearer"})
+        result = load_tokens()
+    assert result["access_token"] == "abc123"
+    assert result["token_type"] == "bearer"
+    assert "saved_at" in result
+
+
+def test_load_tokens_missing(tmp_path):
+    """Missing token file returns None."""
+    with patch("protocols_io.TOKEN_FILE", tmp_path / "nonexistent.json"):
+        result = load_tokens()
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# URL / ID parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_full_url():
+    """Full protocols.io URL is parsed to URI slug."""
+    result = _parse_protocol_id("https://www.protocols.io/view/one-blot-western-grhbv36")
+    assert result == "one-blot-western-grhbv36"
+
+
+def test_parse_full_url_trailing_slash():
+    """Trailing slash is stripped."""
+    result = _parse_protocol_id("https://www.protocols.io/view/some-protocol-abc123/")
+    assert result == "some-protocol-abc123"
+
+
+def test_parse_full_url_with_query_params():
+    """Query params after the slug are stripped."""
+    result = _parse_protocol_id("https://www.protocols.io/view/my-proto-xyz?version=2&foo=bar")
+    assert result == "my-proto-xyz"
+
+
+def test_parse_uri_slug():
+    """Plain URI slug passes through unchanged."""
+    result = _parse_protocol_id("lysis-buffer-20-ml-c4gytv")
+    assert result == "lysis-buffer-20-ml-c4gytv"
+
+
+def test_parse_numeric_id():
+    """Numeric ID passes through as string."""
+    result = _parse_protocol_id("30756")
+    assert result == "30756"
+
+
+def test_parse_doi():
+    """DOI passes through unchanged."""
+    result = _parse_protocol_id("10.17504/protocols.io.baaciaaw")
+    assert result == "10.17504/protocols.io.baaciaaw"
+
+
+def test_parse_whitespace():
+    """Leading/trailing whitespace is stripped."""
+    result = _parse_protocol_id("  some-protocol-abc  ")
+    assert result == "some-protocol-abc"
+
+
+# ---------------------------------------------------------------------------
+# API functions (mocked)
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(json_data, status_code=200, headers=None):
+    """Build a mock requests.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.text = json.dumps(json_data)
+    resp.headers = headers if headers is not None else {}
+    return resp
+
+
+def _unlimited_limiter() -> _RateLimiter:
+    """Avoid client-side throttle interfering with API unit tests."""
+    return _RateLimiter(max_calls=10_000, window=1.0)
+
+
+@patch("protocols_io.requests.get")
+def test_search_protocols(mock_get):
+    """search_protocols calls the correct API endpoint."""
+    demo_data = _load_demo_json("demo_search_results.json")
+    mock_get.return_value = _mock_response(demo_data)
+
+    with patch("protocols_io.get_access_token", return_value="fake_token"), \
+         patch("protocols_io._rate_limiter", _unlimited_limiter()):
+        result = search_protocols("RNA extraction")
+
+    assert result is not None
+    assert len(result["items"]) == 5
+    call_url = mock_get.call_args[0][0]
+    assert "/api/v3/protocols" in call_url
+
+
+@patch("protocols_io.requests.get")
+def test_get_protocol(mock_get):
+    """get_protocol calls the v4 endpoint."""
+    demo_data = _load_demo_json("demo_protocol.json")
+    mock_get.return_value = _mock_response(demo_data)
+
+    with patch("protocols_io.get_access_token", return_value="fake_token"), \
+         patch("protocols_io._rate_limiter", _unlimited_limiter()):
+        result = get_protocol(12001)
+
+    assert result is not None
+    assert result["payload"]["id"] == 12001
+    call_url = mock_get.call_args[0][0]
+    assert "/api/v4/protocols/12001" in call_url
+
+
+@patch("protocols_io.requests.get")
+def test_get_protocol_steps(mock_get):
+    """get_protocol_steps calls the steps endpoint."""
+    steps_data = {"steps": [{"step": "Do something"}], "status_code": 0}
+    mock_get.return_value = _mock_response(steps_data)
+
+    with patch("protocols_io.get_access_token", return_value="fake_token"), \
+         patch("protocols_io._rate_limiter", _unlimited_limiter()):
+        result = get_protocol_steps(12001)
+
+    assert result is not None
+    assert len(result["steps"]) == 1
+    call_url = mock_get.call_args[0][0]
+    assert "/api/v4/protocols/12001/steps" in call_url
+
+
+@patch("protocols_io.requests.get")
+def test_api_expired_token_returns_none(mock_get):
+    """Expired token (status 1219) returns None with an error message."""
+    expired_resp = _mock_response({"status_code": 1219}, status_code=200)
+    mock_get.return_value = expired_resp
+
+    with patch("protocols_io.get_access_token", return_value="old_token"), \
+         patch("protocols_io._rate_limiter", _unlimited_limiter()):
+        result = search_protocols("test")
+
+    assert result is None
+    assert mock_get.call_count == 1
+
+
+@patch("protocols_io.time.sleep")
+@patch("protocols_io.requests.get")
+def test_api_429_retries_then_success(mock_get, mock_sleep):
+    r429 = _mock_response({}, status_code=429, headers={"Retry-After": "1"})
+    ok = _mock_response({"items": [], "status_code": 0}, status_code=200)
+    mock_get.side_effect = [r429, ok]
+
+    with patch("protocols_io.get_access_token", return_value="t"), \
+         patch("protocols_io._rate_limiter", _unlimited_limiter()):
+        result = search_protocols("x")
+
+    assert result is not None
+    assert mock_get.call_count == 2
+    mock_sleep.assert_called_once_with(1)
+
+
+@patch("protocols_io.time.sleep")
+@patch("protocols_io.requests.get")
+def test_api_429_exhausts_retries(mock_get, mock_sleep):
+    r429 = _mock_response({}, status_code=429, headers={"Retry-After": "1"})
+    mock_get.return_value = r429
+
+    with patch("protocols_io.get_access_token", return_value="t"), \
+         patch("protocols_io._rate_limiter", _unlimited_limiter()):
+        result = search_protocols("x")
+
+    assert result is None
+    assert mock_get.call_count == 3
+
+
+@patch("protocols_io.time.sleep")
+@patch("protocols_io.requests.get")
+def test_api_429_retry_after_capped(mock_get, mock_sleep):
+    r429 = _mock_response({}, status_code=429, headers={"Retry-After": "9999"})
+    ok = _mock_response({"items": [], "status_code": 0}, status_code=200)
+    mock_get.side_effect = [r429, ok]
+
+    with patch("protocols_io.get_access_token", return_value="t"), \
+         patch("protocols_io._rate_limiter", _unlimited_limiter()):
+        search_protocols("x")
+
+    mock_sleep.assert_called_once_with(120)
+
+
+@patch("protocols_io.time.sleep")
+def test_rate_limiter_waits_when_full(mock_sleep):
+    lim = _RateLimiter(max_calls=2, window=60.0)
+    lim.wait()
+    lim.wait()
+    lim.wait()
+    assert mock_sleep.called


### PR DESCRIPTION
## Summary

<!-- What does this PR do? 1-3 bullet points. -->
- Search, browse, and retrieve scientific protocols from protocols.io via REST API

## Skill affected

<!-- Which skill does this change? e.g. pharmgx-reporter, equity-scorer, or "new skill: my-skill-name" -->
new skill: protocols-io

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology)
- [x] Tests included and passing (`pytest -v`)
- [x] Demo data included for reviewers to test
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

<!-- Paste pytest output or describe how you tested -->
(base) ➜  ClawBio git:(hackathon-protocols-io) pytest -q skills/protocols-io/tests/test_protocols_io.py
...................................                                                                               [100%]
35 passed in 0.08s