### PR TITLE
fix(struct-predictor): preserve Boltz-2 output structure

### DIFF
--- a/skills/struct-predictor/SKILL.md
+++ b/skills/struct-predictor/SKILL.md
@@ -72,16 +72,22 @@ Predict a two-chain complex:
 
 ```
 output_dir/
-  report.md              # primary markdown report
-  viewer.html            # self-contained 3Dmol.js 3D viewer (open in browser)
-  result.json            # machine-readable summary
-  structure.cif          # predicted structure (copied from boltz output)
+  boltz_results_[name]/                    # Boltz native output
+    lightning_logs/                        # training/eval logs
+    predictions/
+      [name]/
+        [name]_model_0.cif                 # predicted structure (pLDDT in B-factors)
+        confidence_[name]_model_0.json     # confidence scores (ptm, iptm, pae, plddt)
+    processed/                             # Boltz intermediate files
+  report.md                                # primary markdown report
+  viewer.html                              # self-contained 3Dmol.js 3D viewer (open in browser)
+  result.json                              # machine-readable summary
   figures/
-    plddt.png            # per-residue pLDDT confidence plot
-    pae.png              # PAE inter-residue error heatmap
+    plddt.png                              # per-residue pLDDT confidence plot
+    pae.png                                # PAE inter-residue error heatmap
   reproducibility/
-    commands.sh          # exact boltz predict command used
-    environment.txt      # boltz version snapshot
+    commands.sh                            # exact boltz predict command used
+    environment.txt                        # boltz version snapshot
 ```
 
 ## YAML Complex Format

--- a/skills/struct-predictor/core/report.py
+++ b/skills/struct-predictor/core/report.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import importlib.metadata
 import json
-import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -79,12 +78,10 @@ def generate_report(
     _plot_plddt(output_dir / "figures" / "plddt.png", plddt, chain_boundaries)
     _plot_pae(output_dir / "figures" / "pae.png", pae, chain_boundaries)
 
-    shutil.copy2(cif_path, output_dir / "structure.cif")
-
     from core.viewer import generate_viewer_html
     generate_viewer_html(
         output_path=output_dir / "viewer.html",
-        cif_path=output_dir / "structure.cif",
+        cif_path=cif_path,
         plddt=plddt,
         chain_boundaries=chain_boundaries,
     )

--- a/skills/struct-predictor/struct_predictor.py
+++ b/skills/struct-predictor/struct_predictor.py
@@ -68,10 +68,10 @@ def run_struct_prediction(
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    with tempfile.TemporaryDirectory(prefix="struct_predictor_") as _tmpdir:
+    # Step 1: Prepare input YAML in a temp dir (adds msa: empty for offline run)
+    with tempfile.TemporaryDirectory(prefix="struct_predictor_input_") as _tmpdir:
         work_dir = Path(_tmpdir)
 
-        # --- Step 1: Prepare input ---
         if demo:
             print(f"  Demo mode: {DEMO_NAME} (20 residues, PDB 1L2Y)")
             prepared = validate_and_prepare(_DEMO_YAML, work_dir / "boltz_input")
@@ -83,45 +83,44 @@ def run_struct_prediction(
 
         print(f"  Chains: {len(prepared['sequences'])}, type: {prepared['input_type']}")
 
-        # --- Step 2: Boltz prediction ---
-        boltz_raw_dir = work_dir / "boltz_raw"
+        # Step 2: Boltz writes directly to output_dir, preserving its native layout:
+        #   output_dir/lightning_logs/
+        #   output_dir/predictions/<name>/<name>_model_0.cif
+        #   output_dir/predictions/<name>/confidence_<name>_model_0.json
         print("  Running Boltz-2 prediction...")
         predict_result = run_boltz(
             input_path=prepared["boltz_input_path"],
-            boltz_output_dir=boltz_raw_dir,
-        )
-        cif_path = predict_result["cif_path"]
-        conf_json_path = predict_result["confidence_json_path"]
-
-        cmd = _build_cmd(
-            input_label=input_label,
-            output_dir=output_dir,
-            demo=demo,
+            boltz_output_dir=output_dir,
         )
 
-        # --- Step 3: Extract confidence ---
-        print("  Extracting pLDDT and PAE...")
-        conf = extract_confidence(cif_path, conf_json_path)
-        plddt = conf["plddt"]
-        pae   = conf["pae"]
-        chain_boundaries = conf["chain_boundaries"]
+    cif_path = predict_result["cif_path"]
+    conf_json_path = predict_result["confidence_json_path"]
 
-        print(f"  Mean pLDDT: {plddt.mean():.1f}")
-        print(f"  Residues: {len(plddt)}")
+    cmd = _build_cmd(input_label=input_label, output_dir=output_dir, demo=demo)
 
-        # --- Step 4: Generate report ---
-        print(f"  Writing report to {output_dir}/")
-        generate_report(
-            output_dir=output_dir,
-            sequences_info=prepared["sequences"],
-            plddt=plddt,
-            pae=pae,
-            chain_boundaries=chain_boundaries,
-            cif_path=cif_path,
-            cmd=cmd,
-            input_label=input_label,
-            demo=demo,
-        )
+    # Step 3: Extract confidence
+    print("  Extracting pLDDT and PAE...")
+    conf = extract_confidence(cif_path, conf_json_path)
+    plddt = conf["plddt"]
+    pae   = conf["pae"]
+    chain_boundaries = conf["chain_boundaries"]
+
+    print(f"  Mean pLDDT: {plddt.mean():.1f}")
+    print(f"  Residues: {len(plddt)}")
+
+    # Step 4: Write ClawBio artifacts alongside Boltz output at output_dir root
+    print(f"  Writing report to {output_dir}/")
+    generate_report(
+        output_dir=output_dir,
+        sequences_info=prepared["sequences"],
+        plddt=plddt,
+        pae=pae,
+        chain_boundaries=chain_boundaries,
+        cif_path=cif_path,
+        cmd=cmd,
+        input_label=input_label,
+        demo=demo,
+    )
 
     result = json.loads((output_dir / "result.json").read_text())
     print(f"\n  Report: {output_dir / 'report.md'}")

--- a/skills/struct-predictor/tests/test_struct_predictor.py
+++ b/skills/struct-predictor/tests/test_struct_predictor.py
@@ -483,16 +483,6 @@ class TestReport:
         assert "3Dmol" in html or "3dmol" in html
         assert "data_TEST" in html  # CIF content inlined
 
-    def test_structure_cif_copied(self, tmp_path):
-        plddt, pae, cb, seqs = self._make_inputs()
-        cif_src = tmp_path / "fake.cif"
-        cif_src.write_text("data_TEST\n")
-        generate_report(
-            output_dir=tmp_path / "out", sequences_info=seqs, plddt=plddt,
-            pae=pae, chain_boundaries=cb, cif_path=cif_src,
-            cmd="boltz predict input.yaml", input_label="test.yaml", demo=False,
-        )
-        assert (tmp_path / "out" / "structure.cif").exists()
 
     def test_reproducibility_files(self, tmp_path):
         plddt, pae, cb, seqs = self._make_inputs()
@@ -592,12 +582,15 @@ class TestPipeline:
                 input_path=None, output_dir=tmp_path / "out", demo=True,
             )
 
-        assert (tmp_path / "out" / "report.md").exists()
-        assert (tmp_path / "out" / "result.json").exists()
-        assert (tmp_path / "out" / "structure.cif").exists()
-        assert (tmp_path / "out" / "figures" / "plddt.png").exists()
-        assert (tmp_path / "out" / "figures" / "pae.png").exists()
-        assert (tmp_path / "out" / "viewer.html").exists()
+        out = tmp_path / "out"
+        # ClawBio artifacts at root
+        assert (out / "report.md").exists()
+        assert (out / "result.json").exists()
+        assert (out / "figures" / "plddt.png").exists()
+        assert (out / "figures" / "pae.png").exists()
+        assert (out / "viewer.html").exists()
+        # Boltz native layout preserved — CIF lives in predictions/<name>/
+        assert (out / "predictions" / "Trpcage" / "Trpcage_model_0.cif").exists()
         assert result["demo"] is True
         assert result["n_residues"] == 20
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? 1-3 bullet points. -->
- Preserve Boltz-2 output structure

## Skill affected
struct-predictor

<!-- Which skill does this change? e.g. pharmgx-reporter, equity-scorer, or "new skill: my-skill-name" -->

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology)
- [x] Tests included and passing (`pytest -v`)
- [x] Demo data included for reviewers to test
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

<!-- Paste pytest output or describe how you tested -->
```
pytest -q skills/struct-predictor/tests/test_struct_predictor.py
...............................................                                                                   [100%]
47 passed in 1.77s
```