### PR TITLE
Fix source for claude-code marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
       "homepage": "https://clawbio.ai",
       "repository": "https://github.com/ClawBio/ClawBio",
       "license": "MIT",
-      "source": ".",
+      "source": "./",
       "category": "life-sciences",
       "keywords": [
         "bioinformatics",


### PR DESCRIPTION
## Summary

<!-- What does this PR do? 1-3 bullet points. -->

This commit fixed the source field in `.claude-plugin/marketplace.json`

## Detail
Running the official provided plugin installation command for claude-code:
```bash
/plugin marketplace add ClawBio/ClawBio
```

An error occurs:
```
/plugin marketplace add ClawBio/ClawBio
  ⎿  Error: Failed to parse marketplace file at /Users/czw/.claude/plugins/marketplaces/ClawBio-ClawBio/.claude-plugin/marketplace.json: Invalid schema:
     /Users/czw/.claude/plugins/marketplaces/ClawBio-ClawBio/.claude-plugin/marketplace.json plugins.0.source: Invalid input
```

Claude Code [official documents](https://code.claude.com/docs/en/plugin-marketplaces#plugin-sources) saying that: Local directory within the marketplace repo. Must start with `./`
<img width="1458" height="822" alt="image" src="https://github.com/user-attachments/assets/0789622d-0baf-486d-b0d4-de8003ca70b6" />
