### PR TITLE
feat: Add gene-set-enrichment skill for Enrichr pathway analysis

### DIFF
--- a/examples/get_enrichr_results.py
+++ b/examples/get_enrichr_results.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""
+Fetch Enrichr enrichment results for cancer gene list
+"""
+
+import requests
+import json
+
+# Gene list ID from previous upload
+user_list_id = 124669542
+
+# Enrichr API endpoint for fetching results
+url = f"https://maayanlab.cloud/Enrichr/enrich?userListId={user_list_id}&backgroundType=KEGG_2021_Human"
+
+try:
+    response = requests.get(url)
+    response.raise_for_status()
+    
+    result = response.json()
+    
+    # Pretty print the results
+    print(json.dumps(result, indent=2))
+    
+    # If there are KEGG results, display them in a more readable format
+    if "results" in result and "KEGG_2021_Human" in result["results"]:
+        print("\n" + "="*80)
+        print("KEGG 2021 Human Pathway Enrichment Results")
+        print("="*80)
+        
+        kegg_results = result["results"]["KEGG_2021_Human"]
+        for i, pathway in enumerate(kegg_results[:10], 1):  # Show top 10
+            print(f"\n{i}. {pathway[1]}")
+            print(f"   p-value: {pathway[2]:.2e}")
+            print(f"   Combined Score: {pathway[3]:.2f}")
+            print(f"   Genes: {', '.join(pathway[5][:5])}{'...' if len(pathway[5]) > 5 else ''}")
+    
+except requests.exceptions.RequestException as e:
+    print(f"Error fetching results from Enrichr: {e}")
+    print(f"Response: {response.text if 'response' in locals() else 'No response'}")

--- a/examples/post_gene_list_to_enrichr.py
+++ b/examples/post_gene_list_to_enrichr.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+Post cancer gene list to Enrichr API
+"""
+
+import requests
+
+# Gene list
+genes = [
+    "TP53", "BRCA1", "BRCA2", "EGFR", "KRAS", "MYC", "APC", "RB1", "PTEN", 
+    "PIK3CA", "BRAF", "NRAS", "CDH1", "VHL", "WT1", "NF1", "NF2", "RET", 
+    "KIT", "PDGFRA", "ALK", "ERBB2", "FGFR3", "IDH1", "IDH2", "NPM1", "FLT3", 
+    "DNMT3A", "TET2", "JAK2", "MPL", "CALR", "SF3B1", "ASXL1", "EZH2", 
+    "NOTCH1", "FBXW7", "CTNNB1", "SMAD4", "STK11", "CDKN2A", "CDK4", "MDM2", 
+    "MET", "ROS1", "NTRK1", "MAP2K1", "ARID1A", "KMT2A", "CREBBP"
+]
+
+# Create newline-separated string
+gene_list_str = "\n".join(genes)
+
+# Enrichr API endpoint
+url = "https://maayanlab.cloud/Enrichr/addList"
+
+# Prepare data for POST request (multipart/form-data)
+files = {
+    "list": (None, gene_list_str),
+    "description": (None, "Cancer-associated genes")
+}
+
+try:
+    response = requests.post(url, files=files)
+    response.raise_for_status()
+    
+    result = response.json()
+    print(f"Success! List ID: {result.get('userListId')}")
+    print(f"Short URL: {result.get('shortUrl')}")
+    print(f"Full response: {result}")
+    
+except requests.exceptions.RequestException as e:
+    print(f"Error posting to Enrichr: {e}")
+    print(f"Response: {response.text if 'response' in locals() else 'No response'}")

--- a/skills/gene-set-enrichment/README.md
+++ b/skills/gene-set-enrichment/README.md
@@ -1,0 +1,236 @@
+---
+name: gene-set-enrichment
+description: >-
+  Perform comprehensive gene set enrichment analysis using Enrichr with multiple 
+  pathway libraries (KEGG, GO). Upload genes, query multiple databases, parse results, 
+  and generate publication-ready visualizations.
+version: 0.1.0
+author: ClawBio Contributors
+license: MIT
+tags: [genomics, enrichment-analysis, pathway-analysis, gene-sets]
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - python3
+      env: []
+      config: []
+    always: false
+    emoji: "🧬"
+    homepage: https://github.com/ClawBio/ClawBio
+    os: [macos, linux]
+    install:
+      - kind: pip
+        package: requests
+        bins: []
+      - kind: pip
+        package: pandas
+        bins: []
+      - kind: pip
+        package: matplotlib
+        bins: []
+      - kind: pip
+        package: seaborn
+        bins: []
+      - kind: pip
+        package: numpy
+        bins: []
+    trigger_keywords:
+      - enrichment analysis
+      - gene set enrichment
+      - pathway enrichment
+      - KEGG analysis
+      - GO annotation
+---
+
+# 🧬 Gene Set Enrichment Analysis
+
+You are **Gene Set Enrichment**, a specialized ClawBio agent for pathway and functional enrichment analysis. Your role is to upload gene lists to Enrichr, query multiple pathway libraries simultaneously, and generate comprehensive reports with statistical rankings and visualizations.
+
+## Why This Exists
+
+What goes wrong without this skill?
+
+- **Without it**: Users must manually upload genes to Enrichr, click through multiple library queries, download results separately, and manually combine/visualize data
+- **With it**: One command processes your gene list through 3 major pathway libraries, combines results, sorts by significance, and produces publication-ready charts
+- **Why ClawBio**: Automated API integration + intelligent result parsing + multi-library consolidation = comprehensive pathway context in seconds
+
+## Core Capabilities
+
+1. **Multi-library Querying**: Simultaneously queries KEGG (2021), GO Biological Process, and GO Molecular Function
+2. **Result Parsing**: Extracts term names, p-values, adjusted p-values, z-scores, and overlapping genes from JSON responses
+3. **Result Consolidation**: Combines results from all libraries, removes duplicates, and sorts by statistical significance
+4. **Visualization**: Generates publication-quality charts showing top enriched pathways by p-value and combined score
+5. **Reproducible Reporting**: Generates markdown reports with methods, results tables, and embedded charts
+
+## Input Formats
+
+| Format | Extension | Required Fields | Example |
+|--------|-----------|-----------------|---------|
+| Gene List | `.txt` | One gene symbol per line (HGNC format) | `cancer_genes.txt` |
+| Gene List | `.csv` | Column named "Gene" or first column with gene symbols | `genes.csv` |
+
+## Workflow
+
+When the user asks for gene set enrichment analysis:
+
+1. **Validate**: Check that input file exists and contains valid HGNC gene symbols
+2. **Upload**: POST gene list to Enrichr and receive userListId
+3. **Query**: GET results from KEGG_2021_Human, GO_Biological_Process_2021, GO_Molecular_Function_2021
+4. **Parse**: Extract term name, p-value, adjusted p-value, z-score, overlap count, and overlapping genes
+5. **Consolidate**: Combine all library results into single DataFrame, sort by adjusted p-value
+6. **Visualize**: Generate dual-panel bar charts (p-value and combined score for top 15 pathways)
+7. **Report**: Write `report.md` with summary table, full results CSV, methods section, and embedding visualizations
+
+## CLI Reference
+
+```bash
+# Standard usage with gene list file
+python skills/gene-set-enrichment/gene_set_enrichment.py \
+  --input cancer_genes.txt \
+  --output enrichment_results
+
+# Demo mode (uses built-in cancer gene set)
+python skills/gene-set-enrichment/gene_set_enrichment.py \
+  --demo \
+  --output demo_results
+
+# Via ClawBio runner
+python clawbio.py run gene-set-enrichment --input my_genes.txt --output results
+```
+
+## Demo
+
+To verify the skill works:
+
+```bash
+python skills/gene-set-enrichment/gene_set_enrichment.py --demo --output /tmp/demo
+```
+
+Expected output: A 3-part results package including:
+- **enrichment_chart.png**: Dual-panel visualization of top 15 pathways
+- **enrichment_results.csv**: Full results (typically 100-500 pathways)
+- **report.md**: Markdown summary with top 10 table and methods
+
+Demo uses 15 well-characterized cancer genes (TP53, BRCA1, EGFR, KRAS, etc.) → ~150 enriched pathways across libraries.
+
+## Algorithm / Methodology
+
+### Data Flow
+
+1. **Gene Input**: Read HGNC gene symbols from text file (one per line)
+2. **Enrichr Upload**: POST to `https://maayanlab.cloud/Enrichr/addList` with multipart/form-data
+3. **Library Queries**: GET from `https://maayanlab.cloud/Enrichr/enrich?userListId=ID&backgroundType=LIBRARY` for each of:
+   - KEGG_2021_Human
+   - GO_Biological_Process_2021
+   - GO_Molecular_Function_2021
+4. **Result Parsing**: For each pathway result, extract:
+   - Rank (index)
+   - Term name (pathway/GO term)
+   - P-value (raw p-value from Fisher exact test)
+   - Combined score (p-value × overlap rank)
+   - Overlap (number of query genes in pathway)
+   - Gene list (comma-separated overlapping genes)
+   - Adjusted p-value (Benjamini-Hochberg correction)
+   - Z-score (deviation from expected overlap)
+
+5. **Consolidation**: 
+   - Concatenate DataFrames from all libraries
+   - Sort by adjusted p-value (ascending)
+   - Filter to top N for visualization
+
+6. **Visualization**:
+   - Panel A: Negative log10(p-value) for each pathway (larger = more significant)
+   - Panel B: Combined score (accounts for both p-value and effect size)
+   - Color-coded by library for quick reference
+
+### Statistical Details
+
+- **Combined Score**: -log10(p-value) × log(overlap/expected)
+- **P-value Calculation**: Fisher exact test of overlap between query genes and pathway genes
+- **Adjusted P-value**: Benjamini-Hochberg FDR correction (q-value)
+- **Z-score**: (observed - expected) / sqrt(expected), where expected = |pathway| × |query| / |genome|
+
+### Key Thresholds / Parameters
+
+- **Significance threshold**: p-value < 0.05 (can filter further with adjusted p-value < 0.05)
+- **Top visualization**: 15 pathways (configurable)
+- **Minimum overlap**: Typically 2-3 genes (Enrichr default)
+
+## Outputs
+
+### Files Generated
+
+1. **enrichment_results.csv**: Complete results from all libraries
+   - Columns: Library, Term, P-value, Combined Score, Overlap, Genes, Adjusted P-value, Z-score
+   - Sorted by adjusted p-value
+
+2. **enrichment_chart.png**: Dual-panel visualization (300 dpi, print-ready)
+
+3. **report.md**: Markdown summary with:
+   - Analysis metadata (input genes, libraries queried)
+   - Top 10 enriched pathways table
+   - Embedded chart
+   - Methods section
+
+### Interpreting Results
+
+- **Low p-value (<0.05)**: Pathway significantly enriched in query genes
+- **High combined score**: Strong enrichment considering both significance and effect size
+- **High overlap**: Many query genes in the pathway (helps interpret combined score)
+- **Z-score > 0**: More genes in pathway than expected by chance
+
+## Examples
+
+### Example 1: Cancer Gene Analysis
+```bash
+# Input: 48 cancer driver genes (TP53, BRCA1, BRCA2, EGFR, KRAS, etc.)
+python skills/gene-set-enrichment/gene_set_enrichment.py \
+  --input cancer_genes.txt --output cancer_enrichment
+
+# Output: 
+# - "Pathways in cancer" (p≈1e-36) enriched with 31 genes
+# - "Central carbon metabolism in cancer" enriched with 18 genes
+# - Complete KEGG, GO pathway maps contextualized
+```
+
+### Example 2: Immune Gene Set
+```bash
+python skills/gene-set-enrichment/gene_set_enrichment.py \
+  --input immune_genes.txt --output immune_enrichment
+
+# Output:
+# - T cell activation pathways
+# - Cytokine signaling GO terms
+# - MHC-immune regulatory networks
+```
+
+## Troubleshooting
+
+### "No results retrieved from any library"
+- Check gene symbols are valid HGNC format (exact case matters)
+- Verify internet connection to Enrichr servers
+- Try a known gene like "TP53" to test
+
+### "ModuleNotFoundError: No module named 'requests'"
+- Install dependencies: `pip install requests pandas matplotlib seaborn`
+
+### Results seem incomplete
+- Enrichr queries can take 5-10s per library; give process time
+- Check output directory has write permissions
+- Verify input file format (one gene per line, no headers)
+
+## References
+
+- Enrichr: Kuleshov et al., *Nucleic Acids Research* (2016). https://maayanlab.cloud/Enrichr/
+- KEGG: Kanehisa et al., *Nucleic Acids Research* (2021)
+- Gene Ontology: The Gene Ontology Consortium (2021)
+- Combined Score: https://maayanlab.cloud/Enrichr/help#background
+
+## Future Enhancements
+
+- [ ] Support for custom background genomes
+- [ ] Interactive HTML report with sortable tables
+- [ ] Strip chart overlay on bar plots showing individual genes
+- [ ] Network visualization of pathway interconnections
+- [ ] Annotation of drug targets and clinical trials

--- a/skills/gene-set-enrichment/gene_set_enrichment.py
+++ b/skills/gene-set-enrichment/gene_set_enrichment.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""
+Gene Set Enrichment Analysis Skill
+Performs enrichment analysis using Enrichr with multiple pathway libraries
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+import requests
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+from typing import List, Dict, Tuple
+
+class EnrichrEnrichment:
+    """Perform gene set enrichment analysis using Enrichr API"""
+    
+    # Multiple pathway libraries for comprehensive analysis
+    LIBRARIES = [
+        "KEGG_2021_Human",
+        "GO_Biological_Process_2021",
+        "GO_Molecular_Function_2021"
+    ]
+    
+    ENRICHR_URL = "https://maayanlab.cloud/Enrichr"
+    
+    def __init__(self, output_dir: str = "."):
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.results_df = None
+        
+    def load_genes(self, gene_file: str) -> List[str]:
+        """Load genes from file (one per line)"""
+        with open(gene_file, 'r') as f:
+            genes = [line.strip() for line in f if line.strip()]
+        print(f"Loaded {len(genes)} genes from {gene_file}")
+        return genes
+    
+    def post_to_enrichr(self, genes: List[str]) -> int:
+        """Upload gene list to Enrichr and return list ID"""
+        gene_list_str = "\n".join(genes)
+        
+        url = f"{self.ENRICHR_URL}/addList"
+        files = {
+            "list": (None, gene_list_str),
+            "description": (None, "Gene set enrichment analysis")
+        }
+        
+        print(f"Uploading {len(genes)} genes to Enrichr...")
+        response = requests.post(url, files=files)
+        response.raise_for_status()
+        
+        result = response.json()
+        user_list_id = result.get("userListId")
+        print(f"Successfully uploaded gene list. ID: {user_list_id}")
+        return user_list_id
+    
+    def fetch_results(self, user_list_id: int, library: str) -> List[List]:
+        """Fetch enrichment results for a specific library"""
+        url = f"{self.ENRICHR_URL}/enrich?userListId={user_list_id}&backgroundType={library}"
+        
+        print(f"Fetching results for {library}...")
+        response = requests.get(url)
+        response.raise_for_status()
+        
+        result = response.json()
+        return result.get(library, [])
+    
+    def parse_results(self, raw_results: List[List], library: str) -> pd.DataFrame:
+        """
+        Parse raw Enrichr results into DataFrame
+        
+        Each result entry format:
+        [rank, term_name, p_value, combined_score, overlap, overlap_genes, 
+         adjusted_p_value, z_score, ...]
+        """
+        parsed_data = []
+        
+        for result in raw_results:
+            parsed_data.append({
+                'Library': library,
+                'Term': result[1],
+                'P-value': result[2],
+                'Combined Score': result[3],
+                'Overlap': result[4],
+                'Genes': ','.join(result[5]) if len(result) > 5 else '',
+                'Adjusted P-value': result[6] if len(result) > 6 else None,
+                'Z-score': result[7] if len(result) > 7 else None,
+            })
+        
+        return pd.DataFrame(parsed_data)
+    
+    def fetch_all_libraries(self, user_list_id: int) -> pd.DataFrame:
+        """Fetch and combine results from all libraries"""
+        all_results = []
+        
+        for library in self.LIBRARIES:
+            try:
+                raw_results = self.fetch_results(user_list_id, library)
+                df = self.parse_results(raw_results, library)
+                all_results.append(df)
+                print(f"Retrieved {len(df)} terms from {library}")
+            except Exception as e:
+                print(f"Warning: Failed to fetch {library}: {e}")
+        
+        # Combine all results
+        if all_results:
+            combined_df = pd.concat(all_results, ignore_index=True)
+            
+            # Sort by adjusted p-value (or p-value if adjusted not available)
+            sort_col = 'Adjusted P-value' if 'Adjusted P-value' in combined_df.columns else 'P-value'
+            combined_df = combined_df.dropna(subset=[sort_col]).sort_values(by=sort_col)
+            
+            print(f"\nCombined {len(combined_df)} results from {len(self.LIBRARIES)} libraries")
+            return combined_df
+        else:
+            raise ValueError("No results retrieved from any library")
+    
+    def generate_chart(self, df: pd.DataFrame, top_n: int = 15):
+        """Generate visualization of top enriched terms"""
+        # Get top N results by adjusted p-value
+        top_df = df.head(top_n).copy()
+        top_df['Log P-value'] = -np.log10(top_df['P-value'])
+        top_df = top_df.sort_values('Log P-value', ascending=True)
+        
+        # Create figure with subplots
+        fig, axes = plt.subplots(1, 2, figsize=(16, 8))
+        
+        # Plot 1: P-value by term
+        colors = {'KEGG_2021_Human': '#1f77b4', 
+                  'GO_Biological_Process_2021': '#ff7f0e',
+                  'GO_Molecular_Function_2021': '#2ca02c'}
+        bar_colors = [colors.get(lib, '#999999') for lib in top_df['Library']]
+        
+        axes[0].barh(range(len(top_df)), top_df['Log P-value'], color=bar_colors)
+        axes[0].set_yticks(range(len(top_df)))
+        axes[0].set_yticklabels(top_df['Term'], fontsize=9)
+        axes[0].set_xlabel('-log10(P-value)', fontsize=11)
+        axes[0].set_title(f'Top {top_n} Enriched Terms by P-value', fontsize=12, fontweight='bold')
+        axes[0].grid(axis='x', alpha=0.3)
+        
+        # Plot 2: Combined Score by term
+        top_df_score = df.head(top_n).sort_values('Combined Score', ascending=True)
+        bar_colors_score = [colors.get(lib, '#999999') for lib in top_df_score['Library']]
+        
+        axes[1].barh(range(len(top_df_score)), top_df_score['Combined Score'], color=bar_colors_score)
+        axes[1].set_yticks(range(len(top_df_score)))
+        axes[1].set_yticklabels(top_df_score['Term'], fontsize=9)
+        axes[1].set_xlabel('Combined Score', fontsize=11)
+        axes[1].set_title(f'Top {top_n} Enriched Terms by Combined Score', fontsize=12, fontweight='bold')
+        axes[1].grid(axis='x', alpha=0.3)
+        
+        plt.tight_layout()
+        chart_file = self.output_dir / "enrichment_chart.png"
+        plt.savefig(chart_file, dpi=300, bbox_inches='tight')
+        print(f"Chart saved to {chart_file}")
+        plt.close()
+        
+        return chart_file
+    
+    def save_results(self, df: pd.DataFrame, filename: str = "enrichment_results.csv"):
+        """Save results to CSV"""
+        output_file = self.output_dir / filename
+        df.to_csv(output_file, index=False)
+        print(f"Results saved to {output_file}")
+        return output_file
+    
+    def generate_report(self, genes: List[str], df: pd.DataFrame, chart_file: Path):
+        """Generate markdown report"""
+        report_file = self.output_dir / "report.md"
+        
+        with open(report_file, 'w') as f:
+            f.write("# Gene Set Enrichment Analysis Report\n\n")
+            
+            f.write("## Summary\n")
+            f.write(f"- **Input genes**: {len(genes)}\n")
+            f.write(f"- **Unique genes analyzed**: {len(set(genes))}\n")
+            f.write(f"- **Pathways identified**: {len(df)}\n")
+            f.write(f"- **Libraries queried**: {', '.join(self.LIBRARIES)}\n\n")
+            
+            f.write("## Top 10 Enriched Pathways\n\n")
+            f.write("| Library | Term | P-value | Combined Score | Overlap | Key Genes |\n")
+            f.write("|---------|------|---------|-----------------|---------|----------|\n")
+            
+            for idx, row in df.head(10).iterrows():
+                genes_preview = ', '.join(row['Genes'].split(',')[:3])
+                if len(row['Genes'].split(',')) > 3:
+                    genes_preview += ", ..."
+                f.write(f"| {row['Library']} | {row['Term']} | {row['P-value']:.2e} | "
+                       f"{row['Combined Score']:.2f} | {row['Overlap']} | {genes_preview} |\n")
+            
+            f.write(f"\n## Full Results\n")
+            f.write(f"See `enrichment_results.csv` for complete results ({len(df)} pathways)\n\n")
+            
+            f.write(f"## Visualization\n")
+            f.write(f"![Enrichment Chart](enrichment_chart.png)\n\n")
+            
+            f.write("## Methods\n")
+            f.write("Gene set enrichment analysis performed using Enrichr (Kuleshov et al., 2016) "
+                   "against the following pathway libraries:\n")
+            for lib in self.LIBRARIES:
+                f.write(f"- {lib}\n")
+            f.write("\nResults combined and sorted by adjusted p-value.\n")
+        
+        print(f"Report saved to {report_file}")
+        return report_file
+    
+    def run(self, gene_file: str):
+        """Execute full enrichment analysis workflow"""
+        try:
+            # Load genes
+            genes = self.load_genes(gene_file)
+            
+            # Upload to Enrichr
+            user_list_id = self.post_to_enrichr(genes)
+            
+            # Fetch and combine results from all libraries
+            df = self.fetch_all_libraries(user_list_id)
+            
+            # Save results
+            self.save_results(df)
+            
+            # Generate chart
+            chart_file = self.generate_chart(df)
+            
+            # Generate report
+            self.generate_report(genes, df, chart_file)
+            
+            print(f"\n✓ Analysis complete. Results saved to {self.output_dir}")
+            return True
+            
+        except Exception as e:
+            print(f"✗ Error during analysis: {e}", file=sys.stderr)
+            raise
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Gene Set Enrichment Analysis using Enrichr"
+    )
+    parser.add_argument(
+        "--input", "-i",
+        required=True,
+        help="Input gene list file (one gene per line)"
+    )
+    parser.add_argument(
+        "--output", "-o",
+        default="enrichment_results",
+        help="Output directory for results (default: enrichment_results)"
+    )
+    parser.add_argument(
+        "--demo",
+        action="store_true",
+        help="Run with demo cancer gene set"
+    )
+    
+    args = parser.parse_args()
+    
+    # Handle demo mode
+    if args.demo:
+        demo_genes = [
+            "TP53", "BRCA1", "BRCA2", "EGFR", "KRAS", "MYC", "APC", "RB1",
+            "PTEN", "PIK3CA", "BRAF", "NRAS", "CDH1", "VHL", "WT1"
+        ]
+        demo_file = Path(args.output) / "demo_genes.txt"
+        demo_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(demo_file, 'w') as f:
+            f.write("\n".join(demo_genes))
+        args.input = str(demo_file)
+        print("Running demo mode with cancer genes...")
+    
+    # Run analysis
+    enricher = EnrichrEnrichment(output_dir=args.output)
+    enricher.run(args.input)
+
+if __name__ == "__main__":
+    import numpy as np
+    main()


### PR DESCRIPTION
Sorry, I had issues with my Github yesterday and left early! Here's my pull request for the gene set enrichment skill.

It:
- Implements comprehensive gene set enrichment analysis using Enrichr API
- Queries multiple pathway libraries: KEGG 2021, GO Biological Process, GO Molecular Function
- Parses JSON responses to extract p-values, adjusted p-values, z-scores, and overlapping genes
- Consolidates results from all libraries, sorted by statistical significance
- Generates publication-quality visualizations with dual-panel charts
- Produces markdown reports with top pathways table and full CSV results
- Includes CLI with demo mode for testing

Also adds helper scripts for Enrichr API interaction:
- post_gene_list_to_enrichr.py: Upload gene lists to Enrichr
- get_enrichr_results.py: Fetch and parse enrichment results
