### PR TITLE
Add ncbi-datasets skill

### DIFF
--- a/skills/ncbi-datasets/SKILL.md
+++ b/skills/ncbi-datasets/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: ncbi-datasets
+description: >-
+  Download genomes, genes, virus sequences, and taxonomy data from NCBI using
+  the datasets and dataformat CLI tools.
+version: 0.1.0
+author: nullvoid42
+domain: datasets
+license: MIT
+
+tags: [
+  ncbi,
+  genomics,
+  bioinformatics,
+  genome-download,
+  gene,
+  virus,
+  taxonomy,
+  datasets,
+  dataformat,
+  refseq,
+  genbank
+]
+
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - datasets
+        - dataformat
+      env: []        
+      config: []
+    always: false
+    homepage: https://www.ncbi.nlm.nih.gov/datasets/
+    os: [macos, linux, windows]
+    install:
+      - kind: conda
+        package: ncbi-datasets-cli
+        channel: conda-forge
+        bins: [datasets, dataformat]
+    trigger_keywords:
+      - ncbi
+      - datasets download
+      - datasets summary
+      - dataformat
+      - download genome
+      - download gene
+      - reference genome
+      - genome accession
+      - gene symbol
+      - ortholog
+      - download virus
+      - sars-cov-2 sequence
+      - taxonomy data
+      - dehydrated download
+      - rehydrate
+      - GCF
+      - GCA
+---
+
+# 🦖 Skill Name
+
+You are **ncbi-datasets**, a specialised ClawBio agent for bioinformatics data downloader. Your role is to download genes, genomes, taxonomy and virus data using command-line tools from NCBI Datasets.
+
+## Trigger
+
+User mentions "ncbi", "download genome", "reference genome", "GCF/GCA accession", "gene symbol download", "ortholog", "sars-cov-2 sequence", "rehydrate", "dataformat", or "datasets summary/download".
+
+## Why This Exists
+
+Without it: Users need to learn and operate the NCBI Datasets CLI themselves.
+
+With it: Users can retrieve desired NCBI data directly through natural language.
+
+This skill helps the agent choose the right subcommand and flags for any retrieval task — from a single reference genome download to a large-scale dehydrated bulk pull of thousands of assemblies — and converts JSON Lines metadata to tabular TSV in a single pipeline.
+
+## Core Capabilities
+
+1. **Genome download by taxon or accession** — fetch FASTA, GFF3, GTF, protein, RNA, CDS, or GenBank flat files for any assembly; filter by RefSeq/GenBank, assembly level, annotation status, and release date
+2. **Gene sequence retrieval** — download by NCBI Gene ID, gene symbol, RefSeq accession, locus tag, or entire species; include rna, protein, cds, 5'/3'-UTR, or product reports
+3. **Ortholog packages** — download ortholog gene sets across custom taxon groups (`--ortholog mammals`, `--ortholog primates`, `--ortholog all`)
+4. **Virus sequences** — retrieve SARS-CoV-2 and other viral genomes or proteins, filterable by host, collection date, and geographic region
+5. **Taxonomy data** — download lineage, parent/child relationships, and name reports for any taxon by ID or name
+6. **Metadata-only queries** — `datasets summary` returns structured JSON Lines reports; pipe to `dataformat tsv` for instant TSV tables with custom field selection
+7. **Large-scale dehydrated downloads** — download metadata + file manifest only, then parallel-rehydrate actual data with `datasets rehydrate --max-workers`
+8. **Preview before downloading** — `--preview` shows package size and file count without transferring data
+
+## Scope
+
+This skill focuses exclusively on interfacing with the NCBI Datasets CLI to retrieve public genomic, gene, virus, and taxonomy data. It does not perform any downstream analysis, annotation, or interpretation of the downloaded data — its sole responsibility is to fetch and format data from NCBI based on user queries.
+
+## Workflow
+
+1. **Identify data type** — genome, gene, virus, or taxonomy?
+2. **Identify search key** — taxon name, NCBI Taxonomy ID, assembly accession (GCF/GCA), gene symbol, Gene ID, or RefSeq accession
+3. **Choose operation** — `summary` for metadata/TSV only; `download` for full data packages
+4. **Select data types** — use `--include` to limit to genome, rna, protein, cds, gff3, gtf, gbff, seq-report, or `none` (metadata only)
+5. **Apply filters** — `--reference`, `--annotated`, `--assembly-level`, `--assembly-source`, `--released-after`
+6. **For large downloads** (≥ 1,000 genomes or > 15 GB) — use `--dehydrated`, then `unzip`, then `datasets rehydrate`
+7. **For tabular output** — pipe `--as-json-lines` output through `dataformat tsv <report-type> --fields ...`
+
+## Input Formats
+
+| Format | Extension | Required Fields | Example |
+|--------|-----------|----------------|---------|
+| Accession list | `.txt` | One accession per line | `GCF_000001405.40` |
+| FASTA (input filter) | `.fa`, `.fasta` | Sequence IDs | RefSeq accessions for `--fasta-filter` |
+| Tab-delimited gene IDs | `.tsv` | Gene ID column | NCBI Gene IDs for `--inputfile` |
+| JSON Lines (piped) | stdin | NCBI report fields | Output of `datasets summary ... --as-json-lines` |
+
+## CLI Reference
+
+> Full CLI reference (all flags, field names, report types): [`references/ncbi-datasets.md`](references/ncbi-datasets.md)
+
+```bash
+# ── Genome metadata as TSV ────────────────────────────────────────────────────
+datasets summary genome taxon human --assembly-source refseq --as-json-lines \
+  | dataformat tsv genome --fields accession,assminfo-name,organism-name,assminfo-level
+
+# ── Download reference genome (FASTA + GFF3) ─────────────────────────────────
+datasets download genome taxon human --reference --include genome,gff3 \
+  --filename human_ref.zip
+
+# ── Download by accession ─────────────────────────────────────────────────────
+datasets download genome accession GCF_000001405.40 --filename human_GRCh38.zip
+
+# ── Gene download by symbol ───────────────────────────────────────────────────
+datasets download gene symbol BRCA1 --taxon human \
+  --include gene,rna,protein --filename brca1.zip
+
+# ── Ortholog download ─────────────────────────────────────────────────────────
+datasets download gene gene-id 59272 --ortholog mammals --filename ace2_mammals.zip
+
+# ── Virus download ────────────────────────────────────────────────────────────
+datasets download virus genome taxon sars-cov-2 --host dog \
+  --filename sarscov2_dog.zip
+
+# ── Taxonomy download ─────────────────────────────────────────────────────────
+datasets download taxonomy taxon 'bos taurus' --include names --parents --children
+
+# ── Large-scale dehydrated workflow ──────────────────────────────────────────
+datasets download genome accession --inputfile accessions.txt \
+  --dehydrated --filename bacteria.zip
+unzip bacteria.zip -d bacteria
+datasets rehydrate --directory bacteria/ --max-workers 20
+
+# ── Preview without downloading ───────────────────────────────────────────────
+datasets download genome taxon human --reference --preview
+
+# ── See ## Demo section for a runnable, zero-auth example ─────────────────────
+```
+
+## Demo
+
+To verify the skill works for retrieving yeast reference genome metadata and outputting a TSV summary:
+
+```bash
+datasets summary genome taxon 'saccharomyces cerevisiae' \
+  --reference --as-json-lines \
+  | dataformat tsv genome \
+  --fields accession,organism-name,assminfo-level,assminfo-release-date
+```
+
+**Expected output**: one header row followed by one TSV data row per reference assembly; columns match the `--fields` values in order. 
+Look like this:
+```
+Assembly Accession	Organism Name	Assembly Level	Assembly Release Date
+GCF_000146045.2	Saccharomyces cerevisiae S288C	Complete Genome	2014-12-17
+```
+
+## Downloaded ZIP file structure
+
+After `unzip ncbi_dataset.zip -d my_dataset/`, the extracted archive contains:
+
+```
+my_dataset/
+├── ncbi_dataset/
+│   └── data/
+│       ├── dataset_catalog.json          # Package manifest and file index
+│       ├── assembly_data_report.jsonl    # Per-assembly metadata (JSON Lines)
+│       ├── GCF_000001405.40/
+│       │   ├── GCF_000001405.40_GRCh38.p14_genomic.fna   # Genomic FASTA
+│       │   ├── genomic.gff               # GFF3 annotation
+│       │   ├── protein.faa               # Protein sequences
+│       │   ├── rna.fna                   # Transcript sequences
+│       │   └── cds_from_genomic.fna      # CDS sequences
+│       └── ...                           # Additional accession dirs
+└── README.md                             # NCBI usage notes
+```
+
+For gene packages the layout is analogous, with `gene.fna`, `rna.fna`, `protein.faa`, and `gene_result.jsonl` under each Gene-ID directory.
+
+## Dependencies
+
+**Required:**
+- `datasets` CLI v16+ (NCBI Datasets command-line tool)
+- `dataformat` CLI v16+ (NCBI JSON Lines → TSV/Excel converter)
+
+**Install via conda (recommended — works on macOS, Linux, Windows):**
+
+```bash
+conda install -c conda-forge ncbi-datasets-cli
+```
+
+**Install via direct download (macOS / Linux / Windows):**
+> See [`references/ncbi-datasets.md § Installation`](references/ncbi-datasets.md#installation) for curl commands, or visit the [official NCBI install guide](https://www.ncbi.nlm.nih.gov/datasets/docs/v2/download-and-install/).
+
+**Optional:**
+- `unzip` / `7z` — for extracting downloaded zip archives
+
+## Error handling
+- Attempt to use --help to retrieve command usage and parameter descriptions
+- Refer to the [NCBI Datasets documentation](https://www.ncbi.nlm.nih.gov/datasets/docs/v2/) for further troubleshooting and guidance
+
+## Safety
+
+- **Local-first**: All data is downloaded directly from NCBI public servers to the local filesystem; no third-party intermediary stores your queries or results
+- **Public databases only**: This skill makes network calls exclusively to `api.ncbi.nlm.nih.gov` and `ftp.ncbi.nlm.nih.gov` — both are unauthenticated public endpoints (API key is optional, not required)
+- **No hardcoded paths**: All output paths use user-supplied `--filename` or relative defaults; no absolute paths are embedded
+- **No hallucination**: Accession numbers, gene IDs, organism names, and field values are fetched live from NCBI — this skill never invents identifiers or fabricates metadata
+- **Preview before large transfers**: Always use `--preview` before downloading multi-GB packages to confirm scope
+- **Disclaimer**: ClawBio is a research and educational tool. It is not a medical device and does not provide clinical diagnoses. Consult a qualified professional before making any clinical or regulatory decisions based on downloaded data.
+
+## Citations
+
+- **NCBI Datasets CLI** — Sayers et al. (2022) "Database resources of the National Center for Biotechnology Information." *Nucleic Acids Research*, 50(D1): D20–D26. https://doi.org/10.1093/nar/gkab1112
+- **NCBI Genome Database** — https://www.ncbi.nlm.nih.gov/genome/
+- **NCBI Datasets Documentation** - https://www.ncbi.nlm.nih.gov/datasets/docs/v2/
+- **RefSeq** — O'Leary et al. (2016) "Reference sequence (RefSeq) database at NCBI: current status, taxonomic expansion, and functional annotation." *Nucleic Acids Research*, 44(D1): D733–D745. https://doi.org/10.1093/nar/gkv1189
+- **NCBI Gene** — https://www.ncbi.nlm.nih.gov/gene/
+- **NCBI Taxonomy** — Schoch et al. (2020) "NCBI Taxonomy: a comprehensive update on curation, resources and tools." *Database*, 2020: baaa062. https://doi.org/10.1093/database/baaa062
+- **NCBI Virus** — Hatcher et al. (2017) "Virus Variation Resource – improved response to emergent viral outbreaks." *Nucleic Acids Research*, 45(D1): D482–D490. https://doi.org/10.1093/nar/gkw1065
+

--- a/skills/ncbi-datasets/references/ncbi-datasets.md
+++ b/skills/ncbi-datasets/references/ncbi-datasets.md
@@ -1,0 +1,449 @@
+# NCBI Datasets CLI Skill
+
+Use the following knowledge to help users work with the NCBI Datasets CLI tools (`datasets` and `dataformat`).
+
+---
+
+## Overview
+
+NCBI Datasets provides two CLI tools:
+- **`datasets`** — download and summarize biological data from NCBI
+- **`dataformat`** — convert JSON Lines metadata into TSV or Excel formats
+
+Data is delivered as zip archives; extracted files reside in `ncbi_dataset/data/`.
+
+---
+
+## Installation
+
+### Conda (recommended)
+```bash
+conda create -n ncbi_datasets
+conda activate ncbi_datasets
+conda install -c conda-forge ncbi-datasets-cli
+```
+
+### curl — macOS (Universal)
+```bash
+curl -o datasets 'https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/v2/mac/datasets'
+curl -o dataformat 'https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/v2/mac/dataformat'
+chmod +x datasets dataformat
+```
+
+### curl — Linux (AMD64)
+```bash
+curl -o datasets 'https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/v2/linux-amd64/datasets'
+curl -o dataformat 'https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/v2/linux-amd64/dataformat'
+chmod +x datasets dataformat
+```
+
+### curl — Windows (64-bit)
+```bash
+curl -o datasets.exe "https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/v2/win64/datasets.exe"
+curl -o dataformat.exe "https://ftp.ncbi.nlm.nih.gov/pub/datasets/command-line/v2/win64/dataformat.exe"
+```
+
+---
+
+## `datasets` — Command Reference
+
+### Top-level subcommands
+| Subcommand | Description |
+|---|---|
+| `summary` | Print metadata report (genome, gene, virus, taxonomy) |
+| `download` | Download data as a zip file |
+| `rehydrate` | Rehydrate a dehydrated (large) dataset |
+| `completion` | Generate shell autocompletion scripts |
+
+### Global flags
+| Flag | Description |
+|---|---|
+| `--api-key string` | NCBI API key (increases rate limits) |
+| `--debug` | Emit debugging info |
+| `--help` | Print detailed help |
+| `--version` | Print version |
+
+---
+
+## Genome Commands
+
+### `datasets summary genome`
+
+```bash
+# By taxon
+datasets summary genome taxon human
+datasets summary genome taxon 'mus musculus'
+
+# By accession (assembly or BioProject)
+datasets summary genome accession GCF_000001405.40
+datasets summary genome accession PRJEB33226
+
+# Filters
+datasets summary genome taxon human --reference
+datasets summary genome taxon human --annotated
+datasets summary genome taxon human --assembly-level complete
+datasets summary genome taxon human --released-after 2020-01-01
+datasets summary genome taxon human --search 'T2T Consortium'
+
+# Sequence report
+datasets summary genome accession GCF_000006945.2 --report sequence --as-json-lines \
+  | dataformat tsv genome-seq --fields accession,genbank-seq-acc,refseq-seq-acc,chr-name
+
+# TSV output with custom fields
+datasets summary genome taxon sharks --assembly-source refseq --as-json-lines \
+  | dataformat tsv genome --fields accession,assminfo-name,annotinfo-name,annotinfo-release-date,organism-name
+```
+
+**`summary genome` flags:**
+| Flag | Values / Default | Description |
+|---|---|---|
+| `--annotated` | — | Limit to annotated genomes |
+| `--assembly-level` | `chromosome,complete,contig,scaffold` | Comma-separated assembly levels |
+| `--assembly-source` | `RefSeq`, `GenBank`, `all` (default) | Source database |
+| `--assembly-version` | `latest` (default), `all` | Version filter |
+| `--as-json-lines` | — | JSON Lines output (required for piping to `dataformat`) |
+| `--exclude-atypical` | — | Exclude atypical assemblies |
+| `--exclude-multi-isolate` | — | Exclude multi-isolate project assemblies |
+| `--from-type` | — | Only records with type material |
+| `--limit` | `all` (default), number | Number of results |
+| `--mag` | `only`, `exclude`, `all` (default) | Metagenome-assembled genomes |
+| `--reference` | — | Limit to reference genomes |
+| `--released-after` | ISO 8601 date | Released on or after date |
+| `--released-before` | ISO 8601 date | Released on or before date |
+| `--report` | `genome` (default), `sequence`, `ids_only` | Report type |
+| `--search` | string | Text search (repeatable) |
+
+---
+
+### `datasets download genome`
+
+```bash
+# By taxon
+datasets download genome taxon human --filename human_dataset.zip
+
+# By accession
+datasets download genome accession GCF_000001405.40 --filename human_GRCh38.zip
+
+# With specific data files
+datasets download genome taxon human --reference --include genome,protein
+datasets download genome taxon human --reference --include genome,rna,cds,protein,gff3
+
+# Metadata only
+datasets download genome taxon human --reference --include none
+
+# Specific chromosomes
+datasets download genome accession GCF_000001405.40 --chromosomes X,Y --include genome,gff3
+
+# Preview without downloading
+datasets download genome taxon human --reference --preview
+```
+
+**`--include` values for genome:**
+| Value | Description |
+|---|---|
+| `genome` | Genomic sequences (FASTA) — default |
+| `rna` | Transcript sequences |
+| `protein` | Amino acid sequences |
+| `cds` | Nucleotide coding sequences |
+| `gff3` | General feature file |
+| `gtf` | Gene transfer format |
+| `gbff` | GenBank flat file |
+| `seq-report` | Sequence report file |
+| `all` | All of the above |
+| `none` | No sequences (metadata only) |
+
+**`download genome` flags:**
+| Flag | Values / Default | Description |
+|---|---|---|
+| `--annotated` | — | Limit to annotated genomes |
+| `--assembly-level` | `chromosome,complete,contig,scaffold` | Assembly level filter |
+| `--assembly-source` | `RefSeq`, `GenBank`, `all` (default) | Source database |
+| `--chromosomes` | comma-separated list or `all` | Limit to specific chromosomes |
+| `--dehydrated` | — | Download metadata only, rehydrate later |
+| `--exclude-atypical` | — | Exclude atypical assemblies |
+| `--fast-zip-validation` | — | Skip zip checksum validation |
+| `--filename` | string | Output filename (default: `ncbi_dataset.zip`) |
+| `--include` | see table above | Data file types to include |
+| `--no-progressbar` | — | Hide progress bar |
+| `--preview` | — | Show package info without downloading |
+| `--reference` | — | Limit to reference genomes |
+| `--released-after` | ISO 8601 date | Released on or after date |
+| `--released-before` | ISO 8601 date | Released on or before date |
+| `--search` | string | Text search (repeatable) |
+
+---
+
+### Large Genome Downloads (Dehydrate → Rehydrate)
+
+Use this workflow for ≥ 1,000 genomes or packages > 15 GB:
+
+```bash
+# Step 1: Download dehydrated package (metadata + file list only)
+datasets download genome accession --inputfile accessions.txt --dehydrated --filename my-genomes.zip
+
+# Step 2: Unzip
+unzip my-genomes.zip -d my-genomes
+
+# Step 3: Download actual data files
+datasets rehydrate --directory my-genomes/
+```
+
+**`rehydrate` flags:**
+| Flag | Description |
+|---|---|
+| `--directory string` | Directory containing unzipped dehydrated package |
+| `--gzip` | Rehydrate to gzip format |
+| `--list` | Dry run: list files that would be downloaded |
+| `--match string` | Only rehydrate files matching this substring |
+| `--max-workers int` | Concurrent download workers (1–30, default: 10) |
+| `--no-progressbar` | Hide progress bar |
+
+---
+
+## Gene Commands
+
+### `datasets summary gene`
+
+```bash
+# By NCBI Gene IDs
+datasets summary gene gene-id 1 2 3 9 10
+
+# By gene symbols
+datasets summary gene symbol ACRV1 A2M --taxon human
+datasets summary gene symbol brca1 --taxon 'mus musculus'
+
+# By RefSeq accession
+datasets summary gene accession NM_020107.5 NP_001334352.2
+
+# By taxon (all genes in species)
+datasets summary gene taxon human
+
+# Product report
+datasets summary gene symbol ACRV1 --report product
+
+# TSV output
+datasets summary gene symbol ACRV1 A2M --as-json-lines \
+  | dataformat tsv gene --fields symbol,gene-id,synonyms
+
+# Predefined summary template
+datasets summary gene symbol ACRV1 A2M --as-json-lines \
+  | dataformat tsv gene --template summary
+
+# Gene ontology table
+datasets summary gene symbol ACRV1 --as-json-lines \
+  | dataformat tsv --template gene-ontology
+```
+
+**`summary gene` flags:**
+| Flag | Values / Default | Description |
+|---|---|---|
+| `--as-json-lines` | — | JSON Lines output (required for piping to `dataformat`) |
+| `--limit` | `all` (default), number | Number of results |
+| `--report` | `gene` (default), `product`, `ids_only` | Report type |
+
+**`summary gene` subcommands:**
+- `gene-id` — by NCBI Gene ID
+- `symbol` — by gene symbol (requires `--taxon` for disambiguation)
+- `accession` — by RefSeq nucleotide or protein accession
+- `taxon` — by species (NCBI Taxonomy ID, scientific or common name)
+- `locus-tag` — by locus tag
+
+---
+
+### `datasets download gene`
+
+```bash
+# By Gene ID
+datasets download gene gene-id 672
+
+# By gene symbol
+datasets download gene symbol ACRV1 A2M --taxon human
+datasets download gene symbol brca1 --taxon 'mus musculus'
+
+# By RefSeq accession
+datasets download gene accession NM_020107.5 NP_001334352.2
+
+# All human genes
+datasets download gene taxon human
+
+# Include specific data types
+datasets download gene gene-id 672 --include gene,protein
+datasets download gene gene-id 672 --include gene,rna,cds,protein
+
+# Metadata only
+datasets download gene gene-id 672 --include none
+
+# Orthologs
+datasets download gene gene-id 59272 --ortholog mammals       # ACE2 in mammals
+datasets download gene symbol cftr --ortholog all              # CFTR complete set
+datasets download gene accession NM_000492.4 --ortholog primates
+
+# Filter sequences by accession
+datasets download gene gene-id 2778 --fasta-filter NC_000020.11,NM_001077490.3
+```
+
+**`--include` values for gene:**
+| Value | Description |
+|---|---|
+| `rna` | Transcript sequences — default |
+| `protein` | Amino acid sequences — default |
+| `gene` | Gene sequences |
+| `cds` | Nucleotide coding sequences |
+| `5p-utr` | 5'-UTR sequences |
+| `3p-utr` | 3'-UTR sequences |
+| `product-report` | Transcript and protein locations/metadata |
+| `none` | No sequences (metadata only) |
+
+**`download gene` flags:**
+| Flag | Description |
+|---|---|
+| `--fasta-filter strings` | Limit sequences to specified RefSeq accessions (comma-separated) |
+| `--fasta-filter-file string` | Read accessions from a file |
+| `--filename string` | Output filename (default: `ncbi_dataset.zip`) |
+| `--include string` | Data file types to include (default: `rna,protein`) |
+| `--no-progressbar` | Hide progress bar |
+| `--ortholog string` | Download ortholog set (`all` or a taxon, e.g. `mammals`, `primates`) |
+| `--preview` | Show package info without downloading |
+
+---
+
+## Virus Commands
+
+```bash
+# Download SARS-CoV-2 genomes from dog hosts
+datasets download virus genome taxon sars-cov-2 --host dog
+
+# Download SARS-CoV-2 spike protein from dog hosts
+datasets download virus protein S --host dog --filename SARS2-spike-dog.zip
+
+# Get virus metadata
+datasets summary virus genome taxon sars-cov-2
+```
+
+---
+
+## Taxonomy Commands
+
+```bash
+# Download taxonomy for a taxon
+datasets download taxonomy taxon 'bos taurus'
+
+# Multiple taxa; include name report
+datasets download taxonomy taxon human,'drosophila melanogaster' --include names
+
+# Include parent and child nodes
+datasets download taxonomy taxon 10116 --parents --children
+```
+
+**Default taxonomy package:** `taxonomy_report.jsonl`, `taxonomy_summary.tsv`, `dataset_catalog.json`
+
+---
+
+## `dataformat` — Command Reference
+
+Converts NCBI JSON Lines metadata into tabular formats.
+
+### Subcommands
+| Subcommand | Description |
+|---|---|
+| `tsv` | Convert to TSV |
+| `excel` | Convert to Excel workbook |
+| `catalog` | Print the package catalog |
+| `completion` | Shell autocompletion |
+| `version` | Print version |
+
+### Report types (used with `tsv` or `excel`)
+| Report type | Description |
+|---|---|
+| `genome` | Genome Assembly Data Report |
+| `genome-seq` | Genome Assembly Sequence Report |
+| `genome-annotations` | Genome Annotation Report |
+| `gene` | Gene Report |
+| `gene-product` | Gene Product Report |
+| `prok-gene` | Prokaryote Gene Report |
+| `prok-gene-location` | Prokaryote Gene Location Report |
+| `virus-genome` | Virus Data Report |
+| `virus-annotation` | Virus Annotation Report |
+| `taxonomy` | Taxonomy Report |
+| `organelle` | Organelle Report |
+| `biocollection` | Biocollection Report |
+| `microbigge` | MicroBIGG-E Data Report |
+
+### `dataformat tsv` key flags
+| Flag | Description |
+|---|---|
+| `--fields field1,field2,...` | Specify columns to output |
+| `--template name` | Use predefined template (`summary`, `gene-ontology`) |
+| `--elide-header` | Omit the header row |
+| `--force` | Skip type check prompt |
+
+### Examples
+```bash
+# Genome TSV with custom fields
+datasets summary genome taxon sharks --assembly-source refseq --as-json-lines \
+  | dataformat tsv genome --fields accession,assminfo-name,organism-name
+
+# Gene TSV with template
+datasets summary gene symbol ACRV1 --as-json-lines \
+  | dataformat tsv gene --template summary
+
+# Gene product report
+datasets summary gene symbol ACRV1 --report product --as-json-lines \
+  | dataformat tsv gene-product --template summary
+
+# Gene ontology
+datasets summary gene symbol ACRV1 --as-json-lines \
+  | dataformat tsv --template gene-ontology
+
+# Sequence report
+datasets summary genome accession GCF_000006945.2 --report sequence --as-json-lines \
+  | dataformat tsv genome-seq --fields accession,genbank-seq-acc,refseq-seq-acc,chr-name
+
+# Excel output
+datasets summary genome taxon human --reference --as-json-lines \
+  | dataformat excel genome --filename human_genomes.xlsx
+```
+
+---
+
+## Shell Autocompletion
+
+```bash
+# bash
+datasets completion bash >> ~/.bashrc
+
+# zsh
+datasets completion zsh >> ~/.zshrc
+
+# fish
+datasets completion fish > ~/.config/fish/completions/datasets.fish
+
+# PowerShell
+datasets completion powershell >> $PROFILE
+```
+
+---
+
+## Key Patterns and Tips
+
+| Pattern | Notes |
+|---|---|
+| Always use `--as-json-lines` when piping to `dataformat` | Required for correct parsing |
+| Use `--inputfile accessions.txt` for large ID lists | One accession per line |
+| Large downloads (≥1000 genomes or >15 GB): use `--dehydrated` + `rehydrate` | Avoids interrupted large transfers |
+| Preview before downloading | `--preview` shows what would be downloaded |
+| API rate limits | Use `--api-key <key>` to increase limits |
+| Custom output filename | `--filename my_data.zip` |
+| Dry run rehydration | `datasets rehydrate --list --directory ...` |
+
+---
+
+## Common Field Names for `dataformat --fields`
+
+**Genome fields:** `accession`, `assminfo-name`, `organism-name`, `organism-tax-id`, `annotinfo-name`, `annotinfo-release-date`, `assminfo-level`, `assminfo-submission-date`, `assminfo-release-date`
+
+**Genome-seq fields:** `accession`, `genbank-seq-acc`, `refseq-seq-acc`, `chr-name`, `seq-length`
+
+**Gene fields:** `symbol`, `gene-id`, `synonyms`, `description`, `tax-name`, `tax-id`, `gene-type`, `transcript-count`
+
+**Gene-product fields:** (use `--template summary` for predefined columns)


### PR DESCRIPTION
## ncbi-datasets Skill

Add the ncbi-datasets skill for downloading genomes, genes, virus sequences, and taxonomy data from NCBI using the datasets and dataformat CLI tools.

### Features
- Genome download by taxon or accession
- Gene sequence retrieval by NCBI Gene ID, symbol, or RefSeq accession
- Ortholog packages across custom taxon groups
- Virus sequences (SARS-CoV-2 and others)
- Taxonomy data download
- Metadata-only queries with TSV output
- Large-scale dehydrated downloads with parallel rehydration

### Files
-  - Main skill file
-  - CLI reference documentation

### Testing
Skill has been tested locally with demo command:
```bash
datasets summary genome taxon 'saccharomyces cerevisiae'   --reference --as-json-lines   | dataformat tsv genome   --fields accession,organism-name,assminfo-level,assminfo-release-date
```

Output:


Author: nullvoid42