### PR TITLE
Add minimal scANVI support to scrna-embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ report/
 | [Galaxy Bridge](skills/galaxy-bridge/) | **MVP** | Search, run, and chain 8,000+ Galaxy bioinformatics tools |
 | [RNA-seq DE](skills/rnaseq-de/) | **MVP** | Bulk/pseudo-bulk differential expression with QC + PCA + contrasts |
 | [Methylation Clock](skills/methylation-clock/) | **MVP** | Epigenetic age from methylation arrays with PyAging clocks |
-| [scRNA Embedding](skills/scrna-embedding/) | **MVP** | scVI latent embedding, batch integration, and stable `integrated.h5ad` export for downstream latent analysis |
+| [scRNA Embedding](skills/scrna-embedding/) | **MVP** | scVI/scANVI latent embedding, batch integration, and stable `integrated.h5ad` export for downstream latent analysis |
 | [scRNA Orchestrator](skills/scrna-orchestrator/) | **MVP** | Scanpy automation: QC, optional doublet detection, clustering, markers, annotation, latent downstream mode, contrastive markers |
 | [Diff Visualizer](skills/diff-visualizer/) | **MVP** | Rich downstream visualisation for bulk RNA-seq DE and scRNA marker/contrast outputs |
 | [Proteomics DE](skills/proteomics-de/) | **MVP** | Differential expression for label-free quantitative (LFQ) intensity data (MaxQuant, DIA-NN) |

--- a/clawbio.py
+++ b/clawbio.py
@@ -328,11 +328,13 @@ SKILLS = {
     "scrna-embedding": {
         "script": SKILLS_DIR / "scrna-embedding" / "scrna_embedding.py",
         "demo_args": ["--demo"],
-        "description": "scRNA Embedding (scVI latent embedding, optional batch integration, stable integrated h5ad export)",
+        "description": "scRNA Embedding (scVI/scANVI latent embedding, optional batch integration, stable integrated h5ad export)",
         "allowed_extra_flags": {
             "--method",
             "--layer",
             "--batch-key",
+            "--labels-key",
+            "--unlabeled-category",
             "--min-genes",
             "--min-cells",
             "--max-mt-pct",
@@ -967,6 +969,12 @@ def main():
     run_parser.add_argument("--method", default=None, help="Embedding backend (scrna-embedding skill)")
     run_parser.add_argument("--layer", default=None, help="Raw-count layer for `.h5ad` input (scrna-embedding skill)")
     run_parser.add_argument("--batch-key", default=None, help="obs batch column for integration (scrna-embedding skill)")
+    run_parser.add_argument("--labels-key", default=None, help="obs label column for scANVI (scrna-embedding skill)")
+    run_parser.add_argument(
+        "--unlabeled-category",
+        default=None,
+        help="Category value representing unlabeled cells for scANVI (scrna-embedding skill)",
+    )
     run_parser.add_argument("--min-genes", type=int, default=None, help="Minimum genes per cell (scrna/scrna-embedding skill)")
     run_parser.add_argument("--min-cells", type=int, default=None, help="Minimum cells per gene (scrna/scrna-embedding skill)")
     run_parser.add_argument(
@@ -1179,6 +1187,10 @@ def main():
             extra.extend(["--layer", args.layer])
         if getattr(args, "batch_key", None):
             extra.extend(["--batch-key", args.batch_key])
+        if getattr(args, "labels_key", None):
+            extra.extend(["--labels-key", args.labels_key])
+        if getattr(args, "unlabeled_category", None):
+            extra.extend(["--unlabeled-category", args.unlabeled_category])
         if getattr(args, "min_genes", None) is not None:
             extra.extend(["--min-genes", str(args.min_genes)])
         if getattr(args, "min_cells", None) is not None:

--- a/llms.txt
+++ b/llms.txt
@@ -35,7 +35,7 @@
 
 - [vcf-annotator](skills/vcf-annotator/SKILL.md): VEP, ClinVar, gnomAD variant annotation
 - [lit-synthesizer](skills/lit-synthesizer/SKILL.md): PubMed/bioRxiv literature search and LLM summarisation
-- [scrna-embedding](skills/scrna-embedding/SKILL.md): scVI latent embedding, batch integration, and stable integrated.h5ad export
+- [scrna-embedding](skills/scrna-embedding/SKILL.md): scVI/scANVI latent embedding, batch integration, and stable integrated.h5ad export
 - [scrna-orchestrator](skills/scrna-orchestrator/SKILL.md): Scanpy single-cell RNA-seq automation with latent downstream mode and contrastive markers
 - [struct-predictor](skills/struct-predictor/SKILL.md): AlphaFold/Boltz protein structure prediction
 - [repro-enforcer](skills/repro-enforcer/SKILL.md): Conda/Singularity/Nextflow reproducibility export

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -128,7 +128,7 @@ TRIGGER_KEYWORDS: dict[str, list[str]] = {
     "equity-scorer": ["HEIM", "equity", "FST", "heterozygosity", "population representation"],
     "nutrigx_advisor": ["nutrition", "nutrigenomics", "diet genetics", "MTHFR", "caffeine", "lactose"],
     "scrna-orchestrator": ["single-cell", "scrna", "h5ad", "mtx", "10x", "scanpy", "umap", "leiden"],
-    "scrna-embedding": ["scvi", "latent", "embedding", "integration", "batch correction", "10x"],
+    "scrna-embedding": ["scvi", "scanvi", "latent", "embedding", "integration", "batch correction", "10x"],
     "rnaseq-de": ["differential expression", "bulk rna", "rna-seq", "count matrix", "deseq2", "pydeseq2"],
     "diff-visualizer": ["visualize de results", "de visualization", "marker heatmap", "marker dotplot", "top genes heatmap"],
     "claw-ancestry-pca": ["ancestry", "PCA", "admixture", "SGDP", "population structure"],

--- a/skills/bio-orchestrator/SKILL.md
+++ b/skills/bio-orchestrator/SKILL.md
@@ -41,7 +41,7 @@ You are the **Bio Orchestrator**, a ClawBio meta-agent for bioinformatics analys
 | FASTQ/BAM files | seq-wrangler | "Run QC on my reads", "Align to GRCh38" |
 | PDB file or protein query | struct-predictor | "Predict structure of BRCA1", "Compare to AlphaFold" |
 | h5ad/10x Matrix Market input | scrna-orchestrator | "Cluster my single-cell data", "Find marker genes" |
-| scVI / latent integration request | scrna-embedding | "Run scVI on my h5ad", "Batch-correct this dataset", "Build a latent embedding" |
+| scVI / scANVI / latent integration request | scrna-embedding | "Run scVI on my h5ad", "Run scANVI on my labeled h5ad", "Batch-correct this dataset", "Build a latent embedding" |
 | Bulk RNA-seq counts + metadata | rnaseq-de | "Run DESeq2 on this count matrix", "volcano plot for treated vs control" |
 | `integrated.h5ad` / `X_scvi` downstream request | scrna-orchestrator | "Use integrated.h5ad to find markers", "Annotate after scVI", "Run contrastive markers on X_scvi" |
 | Finished DE / marker result tables | diff-visualizer | "Visualize DE results", "Make a marker heatmap", "Top genes heatmap" |

--- a/skills/bio-orchestrator/orchestrator.py
+++ b/skills/bio-orchestrator/orchestrator.py
@@ -66,6 +66,7 @@ KEYWORD_MAP: dict[str, str] = {
     "dragen": "illumina-bridge",
     "illumina": "illumina-bridge",
     "scvi": "scrna-embedding",
+    "scanvi": "scrna-embedding",
     "batch correction": "scrna-embedding",
     "batch integration": "scrna-embedding",
     "integration": "scrna-embedding",

--- a/skills/bio-orchestrator/tests/test_orchestrator.py
+++ b/skills/bio-orchestrator/tests/test_orchestrator.py
@@ -120,6 +120,7 @@ class TestDetectSkillFromQuery:
         ("What is the equity score?", "equity-scorer"),
         ("Run polygenic risk score", "gwas-prs"),
         ("Look up rs12345", "gwas-lookup"),
+        ("Run scanvi on my h5ad", "scrna-embedding"),
         ("Show me differential expression", "rnaseq-de"),
         ("Predict protein structure", "struct-predictor"),
         ("Search pubmed for papers", "lit-synthesizer"),

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "generated_by": "scripts/generate_catalog.py",
-  "skill_count": 33,
+  "skill_count": 39,
   "galaxy_tool_count": 8182,
   "skills": [
     {
@@ -11,7 +11,7 @@
       "version": "0.1.0",
       "status": "mvp",
       "has_script": true,
-      "has_tests": false,
+      "has_tests": true,
       "has_demo": true,
       "demo_command": "python skills/bio-orchestrator/orchestrator.py --demo",
       "dependencies": [],
@@ -94,7 +94,7 @@
     {
       "name": "claw-metagenomics",
       "cli_alias": "metagenomics",
-      "description": "Shotgun metagenomics profiling \u2014 taxonomy, resistome, and functional pathways",
+      "description": "Shotgun metagenomics profiling — taxonomy, resistome, and functional pathways",
       "version": "0.1.0",
       "status": "mvp",
       "has_script": true,
@@ -148,6 +148,27 @@
       "chaining_partners": [
         "equity-scorer"
       ]
+    },
+    {
+      "name": "clinical-trial-finder",
+      "cli_alias": null,
+      "description": "Find clinical trials for a gene, variant, or condition from ClinicalTrials.gov + EUCTR, with FHIR R4 output",
+      "version": "0.1.0",
+      "status": "planned",
+      "has_script": true,
+      "has_tests": true,
+      "has_demo": true,
+      "demo_command": "python skills/clinical-trial-finder/euctr.py --demo",
+      "dependencies": [],
+      "tags": [
+        "clinical-trials",
+        "genomics",
+        "drug-discovery",
+        "clinical",
+        "precision-medicine"
+      ],
+      "trigger_keywords": [],
+      "chaining_partners": []
     },
     {
       "name": "clinpgx",
@@ -222,7 +243,7 @@
     {
       "name": "drug-photo",
       "cli_alias": "drugphoto",
-      "description": "Medication photo to personalised PGx dosage card via Claude vision \u2014 snap a pill, get genotype-informed guidance",
+      "description": "Medication photo to personalised PGx dosage card via Claude vision — snap a pill, get genotype-informed guidance",
       "version": "0.1.0",
       "status": "mvp",
       "has_script": false,
@@ -272,7 +293,7 @@
     {
       "name": "galaxy-bridge",
       "cli_alias": "galaxy",
-      "description": "Galaxy tool discovery, intelligent recommendation, and execution \u2014 8,000+ bioinformatics tools from usegalaxy.org with multi-signal scoring and workflow suggestions",
+      "description": "Galaxy tool discovery, intelligent recommendation, and execution — 8,000+ bioinformatics tools from usegalaxy.org with multi-signal scoring and workflow suggestions",
       "version": "0.2.0",
       "status": "mvp",
       "has_script": true,
@@ -338,9 +359,30 @@
       ]
     },
     {
+      "name": "genome-match",
+      "cli_alias": null,
+      "description": "Score genetic compatibility across all male-female pairings in a Genomebook generation",
+      "version": "0.1.0",
+      "status": "planned",
+      "has_script": true,
+      "has_tests": false,
+      "has_demo": true,
+      "demo_command": "python skills/genome-match/genome_match.py --demo",
+      "dependencies": [],
+      "tags": [
+        "genomebook",
+        "compatibility",
+        "heterozygosity",
+        "disease-risk",
+        "mating-selection"
+      ],
+      "trigger_keywords": [],
+      "chaining_partners": []
+    },
+    {
       "name": "gwas-lookup",
       "cli_alias": "gwas",
-      "description": "Federated variant lookup across 9 genomic databases \u2014 GWAS Catalog, Open Targets, PheWeb (UKB, FinnGen, BBJ), GTEx, eQTL Catalogue, and more.",
+      "description": "Federated variant lookup across 9 genomic databases — GWAS Catalog, Open Targets, PheWeb (UKB, FinnGen, BBJ), GTEx, eQTL Catalogue, and more.",
       "version": "0.1.0",
       "status": "mvp",
       "has_script": true,
@@ -438,9 +480,33 @@
       "chaining_partners": []
     },
     {
+      "name": "methylation-clock",
+      "cli_alias": null,
+      "description": "Compute epigenetic age from DNA methylation arrays using PyAging clocks from GEO accessions or local files.",
+      "version": "0.1.0",
+      "status": "planned",
+      "has_script": true,
+      "has_tests": true,
+      "has_demo": true,
+      "demo_command": "python skills/methylation-clock/methylation_clock.py --demo",
+      "dependencies": [],
+      "tags": [
+        "epigenetics",
+        "methylation",
+        "aging",
+        "clock",
+        "pyaging",
+        "GEO",
+        "illlumina-450k",
+        "EPIC"
+      ],
+      "trigger_keywords": [],
+      "chaining_partners": []
+    },
+    {
       "name": "nutrigx_advisor",
       "cli_alias": "nutrigx",
-      "description": "Personalised nutrition report from consumer genetic data (23andMe, AncestryDNA, VCF) \u2014 interrogates nutritionally-relevant SNPs and generates actionable dietary guidance, all computed locally.",
+      "description": "Personalised nutrition report from consumer genetic data (23andMe, AncestryDNA, VCF) — interrogates nutritionally-relevant SNPs and generates actionable dietary guidance, all computed locally.",
       "version": "0.1.0",
       "status": "mvp",
       "has_script": true,
@@ -494,7 +560,7 @@
     {
       "name": "pharmgx-reporter",
       "cli_alias": "pharmgx",
-      "description": "Pharmacogenomic report from DTC genetic data (23andMe/AncestryDNA) \u2014 12 genes, 31 SNPs, 51 drugs",
+      "description": "Pharmacogenomic report from DTC genetic data (23andMe/AncestryDNA) — 12 genes, 31 SNPs, 51 drugs",
       "version": "0.1.0",
       "status": "mvp",
       "has_script": true,
@@ -553,6 +619,80 @@
       ]
     },
     {
+      "name": "proteomics-de",
+      "cli_alias": null,
+      "description": "Differential expression analysis for label-free quantitative (LFQ) intensity data with standard MaxQuant and DIA-NN output. Workflow includes preprocessing, imputation, and statistical testing.",
+      "version": "0.1.0",
+      "status": "planned",
+      "has_script": true,
+      "has_tests": true,
+      "has_demo": true,
+      "demo_command": "python skills/proteomics-de/proteomics_de.py --demo",
+      "dependencies": [],
+      "tags": [],
+      "trigger_keywords": [],
+      "chaining_partners": []
+    },
+    {
+      "name": "protocols-io",
+      "cli_alias": null,
+      "description": ">-",
+      "version": "0.2.0",
+      "status": "planned",
+      "has_script": true,
+      "has_tests": true,
+      "has_demo": true,
+      "demo_command": "python skills/protocols-io/protocols_io.py --demo",
+      "dependencies": [],
+      "tags": [
+        "protocols",
+        "lab-methods",
+        "reproducibility",
+        "protocols-io",
+        "scientific-methods",
+        "DOI"
+      ],
+      "trigger_keywords": [],
+      "chaining_partners": []
+    },
+    {
+      "name": "pubmed-summariser",
+      "cli_alias": null,
+      "description": ">-",
+      "version": "0.1.0",
+      "status": "planned",
+      "has_script": true,
+      "has_tests": true,
+      "has_demo": true,
+      "demo_command": "python skills/pubmed-summariser/pubmed_api.py --demo",
+      "dependencies": [],
+      "tags": [],
+      "trigger_keywords": [],
+      "chaining_partners": []
+    },
+    {
+      "name": "recombinator",
+      "cli_alias": null,
+      "description": "Produce offspring genomes from parent pairs via meiotic recombination, mutation, and clinical evaluation",
+      "version": "0.1.0",
+      "status": "planned",
+      "has_script": true,
+      "has_tests": false,
+      "has_demo": true,
+      "demo_command": "python skills/recombinator/recombinator.py --demo",
+      "dependencies": [],
+      "tags": [
+        "genomebook",
+        "recombination",
+        "meiosis",
+        "mutation",
+        "offspring",
+        "clinical-genetics"
+      ],
+      "trigger_keywords": [],
+      "chaining_partners": []
+    },
+    {
       "name": "repro-enforcer",
       "cli_alias": null,
       "description": "Export any bioinformatics analysis as a reproducible bundle with Conda environment, Singularity container definition, and Nextflow pipeline.",
@@ -578,7 +718,17 @@
       "has_demo": true,
       "demo_command": "python clawbio.py run rnaseq --demo",
       "dependencies": [],
-      "tags": [],
+      "tags": [
+        "rna-seq",
+        "differential expression",
+        "bulk",
+        "pseudo-bulk",
+        "transcriptomics",
+        "DESeq2",
+        "PyDESeq2",
+        "QC",
+        "PCA"
+      ],
       "trigger_keywords": [
         "differential expression",
         "bulk rna",
@@ -594,7 +744,7 @@
     {
       "name": "scrna-embedding",
       "cli_alias": "scrna-embedding",
-      "description": "Local scVI-based single-cell latent embedding and batch-aware integration from raw-count .h5ad or 10x Matrix Market input, with stable integrated AnnData export for downstream latent analysis.",
+      "description": "Local scVI/scANVI-based single-cell latent embedding and batch-aware integration from raw-count .h5ad or 10x Matrix Market input, with stable integrated AnnData export for downstream latent analysis.",
       "version": "0.1.0",
       "status": "mvp",
       "has_script": true,
@@ -606,6 +756,7 @@
         "scrna",
         "single-cell",
         "scvi",
+        "scanvi",
         "embedding",
         "integration",
         "batch-correction",
@@ -614,6 +765,7 @@
       ],
       "trigger_keywords": [
         "scvi",
+        "scanvi",
         "latent",
         "embedding",
         "integration",
@@ -673,6 +825,26 @@
       "chaining_partners": []
     },
     {
+      "name": "soul2dna",
+      "cli_alias": null,
+      "description": "Compile SOUL.md character profiles into synthetic diploid genomes (.genome.json) via trait-to-allele mapping",
+      "version": "0.1.0",
+      "status": "planned",
+      "has_script": true,
+      "has_tests": false,
+      "has_demo": true,
+      "demo_command": "python skills/soul2dna/soul2dna.py --demo",
+      "dependencies": [],
+      "tags": [
+        "genomebook",
+        "synthetic-genomics",
+        "soul-compiler",
+        "trait-mapping"
+      ],
+      "trigger_keywords": [],
+      "chaining_partners": []
+    },
+    {
       "name": "struct-predictor",
       "cli_alias": null,
       "description": "Local protein structure prediction with AlphaFold, Boltz, or Chai. Compare predicted structures, compute RMSD, visualise 3D models.",
@@ -688,13 +860,38 @@
       "chaining_partners": []
     },
     {
+      "name": "target-validation-scorer",
+      "cli_alias": null,
+      "description": "Evidence-grounded target validation scoring with GO/NO-GO decisions for drug discovery campaigns",
+      "version": "1.0.0",
+      "status": "planned",
+      "has_script": true,
+      "has_tests": true,
+      "has_demo": true,
+      "demo_command": "python skills/target-validation-scorer/target_validation_scorer.py --demo",
+      "dependencies": [
+        "pandas>=2.0",
+        "matplotlib>=3.7",
+        "numpy>=1.24"
+      ],
+      "tags": [
+        "drug-discovery",
+        "target-validation",
+        "evidence-grading",
+        "decision-support",
+        "kinase"
+      ],
+      "trigger_keywords": [],
+      "chaining_partners": []
+    },
+    {
       "name": "ukb-navigator",
       "cli_alias": null,
-      "description": "Semantic search across UK Biobank's 12,000+ data fields and publications \u2014 find the right variables for your research question.",
+      "description": "Semantic search across UK Biobank's 12,000+ data fields and publications — find the right variables for your research question.",
       "version": "0.1.0",
       "status": "mvp",
       "has_script": true,
-      "has_tests": false,
+      "has_tests": true,
       "has_demo": true,
       "demo_command": "python skills/ukb-navigator/ukb_navigator.py --demo",
       "dependencies": [],
@@ -705,6 +902,28 @@
         "biobank schema",
         "data showcase"
       ],
+      "chaining_partners": []
+    },
+    {
+      "name": "variant-annotation",
+      "cli_alias": null,
+      "description": "Annotate VCF variants with Ensembl VEP REST, ClinVar significance, gnomAD/population frequency context, and prioritized variant ranking.",
+      "version": "0.1.0",
+      "status": "planned",
+      "has_script": true,
+      "has_tests": true,
+      "has_demo": true,
+      "demo_command": "python skills/variant-annotation/variant_annotation.py --demo",
+      "dependencies": [],
+      "tags": [
+        "genomics",
+        "vcf",
+        "variant-annotation",
+        "vep",
+        "clinvar",
+        "gnomad"
+      ],
+      "trigger_keywords": [],
       "chaining_partners": []
     },
     {
@@ -721,129 +940,6 @@
       "tags": [],
       "trigger_keywords": [],
       "chaining_partners": []
-    },
-    {
-      "name": "pubmed-summariser",
-      "cli_alias": null,
-      "description": "Search PubMed for a gene name or disease term and generate a structured research briefing of the top recent English-language papers.",
-      "version": "0.1.0",
-      "status": "mvp",
-      "has_script": true,
-      "has_tests": true,
-      "has_demo": true,
-      "demo_command": "python skills/pubmed-summariser/pubmed_summariser.py --demo --output /tmp/pubmed_demo",
-      "dependencies": [
-        "requests"
-      ],
-      "tags": [
-        "pubmed",
-        "literature",
-        "genomics",
-        "research"
-      ],
-      "trigger_keywords": [
-        "pubmed",
-        "summarise papers",
-        "research briefing",
-        "papers about",
-        "recent studies",
-        "gene papers"
-      ],
-      "chaining_partners": [
-        "lit-synthesizer",
-        "gwas-lookup",
-        "gwas-prs"
-      ]
-    },
-    {
-      "name": "soul2dna",
-      "cli_alias": null,
-      "description": "Compile SOUL.md character profiles into synthetic diploid genomes (.genome.json) via trait-to-allele mapping.",
-      "version": "0.1.0",
-      "status": "mvp",
-      "has_script": true,
-      "has_tests": false,
-      "has_demo": true,
-      "demo_command": "python skills/soul2dna/soul2dna.py --demo",
-      "dependencies": [],
-      "tags": [
-        "genomebook",
-        "synthetic-genomics",
-        "soul-compiler",
-        "trait-mapping"
-      ],
-      "trigger_keywords": [
-        "soul2dna",
-        "soul compiler",
-        "soul to genome",
-        "genomebook compile",
-        "synthetic genome"
-      ],
-      "chaining_partners": [
-        "genome-match",
-        "recombinator"
-      ]
-    },
-    {
-      "name": "genome-match",
-      "cli_alias": null,
-      "description": "Score genetic compatibility across all M x F pairings in a Genomebook generation.",
-      "version": "0.1.0",
-      "status": "mvp",
-      "has_script": true,
-      "has_tests": false,
-      "has_demo": true,
-      "demo_command": "python skills/genome-match/genome_match.py --demo",
-      "dependencies": [],
-      "tags": [
-        "genomebook",
-        "compatibility",
-        "heterozygosity",
-        "disease-risk",
-        "mating-selection"
-      ],
-      "trigger_keywords": [
-        "genome match",
-        "compatibility",
-        "mating pairs",
-        "genomebook match",
-        "heterozygosity"
-      ],
-      "chaining_partners": [
-        "soul2dna",
-        "recombinator"
-      ]
-    },
-    {
-      "name": "recombinator",
-      "cli_alias": null,
-      "description": "Produce offspring genomes from parent pairs via meiotic recombination, mutation, and clinical evaluation.",
-      "version": "0.1.0",
-      "status": "mvp",
-      "has_script": true,
-      "has_tests": false,
-      "has_demo": true,
-      "demo_command": "python skills/recombinator/recombinator.py --demo",
-      "dependencies": [],
-      "tags": [
-        "genomebook",
-        "recombination",
-        "meiosis",
-        "mutation",
-        "offspring"
-      ],
-      "trigger_keywords": [
-        "recombinator",
-        "recombination",
-        "offspring",
-        "breed",
-        "meiosis",
-        "next generation"
-      ],
-      "chaining_partners": [
-        "soul2dna",
-        "genome-match"
-      ]
     }
   ]
 }

--- a/skills/scrna-embedding/SKILL.md
+++ b/skills/scrna-embedding/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: scrna-embedding
-description: Local scVI-based single-cell latent embedding and batch-aware integration from raw-count .h5ad or 10x Matrix Market input, with stable integrated AnnData export for downstream latent analysis.
+description: Local scVI/scANVI-based single-cell latent embedding and batch-aware integration from raw-count .h5ad or 10x Matrix Market input, with stable integrated AnnData export for downstream latent analysis.
 version: 0.1.0
 author: Yonghao Zhao
 license: MIT
-tags: [scrna, single-cell, scvi, embedding, integration, batch-correction, h5ad, 10x]
+tags: [scrna, single-cell, scvi, scanvi, embedding, integration, batch-correction, h5ad, 10x]
 metadata:
   openclaw:
     requires:
@@ -31,6 +31,7 @@ metadata:
         bins: []
     trigger_keywords:
       - scvi
+      - scanvi
       - embedding
       - latent
       - integration
@@ -42,20 +43,20 @@ metadata:
 
 # 🧬 scRNA Embedding
 
-You are **scRNA Embedding**, a specialised ClawBio agent for local single-cell latent embedding and batch-aware integration with scVI.
+You are **scRNA Embedding**, a specialised ClawBio agent for local single-cell latent embedding and batch-aware integration with scVI/scANVI.
 
 ## Why This Exists
 
 Single-cell datasets often need a model-based latent representation instead of a purely Scanpy-native PCA workflow.
 
 - **Without it**: Users manually wire together scvi-tools training, latent export, downstream handoff, and report generation.
-- **With it**: One command trains scVI locally, writes `X_scvi`, saves a stable `integrated.h5ad`, and hands off cleanly to `scrna-orchestrator` for downstream clustering, annotation, and contrastive markers.
+- **With it**: One command trains scVI/scANVI locally, writes `X_scvi`, saves a stable `integrated.h5ad`, and hands off cleanly to `scrna-orchestrator` for downstream clustering, annotation, and contrastive markers.
 - **Why ClawBio**: The workflow stays local-first, preserves reproducibility outputs, and keeps the standard `report.md` / `result.json` contract.
 
 ## Core Capabilities
 
 1. **Raw-count Input Validation**: Accept raw-count `.h5ad` and 10x Matrix Market input; reject processed-like matrices.
-2. **scVI Latent Embedding**: Train `scvi.model.SCVI` with optional batch-aware integration.
+2. **scVI/scANVI Latent Embedding**: Train `scvi.model.SCVI` or refine with `scvi.model.SCANVI` using explicit labels.
 3. **Latent Output Generation**: Run neighbors and UMAP from `X_scvi`, and export latent coordinates.
 4. **Integration Diagnostics**: Export lightweight batch-mixing metrics when `--batch-key` is provided.
 5. **Integrated Export**: Save `integrated.h5ad` with `obsm["X_scvi"]`, log-normalized `X`, and raw counts in `layers["counts"]`.
@@ -71,11 +72,11 @@ Single-cell datasets often need a model-based latent representation instead of a
 
 ## Workflow
 
-When the user asks for scVI embedding, latent integration, or batch correction:
+When the user asks for scVI/scANVI embedding, latent integration, or batch correction:
 
 1. **Validate**: Check raw-count `.h5ad` / 10x input (or `--demo`) and reject processed-like matrices.
 2. **Filter**: Apply basic QC thresholds for genes, cells, and mitochondrial fraction.
-3. **Train**: Fit `scvi.model.SCVI` on HVG raw counts, optionally using `--batch-key`.
+3. **Train**: Fit `scvi.model.SCVI` on HVG raw counts, optionally using `--batch-key`, and refine with `scvi.model.SCANVI` when `--method scanvi` plus explicit labels are provided.
 4. **Project**: Export `X_scvi`, run latent-space neighbors and UMAP.
 5. **Generate**: Write a minimal `report.md`, `result.json`, `integrated.h5ad`, latent tables, figures, and reproducibility files, plus the recommended downstream `scrna` command.
 
@@ -90,6 +91,11 @@ python skills/scrna-embedding/scrna_embedding.py \
 python skills/scrna-embedding/scrna_embedding.py \
   --input <input.h5ad> --output <report_dir> \
   --batch-key sample_id
+
+# scANVI with explicit labels
+python skills/scrna-embedding/scrna_embedding.py \
+  --input <input.h5ad> --output <report_dir> \
+  --method scanvi --labels-key cell_type --unlabeled-category Unknown
 
 # 10x Matrix Market directory
 python skills/scrna-embedding/scrna_embedding.py \
@@ -112,7 +118,7 @@ python clawbio.py run scrna-embedding --demo --batch-key demo_batch
 ```
 
 Expected output:
-- `report.md` with scVI-specific embedding and integration summary
+- `report.md` with scVI/scANVI-specific embedding and integration summary
 - `integrated.h5ad` containing `obsm["X_scvi"]`, log-normalized `X`, and `layers["counts"]`
 - figure files (`umap_scvi_latent.png`)
 - optional batch figure (`umap_scvi_batch.png`) when `--batch-key` is set
@@ -131,6 +137,7 @@ Expected output:
 - Select HVGs (`flavor="seurat"`) for scVI training
 3. **Latent model**:
 - Train `scvi.model.SCVI` on raw-count HVGs
+- Optionally refine with `scvi.model.SCANVI` when `--method scanvi`, `--labels-key`, and `--unlabeled-category` are provided
 - Include batch covariate when `--batch-key` is provided
 4. **Latent downstream analysis**:
 - Save `obsm["X_scvi"]`
@@ -144,6 +151,7 @@ Expected output:
 ## Example Queries
 
 - "Run scVI on my h5ad file"
+- "Run scANVI on my labeled h5ad file"
 - "Integrate my batches with scvi-tools"
 - "Build a latent embedding for this 10x matrix"
 - "Export an integrated h5ad with X_scvi"
@@ -176,7 +184,6 @@ output_directory/
 - `scvi-tools`
 
 **Out of scope (v1)**:
-- `scANVI`
 - `totalVI`
 - multimodal integration
 - condition-level DE

--- a/skills/scrna-embedding/scrna_embedding.py
+++ b/skills/scrna-embedding/scrna_embedding.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""ClawBio scRNA Embedding — scVI latent embedding and integration."""
+"""ClawBio scRNA Embedding — scVI/scANVI latent embedding and integration."""
 
 from __future__ import annotations
 
@@ -30,6 +30,13 @@ from clawbio.common.scrna_io import compute_input_checksum, load_count_adata
 EMBEDDING_ARTIFACT_KEY = "clawbio_scrna_embedding"
 DEFAULT_DOWNSTREAM_REP = "X_scvi"
 DEFAULT_COUNTS_LAYER = "counts"
+
+
+def model_display_name(method: str) -> str:
+    """Return the user-facing model name for a backend identifier."""
+    if method == "scanvi":
+        return "scANVI"
+    return "scVI"
 
 
 def _import_scanpy():
@@ -116,7 +123,7 @@ def build_demo_adata(random_state: int):
 
 def load_demo_adata(random_state: int):
     """Load deterministic local synthetic demo data."""
-    return build_demo_adata(random_state), "synthetic_scvi_demo"
+    return build_demo_adata(random_state), "synthetic_scrna_embedding_demo"
 
 
 def load_data(input_path: str | None, demo: bool, random_state: int, layer: str | None):
@@ -151,8 +158,18 @@ def ensure_output_dir(output_dir: Path) -> None:
 
 def validate_args(args: argparse.Namespace) -> None:
     """Validate basic CLI invariants."""
-    if args.method != "scvi":
+    if args.method not in {"scvi", "scanvi"}:
         raise ValueError(f"Unsupported embedding method: {args.method}")
+    if args.method == "scanvi":
+        if not args.labels_key:
+            raise ValueError("--labels-key is required when --method scanvi.")
+        if not args.unlabeled_category:
+            raise ValueError("--unlabeled-category is required when --method scanvi.")
+    else:
+        if args.labels_key:
+            raise ValueError("--labels-key is only supported when --method scanvi.")
+        if args.unlabeled_category:
+            raise ValueError("--unlabeled-category is only supported when --method scanvi.")
     if args.latent_dim < 2:
         raise ValueError("--latent-dim must be >= 2.")
     if args.max_epochs < 1:
@@ -235,6 +252,57 @@ def prepare_batch_obs(adata, batch_key: str | None) -> tuple[Any, str]:
     return adata, batch_key
 
 
+def prepare_label_obs(
+    adata,
+    *,
+    method: str,
+    labels_key: str | None,
+    unlabeled_category: str | None,
+) -> tuple[Any, dict[str, Any]]:
+    """Validate and standardize label metadata for scANVI."""
+    adata = adata.copy()
+    empty_info = {
+        "labels_key": "",
+        "unlabeled_category": "",
+        "n_unlabeled_cells": 0,
+        "unlabeled_category_present": False,
+        "observed_labels": [],
+    }
+    if method != "scanvi":
+        return adata, empty_info
+
+    assert labels_key is not None
+    assert unlabeled_category is not None
+    if labels_key not in adata.obs.columns:
+        available_cols = ", ".join(sorted(map(str, adata.obs.columns.tolist())))
+        raise ValueError(
+            f"Labels key not found in adata.obs: {labels_key}. Available columns: {available_cols}."
+        )
+
+    raw_labels = adata.obs[labels_key]
+    if raw_labels.isna().any():
+        raise ValueError(
+            f"Labels column '{labels_key}' contains missing values. "
+            "Encode unlabeled cells explicitly and set --unlabeled-category to that value."
+        )
+
+    normalized_labels = raw_labels.astype(str)
+    observed_labels = list(pd.Index(pd.unique(normalized_labels), dtype="object"))
+    categories = observed_labels.copy()
+    if unlabeled_category not in categories:
+        categories.append(unlabeled_category)
+
+    adata.obs[labels_key] = pd.Categorical(normalized_labels, categories=categories)
+    n_unlabeled_cells = int((normalized_labels == unlabeled_category).sum())
+    return adata, {
+        "labels_key": labels_key,
+        "unlabeled_category": unlabeled_category,
+        "n_unlabeled_cells": n_unlabeled_cells,
+        "unlabeled_category_present": n_unlabeled_cells > 0,
+        "observed_labels": observed_labels,
+    }
+
+
 def infer_model_device(model) -> str:
     """Infer the device that a trained scVI model used."""
     device = getattr(model, "device", None)
@@ -277,6 +345,69 @@ def train_scvi_model(
     return model, infer_model_device(model)
 
 
+def train_scanvi_model(
+    scvi_model,
+    *,
+    adata_model,
+    labels_key: str,
+    unlabeled_category: str,
+    max_epochs: int,
+    accelerator: str,
+):
+    """Refine a trained SCVI model with scANVI supervision."""
+    scvi = _import_scvi()
+
+    model = scvi.model.SCANVI.from_scvi_model(
+        scvi_model,
+        adata=adata_model,
+        labels_key=labels_key,
+        unlabeled_category=unlabeled_category,
+    )
+    model.train(
+        max_epochs=max_epochs,
+        accelerator=accelerator,
+        enable_progress_bar=False,
+    )
+    return model, infer_model_device(model)
+
+
+def train_embedding_model(
+    adata_model,
+    *,
+    method: str,
+    batch_key: str | None,
+    labels_key: str | None,
+    unlabeled_category: str | None,
+    latent_dim: int,
+    max_epochs: int,
+    accelerator: str,
+    random_state: int,
+):
+    """Train the requested latent model and return the fitted model/device."""
+    scvi_model, accelerator_used = train_scvi_model(
+        adata_model,
+        batch_key=batch_key,
+        latent_dim=latent_dim,
+        max_epochs=max_epochs,
+        accelerator=accelerator,
+        random_state=random_state,
+    )
+    if method == "scvi":
+        return scvi_model, accelerator_used
+
+    assert labels_key is not None
+    assert unlabeled_category is not None
+    scanvi_model, accelerator_used = train_scanvi_model(
+        scvi_model,
+        adata_model=adata_model,
+        labels_key=labels_key,
+        unlabeled_category=unlabeled_category,
+        max_epochs=max_epochs,
+        accelerator=accelerator,
+    )
+    return scanvi_model, accelerator_used
+
+
 def run_latent_embedding(
     adata_norm_full,
     latent: np.ndarray,
@@ -294,10 +425,18 @@ def run_latent_embedding(
     return adata_latent
 
 
-def prepare_latent_plot_labels(adata, *, batch_key: str) -> tuple[Any, str]:
+def prepare_latent_plot_labels(
+    adata,
+    *,
+    batch_key: str,
+    labels_key: str = "",
+) -> tuple[Any, str]:
     """Pick or derive a categorical obs column for the latent UMAP legend."""
     sc = _import_scanpy()
 
+    if labels_key and labels_key in adata.obs.columns:
+        adata.obs[labels_key] = adata.obs[labels_key].astype(str)
+        return adata, labels_key
     if "demo_truth" in adata.obs.columns:
         adata.obs["demo_truth"] = adata.obs["demo_truth"].astype(str)
         return adata, "demo_truth"
@@ -404,10 +543,11 @@ def plot_core_figures(
     adata,
     figures_dir: Path,
     *,
+    method: str,
     batch_key: str,
     latent_color_key: str,
 ) -> list[Path]:
-    """Create scVI latent-space plots."""
+    """Create latent-space plots for the selected embedding backend."""
     import matplotlib
 
     matplotlib.use("Agg")
@@ -415,6 +555,7 @@ def plot_core_figures(
 
     sc = _import_scanpy()
     figures_dir.mkdir(parents=True, exist_ok=True)
+    method_name = model_display_name(method)
 
     created: list[Path] = []
 
@@ -422,7 +563,7 @@ def plot_core_figures(
         adata,
         color=latent_color_key,
         legend_loc="right margin",
-        title=f"scVI latent UMAP ({latent_color_key})",
+        title=f"{method_name} latent UMAP ({latent_color_key})",
         show=False,
     )
     plt.tight_layout()
@@ -436,7 +577,7 @@ def plot_core_figures(
             adata,
             color=batch_key,
             legend_loc="right margin",
-            title=f"scVI latent UMAP ({batch_key})",
+            title=f"{method_name} latent UMAP ({batch_key})",
             show=False,
         )
         plt.tight_layout()
@@ -478,6 +619,8 @@ def write_integrated_h5ad(
         "params": {
             "method": params["method"],
             "batch_key": params["batch_key"],
+            "labels_key": params["labels_key"],
+            "unlabeled_category": params["unlabeled_category"],
             "latent_dim": params["latent_dim"],
             "n_neighbors": params["n_neighbors"],
         },
@@ -495,6 +638,7 @@ def render_report(
     qc_stats: dict[str, int],
     n_hvg: int,
     params: dict[str, Any],
+    label_info: dict[str, Any],
     accelerator_used: str,
     batch_key: str,
     latent_color_key: str,
@@ -502,6 +646,7 @@ def render_report(
     downstream_command: str,
 ) -> Path:
     """Create markdown report.md."""
+    method_name = model_display_name(params["method"])
     header = generate_report_header(
         title="scRNA Embedding Report",
         skill_name="scrna-embedding",
@@ -511,6 +656,9 @@ def render_report(
             "Input format": input_source["format"] if input_source else "demo",
             "Method": params["method"],
             "Batch key": batch_key or "none",
+            "Labels key": label_info["labels_key"] or "none",
+            "Unlabeled category": label_info["unlabeled_category"] or "none",
+            "Unlabeled cells (after QC)": str(label_info["n_unlabeled_cells"]),
             "Cells (before QC)": str(qc_stats["n_cells_before"]),
             "Cells (after QC)": str(qc_stats["n_cells_after"]),
             "Genes (after QC)": str(qc_stats["n_genes_after"]),
@@ -524,9 +672,25 @@ def render_report(
     batch_section = ""
     if batch_key:
         batch_section = (
-            "![scVI Batch UMAP](figures/umap_scvi_batch.png)\n"
+            f"![{method_name} Batch UMAP](figures/umap_scvi_batch.png)\n"
             f"- Figure file: `figures/umap_scvi_batch.png`\n"
             f"- Colored by: `{batch_key}`\n\n"
+        )
+
+    label_section = ""
+    if label_info["labels_key"]:
+        unlabeled_note = (
+            f"Observed **{label_info['n_unlabeled_cells']}** cells matching "
+            f"`{label_info['unlabeled_category']}` after QC."
+            if label_info["unlabeled_category_present"]
+            else f"No cells matched `{label_info['unlabeled_category']}` after QC; "
+            "the run proceeded with fully labeled cells."
+        )
+        label_section = (
+            "## Label Metadata\n\n"
+            f"- Labels key: `{label_info['labels_key']}`\n"
+            f"- Unlabeled category: `{label_info['unlabeled_category']}`\n"
+            f"- {unlabeled_note}\n\n"
         )
 
     body = f"""## Summary
@@ -542,12 +706,12 @@ def render_report(
 
 ## Core Figures
 
-![scVI Latent UMAP](figures/umap_scvi_latent.png)
+![{method_name} Latent UMAP](figures/umap_scvi_latent.png)
 - Figure file: `figures/umap_scvi_latent.png`
 - Colored by: `{latent_color_key}`
 
 {batch_section}
-## Tables
+{label_section}## Tables
 
 - `tables/latent_embeddings.csv`
 {f"- `tables/{batch_metrics_path.name}`" if batch_metrics_path is not None else ""}
@@ -567,10 +731,11 @@ def render_report(
 - Input validation: raw-count `.h5ad` or 10x Matrix Market input only
 - QC/filtering: `min_genes={params["min_genes"]}`, `min_cells={params["min_cells"]}`, `max_mt_pct={params["max_mt_pct"]}`
 - HVG selection: `n_top_hvg={params["n_top_hvg"]}`
-- Embedding method: `scvi.model.SCVI`
+- Embedding method: `{params["model_class"]}`
 - Training: `latent_dim={params["latent_dim"]}`, `max_epochs={params["max_epochs"]}`, `accelerator={params["accelerator"]}`
+- Labels: `labels_key={label_info["labels_key"] or "none"}`, `unlabeled_category={label_info["unlabeled_category"] or "none"}`
 - Neighbors graph: `use_rep="X_scvi"`, `n_neighbors={params["n_neighbors"]}`
-- Visualization labels: latent UMAP uses `{latent_color_key}`; if no annotation exists, `scvi_latent_group` is derived from the scVI graph for display only
+- Visualization labels: latent UMAP uses `{latent_color_key}`; if no annotation exists, `scvi_latent_group` is derived from the latent graph for display only
 - Output focus: latent embedding export, stable integrated artifact generation, and optional batch-view diagnostics only
 
 ## Reproducibility
@@ -616,6 +781,10 @@ def write_reproducibility(
         cmd_parts.extend(["--layer", args.layer])
     if args.batch_key:
         cmd_parts.extend(["--batch-key", args.batch_key])
+    if args.labels_key:
+        cmd_parts.extend(["--labels-key", args.labels_key])
+    if args.unlabeled_category:
+        cmd_parts.extend(["--unlabeled-category", args.unlabeled_category])
 
     defaults = {
         "--min-genes": 200,
@@ -699,7 +868,7 @@ dependencies:
 
 
 def run_pipeline(args: argparse.Namespace) -> dict[str, Any]:
-    """Run the full scVI embedding pipeline."""
+    """Run the full scVI/scANVI embedding pipeline."""
     validate_args(args)
 
     output_dir = Path(args.output)
@@ -723,12 +892,21 @@ def run_pipeline(args: argparse.Namespace) -> dict[str, Any]:
         max_mt_pct=args.max_mt_pct,
     )
     adata_qc, batch_key = prepare_batch_obs(adata_qc, batch_key)
+    adata_qc, label_info = prepare_label_obs(
+        adata_qc,
+        method=args.method,
+        labels_key=args.labels_key,
+        unlabeled_category=args.unlabeled_category,
+    )
     adata_norm_full, adata_model, n_hvg = prepare_training_data(adata_qc, args.n_top_hvg)
     adata_model, _ = prepare_batch_obs(adata_model, batch_key)
 
-    model, accelerator_used = train_scvi_model(
+    model, accelerator_used = train_embedding_model(
         adata_model,
+        method=args.method,
         batch_key=batch_key or None,
+        labels_key=label_info["labels_key"] or None,
+        unlabeled_category=label_info["unlabeled_category"] or None,
         latent_dim=args.latent_dim,
         max_epochs=args.max_epochs,
         accelerator=args.accelerator,
@@ -744,6 +922,7 @@ def run_pipeline(args: argparse.Namespace) -> dict[str, Any]:
     adata_latent, latent_color_key = prepare_latent_plot_labels(
         adata_latent,
         batch_key=batch_key,
+        labels_key=label_info["labels_key"],
     )
 
     table_paths = write_tables(
@@ -769,13 +948,17 @@ def run_pipeline(args: argparse.Namespace) -> dict[str, Any]:
     figure_paths = plot_core_figures(
         adata_latent,
         figures_dir,
+        method=args.method,
         batch_key=batch_key,
         latent_color_key=latent_color_key,
     )
     params = {
         "method": args.method,
+        "model_class": "scvi.model.SCANVI" if args.method == "scanvi" else "scvi.model.SCVI",
         "layer": args.layer or "",
         "batch_key": batch_key,
+        "labels_key": label_info["labels_key"],
+        "unlabeled_category": label_info["unlabeled_category"],
         "min_genes": args.min_genes,
         "min_cells": args.min_cells,
         "max_mt_pct": args.max_mt_pct,
@@ -801,6 +984,7 @@ def run_pipeline(args: argparse.Namespace) -> dict[str, Any]:
         qc_stats=qc_stats,
         n_hvg=n_hvg,
         params=params,
+        label_info=label_info,
         accelerator_used=accelerator_used,
         batch_key=batch_key,
         latent_color_key=latent_color_key,
@@ -818,6 +1002,10 @@ def run_pipeline(args: argparse.Namespace) -> dict[str, Any]:
             "method": args.method,
             "input_format": input_source["format"] if input_source else "demo",
             "batch_key": batch_key,
+            "labels_key": label_info["labels_key"],
+            "unlabeled_category": label_info["unlabeled_category"],
+            "n_unlabeled_cells": label_info["n_unlabeled_cells"],
+            "unlabeled_category_present": label_info["unlabeled_category_present"],
             "cells_before_qc": qc_stats["n_cells_before"],
             "cells_after_qc": qc_stats["n_cells_after"],
             "genes_after_qc": qc_stats["n_genes_after"],
@@ -833,6 +1021,11 @@ def run_pipeline(args: argparse.Namespace) -> dict[str, Any]:
             "layer": args.layer or "",
             "input_format": input_source["format"] if input_source else "demo",
             "batch_key": batch_key,
+            "labels_key": label_info["labels_key"],
+            "unlabeled_category": label_info["unlabeled_category"],
+            "n_unlabeled_cells": label_info["n_unlabeled_cells"],
+            "unlabeled_category_present": label_info["unlabeled_category_present"],
+            "observed_labels": label_info["observed_labels"],
             "cells_before_qc": qc_stats["n_cells_before"],
             "cells_after_qc": qc_stats["n_cells_after"],
             "genes_after_qc": qc_stats["n_genes_after"],
@@ -875,7 +1068,7 @@ def run_pipeline(args: argparse.Namespace) -> dict[str, Any]:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "ClawBio scRNA Embedding — scVI latent embedding and batch-aware diagnostics"
+            "ClawBio scRNA Embedding — scVI/scANVI latent embedding and batch-aware diagnostics"
         ),
     )
     parser.add_argument(
@@ -885,15 +1078,21 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--output", "-o", default="scrna_embedding_report", help="Output directory")
     parser.add_argument("--demo", action="store_true", help="Run local synthetic demo data")
-    parser.add_argument("--method", choices=("scvi",), default="scvi", help="Embedding backend")
+    parser.add_argument("--method", choices=("scvi", "scanvi"), default="scvi", help="Embedding backend")
     parser.add_argument("--layer", default=None, help="Raw-count layer to use for `.h5ad` input")
     parser.add_argument("--batch-key", default=None, help="obs column for batch-aware integration")
+    parser.add_argument("--labels-key", default=None, help="obs column with labels for scANVI")
+    parser.add_argument(
+        "--unlabeled-category",
+        default=None,
+        help="Category value representing unlabeled cells for scANVI",
+    )
     parser.add_argument("--min-genes", type=int, default=200, help="Minimum genes per cell")
     parser.add_argument("--min-cells", type=int, default=3, help="Minimum cells per gene")
     parser.add_argument("--max-mt-pct", type=float, default=20.0, help="Maximum mitochondrial percentage")
     parser.add_argument("--n-top-hvg", type=int, default=2000, help="Number of highly variable genes")
-    parser.add_argument("--latent-dim", type=int, default=10, help="Latent dimensionality for scVI")
-    parser.add_argument("--max-epochs", type=int, default=20, help="Maximum scVI training epochs")
+    parser.add_argument("--latent-dim", type=int, default=10, help="Latent dimensionality for scVI/scANVI")
+    parser.add_argument("--max-epochs", type=int, default=20, help="Maximum scVI/scANVI training epochs")
     parser.add_argument("--n-neighbors", type=int, default=15, help="Neighbors for graph construction")
     parser.add_argument("--random-state", type=int, default=0, help="Random seed")
     parser.add_argument(

--- a/skills/scrna-embedding/tests/test_scrna_embedding.py
+++ b/skills/scrna-embedding/tests/test_scrna_embedding.py
@@ -96,10 +96,23 @@ def _build_input_matrix() -> tuple[np.ndarray, list[str], pd.DataFrame]:
     return np.vstack(rows), genes, obs
 
 
-def _build_h5ad_input(path: Path, *, with_counts_layer: bool = False, processed_x: bool = False) -> None:
+def _build_h5ad_input(
+    path: Path,
+    *,
+    with_counts_layer: bool = False,
+    processed_x: bool = False,
+    label_column: str | None = None,
+    unlabeled_category: str | None = None,
+    unlabeled_stride: int | None = None,
+) -> None:
     from anndata import AnnData  # type: ignore
 
     x, genes, obs = _build_input_matrix()
+    if label_column:
+        labels = obs["truth"].astype(str).copy()
+        if unlabeled_category and unlabeled_stride:
+            labels.iloc[::unlabeled_stride] = unlabeled_category
+        obs[label_column] = labels
     var = pd.DataFrame(index=pd.Index(genes, dtype="object"))
     matrix = x.astype(np.float32) if processed_x else x.astype(np.int32)
     adata = AnnData(X=matrix, obs=obs, var=var)
@@ -262,6 +275,105 @@ def test_h5ad_input_runs_with_batch_key(tmp_path: Path):
     assert "scvi_latent_group" in latent_table.columns
 
 
+def test_scanvi_h5ad_input_runs_with_partial_unlabeled_cells(tmp_path: Path):
+    _require_scvi_stack()
+    input_path = tmp_path / "scanvi_input.h5ad"
+    output_dir = tmp_path / "scanvi_output"
+    _build_h5ad_input(
+        input_path,
+        label_column="cell_label",
+        unlabeled_category="Unknown",
+        unlabeled_stride=5,
+    )
+
+    result = _run_cmd(
+        [
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_dir),
+            "--method",
+            "scanvi",
+            "--labels-key",
+            "cell_label",
+            "--unlabeled-category",
+            "Unknown",
+            "--batch-key",
+            "batch",
+            "--max-epochs",
+            "2",
+            "--accelerator",
+            "cpu",
+            "--min-genes",
+            "1",
+            "--min-cells",
+            "1",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+
+    payload = json.loads((output_dir / "result.json").read_text())
+    assert payload["summary"]["method"] == "scanvi"
+    assert payload["summary"]["labels_key"] == "cell_label"
+    assert payload["summary"]["unlabeled_category"] == "Unknown"
+    assert payload["summary"]["n_unlabeled_cells"] > 0
+    assert payload["summary"]["unlabeled_category_present"] is True
+    assert payload["summary"]["latent_plot_color_by"] == "cell_label"
+
+    report_text = (output_dir / "report.md").read_text(encoding="utf-8")
+    assert "Observed **" in report_text
+    assert "`Unknown` after QC" in report_text
+
+    from anndata import read_h5ad  # type: ignore
+
+    integrated = read_h5ad(output_dir / "integrated.h5ad")
+    params = integrated.uns["clawbio_scrna_embedding"]["params"]
+    assert params["method"] == "scanvi"
+    assert params["labels_key"] == "cell_label"
+    assert params["unlabeled_category"] == "Unknown"
+
+
+def test_scanvi_all_labeled_input_runs_and_reports_no_unlabeled_cells(tmp_path: Path):
+    _require_scvi_stack()
+    input_path = tmp_path / "scanvi_all_labeled.h5ad"
+    output_dir = tmp_path / "scanvi_all_labeled_output"
+    _build_h5ad_input(input_path, label_column="cell_label")
+
+    result = _run_cmd(
+        [
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_dir),
+            "--method",
+            "scanvi",
+            "--labels-key",
+            "cell_label",
+            "--unlabeled-category",
+            "Unknown",
+            "--batch-key",
+            "batch",
+            "--max-epochs",
+            "2",
+            "--accelerator",
+            "cpu",
+            "--min-genes",
+            "1",
+            "--min-cells",
+            "1",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+
+    payload = json.loads((output_dir / "result.json").read_text())
+    assert payload["summary"]["method"] == "scanvi"
+    assert payload["summary"]["n_unlabeled_cells"] == 0
+    assert payload["summary"]["unlabeled_category_present"] is False
+
+    report_text = (output_dir / "report.md").read_text(encoding="utf-8")
+    assert "No cells matched `Unknown` after QC" in report_text
+
+
 def test_layer_allows_processed_x_when_raw_counts_layer_is_selected(tmp_path: Path):
     _require_scvi_stack()
     input_path = tmp_path / "layered.h5ad"
@@ -418,9 +530,122 @@ def test_clawbio_runner_accepts_whitelisted_embedding_flags(tmp_path: Path):
     assert (output_dir / "result.json").exists()
 
 
+def test_scanvi_requires_labels_key(tmp_path: Path):
+    _require_scvi_stack()
+    output_dir = tmp_path / "scanvi_missing_labels_key"
+    result = _run_cmd(
+        [
+            "--demo",
+            "--output",
+            str(output_dir),
+            "--method",
+            "scanvi",
+            "--unlabeled-category",
+            "Unknown",
+        ]
+    )
+    assert result.returncode != 0
+    assert "--labels-key is required when --method scanvi." in result.stderr
+
+
+def test_scanvi_requires_unlabeled_category(tmp_path: Path):
+    _require_scvi_stack()
+    output_dir = tmp_path / "scanvi_missing_unlabeled"
+    result = _run_cmd(
+        [
+            "--demo",
+            "--output",
+            str(output_dir),
+            "--method",
+            "scanvi",
+            "--labels-key",
+            "demo_truth",
+        ]
+    )
+    assert result.returncode != 0
+    assert "--unlabeled-category is required when --method scanvi." in result.stderr
+
+
+def test_scanvi_rejects_missing_labels_column(tmp_path: Path):
+    _require_scvi_stack()
+    input_path = tmp_path / "scanvi_bad_labels_key.h5ad"
+    output_dir = tmp_path / "scanvi_bad_labels_key_output"
+    _build_h5ad_input(input_path)
+
+    result = _run_cmd(
+        [
+            "--input",
+            str(input_path),
+            "--output",
+            str(output_dir),
+            "--method",
+            "scanvi",
+            "--labels-key",
+            "missing_label",
+            "--unlabeled-category",
+            "Unknown",
+            "--min-genes",
+            "1",
+            "--min-cells",
+            "1",
+        ]
+    )
+    assert result.returncode != 0
+    assert "Labels key not found in adata.obs: missing_label." in result.stderr
+
+
+def test_scvi_rejects_scanvi_only_label_flags(tmp_path: Path):
+    _require_scvi_stack()
+    output_dir = tmp_path / "scvi_bad_label_flags"
+    result = _run_cmd(
+        [
+            "--demo",
+            "--output",
+            str(output_dir),
+            "--labels-key",
+            "demo_truth",
+        ]
+    )
+    assert result.returncode != 0
+    assert "--labels-key is only supported when --method scanvi." in result.stderr
+
+
+def test_clawbio_runner_accepts_scanvi_flags(tmp_path: Path):
+    _require_scvi_stack()
+    output_dir = tmp_path / "clawbio_scanvi_output"
+    result = _run_clawbio_cmd(
+        [
+            "--demo",
+            "--output",
+            str(output_dir),
+            "--method",
+            "scanvi",
+            "--labels-key",
+            "demo_truth",
+            "--unlabeled-category",
+            "Unknown",
+            "--latent-dim",
+            "6",
+            "--max-epochs",
+            "2",
+            "--accelerator",
+            "cpu",
+            "--min-genes",
+            "1",
+            "--min-cells",
+            "1",
+        ]
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads((output_dir / "result.json").read_text())
+    assert payload["summary"]["method"] == "scanvi"
+    assert payload["summary"]["labels_key"] == "demo_truth"
+
+
 def test_orchestrator_routes_embedding_keywords_to_new_skill():
     module = _load_orchestrator_module()
     assert module.detect_skill_from_query("Run scvi batch correction on my h5ad") == "scrna-embedding"
+    assert module.detect_skill_from_query("Run scanvi on my labeled h5ad") == "scrna-embedding"
     assert module.detect_skill_from_query("Build a latent embedding for this single-cell dataset") == "scrna-embedding"
     assert module.detect_skill_from_query("Cluster my h5ad and find marker genes") == "scrna-orchestrator"
     assert module.detect_skill_from_query("Use integrated.h5ad with X_scvi to find markers") == "scrna-orchestrator"


### PR DESCRIPTION
## Summary
- add minimal scANVI support to scrna-embedding with explicit label inputs
- keep the existing integrated.h5ad/X_scvi downstream contract intact
- update routing, docs, and catalog metadata

## Testing
- python -m pytest skills/scrna-embedding/tests/test_scrna_embedding.py skills/bio-orchestrator/tests/test_orchestrator.py -v