### PR TITLE
fix: scope scRNA checks to relevant changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,37 @@ jobs:
           git diff --stat HEAD~1 HEAD >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      scrna: ${{ steps.filter.outputs.scrna }}
+      scrna_embedding: ${{ steps.filter.outputs.scrna_embedding }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            scrna:
+              - "skills/scrna-orchestrator/**"
+              - "skills/bio-orchestrator/**"
+              - "clawbio/**"
+              - "clawbio.py"
+              - "pytest.ini"
+              - "requirements.txt"
+              - ".github/workflows/ci.yml"
+            scrna_embedding:
+              - "skills/scrna-embedding/**"
+              - "skills/bio-orchestrator/**"
+              - "clawbio/**"
+              - "clawbio.py"
+              - "pytest.ini"
+              - "requirements.txt"
+              - ".github/workflows/ci.yml"
+
   skill-lint:
     runs-on: ubuntu-latest
     steps:
@@ -94,6 +125,8 @@ jobs:
         run: python -m pytest skills/rnaseq-de/tests/test_rnaseq_de.py -v
 
   scrna-test:
+    needs: changes
+    if: needs.changes.outputs.scrna == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -117,6 +150,8 @@ jobs:
         run: python -m pytest skills/scrna-orchestrator/tests/test_scrna_orchestrator.py -v -rA
 
   scrna-embedding-test:
+    needs: changes
+    if: needs.changes.outputs.scrna_embedding == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+OPT_IN_FLAG = "--include-rna"
+RNA_TEST_DIRS = {
+    "skills/diff-visualizer/tests",
+    "skills/rnaseq-de/tests",
+    "skills/scrna-embedding/tests",
+    "skills/scrna-orchestrator/tests",
+}
+
+
+def pytest_addoption(parser) -> None:
+    parser.addoption(
+        OPT_IN_FLAG,
+        action="store_true",
+        default=False,
+        help="Run resource-intensive RNA/scRNA skill tests during default collection.",
+    )
+
+
+def _is_rna_suite(path: Path, root: Path) -> bool:
+    try:
+        relative = path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return False
+    return any(relative == suite or relative.startswith(f"{suite}/") for suite in RNA_TEST_DIRS)
+
+
+def _explicit_targets(config, root: Path) -> list[Path]:
+    targets: list[Path] = []
+    for arg in config.invocation_params.args:
+        if not arg or arg.startswith("-"):
+            continue
+        target = Path(arg)
+        if not target.is_absolute():
+            target = root / target
+        targets.append(target.resolve())
+    return targets
+
+
+def _is_explicit_target(path: Path, targets: list[Path]) -> bool:
+    resolved = path.resolve()
+    for target in targets:
+        if resolved == target:
+            return True
+        if resolved.is_relative_to(target):
+            return True
+        if target.is_relative_to(resolved):
+            return True
+    return False
+
+
+def pytest_ignore_collect(collection_path: Path, config) -> bool:
+    root = Path(str(config.rootpath)).resolve()
+    candidate = Path(collection_path).resolve()
+
+    if not _is_rna_suite(candidate, root):
+        return False
+    if config.getoption(OPT_IN_FLAG):
+        return False
+    if _is_explicit_target(candidate, _explicit_targets(config, root)):
+        return False
+    return True


### PR DESCRIPTION
## Summary
- skip the `scrna-test` and `scrna-embedding-test` jobs unless a PR changes scRNA-related code or shared inputs they depend on
- keep the existing job names so required check configuration stays stable
- make local `pytest` opt-in for heavy RNA/scRNA suites via `--include-rna`, while preserving explicit path-based runs

## Why
Unrelated PRs were still triggering the heavy scRNA workflows, which added several extra minutes of CI time and unnecessary resource usage.

## Validation
- `python -m pytest skills/scrna-orchestrator/tests/test_scrna_orchestrator.py --collect-only -q`
- `python -m pytest skills/scrna-embedding/tests/test_scrna_embedding.py --collect-only -q`
- `python -m pytest --collect-only -q --continue-on-collection-errors 2>&1 | rg "skills/(diff-visualizer|rnaseq-de|scrna-orchestrator|scrna-embedding)" -n` returns no matches by default
- `python -m pytest --include-rna --collect-only -q --continue-on-collection-errors 2>&1 | rg "skills/(diff-visualizer|rnaseq-de|scrna-orchestrator|scrna-embedding)" -n`
- parsed `.github/workflows/ci.yml` successfully with Python + PyYAML

## Notes
- Full default collection in the current local environment still hits an unrelated pre-existing dependency issue in `skills/methylation-clock/tests/test_methylation_clock.py` because `pyaging` is not installed.
