### PR TITLE
feat(ro-crate): add write_ro_crate() to reproducibility module

### DIFF
--- a/clawbio/common/reproducibility.py
+++ b/clawbio/common/reproducibility.py
@@ -189,7 +189,7 @@ def write_environment_yml(
     conda_lines = "\n".join(f"  - {dep}" for dep in filtered_conda)
     conda_block = f"\n{conda_lines}" if conda_lines else ""
 
-    # Only emit the pip block when there are pip deps — empty pip: is invalid YAML for conda.
+    # Only emit the pip block when there are pip deps - empty pip: is invalid YAML for conda.
     if pip_deps:
         pip_lines = "\n".join(f"      - {dep}" for dep in pip_deps)
         pip_block = f"  - pip:\n{pip_lines}\n"
@@ -295,7 +295,7 @@ def write_ro_crate(
     crate.root_dataset["datePublished"] = completed_at
     crate.root_dataset["license"] = {"@id": "https://spdx.org/licenses/MIT.html"}
 
-    # Add output files — library manages hasPart automatically
+    # Add output files - library manages hasPart automatically
     result_refs = []
     for f in sorted(output_dir.rglob("*")):
         if f.is_file() and f.name != "ro-crate-metadata.json":
@@ -303,7 +303,7 @@ def write_ro_crate(
             crate.add_file(f, dest_path=rel)
             result_refs.append({"@id": rel})
 
-    # Script as contextual entity — not physically in the crate
+    # Script as contextual entity - not physically in the crate
     crate.add(ContextEntity(crate, script_path, properties={
         "@type": "SoftwareSourceCode",
         "name": skill_name,

--- a/clawbio/common/reproducibility.py
+++ b/clawbio/common/reproducibility.py
@@ -1,14 +1,17 @@
 """Reproducibility helpers for ClawBio skills.
 
-Provides write_checksums, write_environment_yml, and portable-bundle helpers
+Provides write_checksums, write_environment_yml, write_commands_sh,
+write_conda_lock, write_ro_crate (RO-Crate 1.1), and portable-bundle helpers
 (ReproPath, ReproCommand, write_portable_commands_sh), all writing into
 <output_dir>/reproducibility/.
 """
 
 from __future__ import annotations
 
+import json
 import subprocess
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Union
 
@@ -257,3 +260,79 @@ def write_conda_lock(output_dir: Path | str) -> Path:
             "conda-lock is not installed. Install it with: pip install conda-lock"
         )
     return repro_dir / "conda-lock.yml"
+
+
+def write_ro_crate(
+    output_dir: Path | str,
+    *,
+    skill_name: str,
+    skill_version: str,
+    script_path: str,
+    description: str = "",
+    completed_at: str | None = None,
+    params: dict | None = None,
+) -> Path:
+    """Write an RO-Crate 1.1 ro-crate-metadata.json to output_dir.
+
+    Includes a CreateAction for run provenance (schema.org).
+    Returns the path of the written file.
+
+    Warning: every file under output_dir is packaged into the crate metadata
+    via rglob("*"). Callers must not place sensitive files (credentials, raw
+    patient data) in output_dir before calling this function.
+    """
+    from rocrate.rocrate import ROCrate
+    from rocrate.model import ContextEntity
+
+    output_dir = Path(output_dir)
+    completed_at = completed_at or datetime.now(timezone.utc).isoformat()
+    action_id = "#run"
+
+    crate = ROCrate(version="1.1")
+    crate.name = f"{skill_name} run"
+    crate.description = description
+    crate.root_dataset["version"] = skill_version
+    crate.root_dataset["datePublished"] = completed_at
+    crate.root_dataset["license"] = {"@id": "https://spdx.org/licenses/MIT.html"}
+
+    # Add output files — library manages hasPart automatically
+    result_refs = []
+    for f in sorted(output_dir.rglob("*")):
+        if f.is_file() and f.name != "ro-crate-metadata.json":
+            rel = str(f.relative_to(output_dir))
+            crate.add_file(f, dest_path=rel)
+            result_refs.append({"@id": rel})
+
+    # Script as contextual entity — not physically in the crate
+    crate.add(ContextEntity(crate, script_path, properties={
+        "@type": "SoftwareSourceCode",
+        "name": skill_name,
+        "version": skill_version,
+        "programmingLanguage": {"@id": "https://www.python.org/"},
+    }))
+
+    # Flatten PropertyValue params as top-level entities
+    param_refs = []
+    for k, v in (params or {}).items():
+        crate.add(ContextEntity(crate, f"#{k}", properties={
+            "@type": "PropertyValue",
+            "name": k,
+            "value": str(v),
+        }))
+        param_refs.append({"@id": f"#{k}"})
+
+    action_props = {
+        "@type": "CreateAction",
+        "name": f"{skill_name} execution",
+        "instrument": {"@id": script_path},
+        "endTime": completed_at,
+        "result": result_refs,
+    }
+    if param_refs:
+        action_props["object"] = param_refs
+    action = crate.add(ContextEntity(crate, action_id, properties=action_props))
+    crate.root_dataset["mentions"] = action
+
+    path = output_dir / "ro-crate-metadata.json"
+    path.write_text(json.dumps(crate.metadata.generate(), indent=2))
+    return path

--- a/clawbio/common/tests/test_reproducibility.py
+++ b/clawbio/common/tests/test_reproducibility.py
@@ -283,3 +283,112 @@ class TestWriteCondaLock:
             mock_run.side_effect = subprocess.CalledProcessError(1, "conda-lock")
             with pytest.raises(subprocess.CalledProcessError):
                 write_conda_lock(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# TestWriteRoCrate
+# ---------------------------------------------------------------------------
+
+
+import json as _json
+
+from clawbio.common.reproducibility import write_ro_crate
+
+
+class TestWriteRoCrate:
+    def test_creates_metadata_file(self, tmp_path):
+        out = write_ro_crate(
+            tmp_path,
+            skill_name="test-skill",
+            skill_version="0.1.0",
+            script_path="skills/test-skill/test_skill.py",
+        )
+        assert out == tmp_path / "ro-crate-metadata.json"
+        assert out.exists()
+
+    def test_metadata_is_valid_json(self, tmp_path):
+        write_ro_crate(
+            tmp_path,
+            skill_name="test-skill",
+            skill_version="0.1.0",
+            script_path="skills/test-skill/test_skill.py",
+        )
+        data = _json.loads((tmp_path / "ro-crate-metadata.json").read_text())
+        assert "@context" in data
+        assert "@graph" in data
+
+    def test_root_dataset_contains_skill_version(self, tmp_path):
+        write_ro_crate(
+            tmp_path,
+            skill_name="test-skill",
+            skill_version="1.2.3",
+            script_path="skills/test-skill/test_skill.py",
+        )
+        graph = _json.loads((tmp_path / "ro-crate-metadata.json").read_text())["@graph"]
+        root = next(e for e in graph if e.get("@id") == "./")
+        assert root.get("version") == "1.2.3"
+
+    def test_create_action_present(self, tmp_path):
+        write_ro_crate(
+            tmp_path,
+            skill_name="test-skill",
+            skill_version="0.1.0",
+            script_path="skills/test-skill/test_skill.py",
+        )
+        graph = _json.loads((tmp_path / "ro-crate-metadata.json").read_text())["@graph"]
+        actions = [e for e in graph if e.get("@type") == "CreateAction"]
+        assert len(actions) == 1
+        assert actions[0]["instrument"]["@id"] == "skills/test-skill/test_skill.py"
+
+    def test_params_included_as_property_values(self, tmp_path):
+        write_ro_crate(
+            tmp_path,
+            skill_name="test-skill",
+            skill_version="0.1.0",
+            script_path="skills/test-skill/test_skill.py",
+            params={"input": "sample.vcf", "threshold": "0.05"},
+        )
+        graph = _json.loads((tmp_path / "ro-crate-metadata.json").read_text())["@graph"]
+        pv = [e for e in graph if e.get("@type") == "PropertyValue"]
+        names = {e["name"] for e in pv}
+        assert {"input", "threshold"} == names
+
+    def test_output_files_registered_as_has_part(self, tmp_path):
+        (tmp_path / "report.md").write_text("# Report")
+        (tmp_path / "figure.png").write_bytes(b"PNG")
+        write_ro_crate(
+            tmp_path,
+            skill_name="test-skill",
+            skill_version="0.1.0",
+            script_path="skills/test-skill/test_skill.py",
+        )
+        graph = _json.loads((tmp_path / "ro-crate-metadata.json").read_text())["@graph"]
+        root = next(e for e in graph if e.get("@id") == "./")
+        has_part_ids = {e["@id"] for e in root.get("hasPart", [])}
+        assert "report.md" in has_part_ids
+        assert "figure.png" in has_part_ids
+
+    def test_description_propagated(self, tmp_path):
+        write_ro_crate(
+            tmp_path,
+            skill_name="test-skill",
+            skill_version="0.1.0",
+            script_path="skills/test-skill/test_skill.py",
+            description="Demo run for testing",
+        )
+        graph = _json.loads((tmp_path / "ro-crate-metadata.json").read_text())["@graph"]
+        root = next(e for e in graph if e.get("@id") == "./")
+        assert root.get("description") == "Demo run for testing"
+
+    def test_completed_at_override(self, tmp_path):
+        ts = "2026-01-01T00:00:00+00:00"
+        write_ro_crate(
+            tmp_path,
+            skill_name="test-skill",
+            skill_version="0.1.0",
+            script_path="skills/test-skill/test_skill.py",
+            completed_at=ts,
+        )
+        graph = _json.loads((tmp_path / "ro-crate-metadata.json").read_text())["@graph"]
+        action = next(e for e in graph if e.get("@type") == "CreateAction")
+        assert action["endTime"] == ts

--- a/clawbio/common/tests/test_reproducibility.py
+++ b/clawbio/common/tests/test_reproducibility.py
@@ -1,5 +1,6 @@
 """Tests for clawbio.common.reproducibility."""
 
+import json
 import subprocess
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -12,6 +13,7 @@ from clawbio.common.reproducibility import (
     write_environment_yml,
     write_commands_sh,
     write_conda_lock,
+    write_ro_crate,
 )
 
 
@@ -290,11 +292,6 @@ class TestWriteCondaLock:
 # ---------------------------------------------------------------------------
 
 
-import json as _json
-
-from clawbio.common.reproducibility import write_ro_crate
-
-
 class TestWriteRoCrate:
     def test_creates_metadata_file(self, tmp_path):
         out = write_ro_crate(
@@ -313,7 +310,7 @@ class TestWriteRoCrate:
             skill_version="0.1.0",
             script_path="skills/test-skill/test_skill.py",
         )
-        data = _json.loads((tmp_path / "ro-crate-metadata.json").read_text())
+        data = json.loads((tmp_path / "ro-crate-metadata.json").read_text())
         assert "@context" in data
         assert "@graph" in data
 
@@ -324,7 +321,7 @@ class TestWriteRoCrate:
             skill_version="1.2.3",
             script_path="skills/test-skill/test_skill.py",
         )
-        graph = _json.loads((tmp_path / "ro-crate-metadata.json").read_text())["@graph"]
+        graph = json.loads((tmp_path / "ro-crate-metadata.json").read_text())["@graph"]
         root = next(e for e in graph if e.get("@id") == "./")
         assert root.get("version") == "1.2.3"
 
@@ -335,7 +332,7 @@ class TestWriteRoCrate:
             skill_version="0.1.0",
             script_path="skills/test-skill/test_skill.py",
         )
-        graph = _json.loads((tmp_path / "ro-crate-metadata.json").read_text())["@graph"]
+        graph = json.loads((tmp_path / "ro-crate-metadata.json").read_text())["@graph"]
         actions = [e for e in graph if e.get("@type") == "CreateAction"]
         assert len(actions) == 1
         assert actions[0]["instrument"]["@id"] == "skills/test-skill/test_skill.py"
@@ -348,7 +345,7 @@ class TestWriteRoCrate:
             script_path="skills/test-skill/test_skill.py",
             params={"input": "sample.vcf", "threshold": "0.05"},
         )
-        graph = _json.loads((tmp_path / "ro-crate-metadata.json").read_text())["@graph"]
+        graph = json.loads((tmp_path / "ro-crate-metadata.json").read_text())["@graph"]
         pv = [e for e in graph if e.get("@type") == "PropertyValue"]
         names = {e["name"] for e in pv}
         assert {"input", "threshold"} == names
@@ -362,7 +359,7 @@ class TestWriteRoCrate:
             skill_version="0.1.0",
             script_path="skills/test-skill/test_skill.py",
         )
-        graph = _json.loads((tmp_path / "ro-crate-metadata.json").read_text())["@graph"]
+        graph = json.loads((tmp_path / "ro-crate-metadata.json").read_text())["@graph"]
         root = next(e for e in graph if e.get("@id") == "./")
         has_part_ids = {e["@id"] for e in root.get("hasPart", [])}
         assert "report.md" in has_part_ids
@@ -376,7 +373,7 @@ class TestWriteRoCrate:
             script_path="skills/test-skill/test_skill.py",
             description="Demo run for testing",
         )
-        graph = _json.loads((tmp_path / "ro-crate-metadata.json").read_text())["@graph"]
+        graph = json.loads((tmp_path / "ro-crate-metadata.json").read_text())["@graph"]
         root = next(e for e in graph if e.get("@id") == "./")
         assert root.get("description") == "Demo run for testing"
 
@@ -389,6 +386,6 @@ class TestWriteRoCrate:
             script_path="skills/test-skill/test_skill.py",
             completed_at=ts,
         )
-        graph = _json.loads((tmp_path / "ro-crate-metadata.json").read_text())["@graph"]
+        graph = json.loads((tmp_path / "ro-crate-metadata.json").read_text())["@graph"]
         action = next(e for e in graph if e.get("@type") == "CreateAction")
         assert action["endTime"] == ts

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ openai>=1.0
 pydeseq2>=0.4
 google-auth>=2,<3
 google-cloud-bigquery>=3,<4
+rocrate>=0.15.0


### PR DESCRIPTION
## Summary

- Adds `write_ro_crate()` to `clawbio/common/reproducibility.py` — writes a spec-valid RO-Crate 1.1 `ro-crate-metadata.json` into the skill output directory after each pipeline run
- Uses `ROCrate(version="1.1")` from the `rocrate` library for entity management and correct JSON-LD serialisation
- Captures `CreateAction` provenance: run parameters, `endTime`, and all result files as `hasPart`

## Skill affected

All skills (via `clawbio/common/reproducibility.py`)

## Checklist

- [ ] SKILL.md is present and complete (YAML frontmatter + methodology)
- [x] Tests included and passing (`pytest -v`)
- [ ] Demo data included for reviewers to test
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

39 passed in clawbio/common/tests/test_reproducibility.py (TestWriteRoCrate: 8 tests, plus existing tests for write_checksums, write_environment_yml, write_commands_sh, write_conda_lock)

Validated with `roc-validator`: **38/38 REQUIRED checks pass** against `ro-crate-1.1` profile.

## Review response (re: #pullrequestreview-4192255594)

- Added `clawbio/common/tests/test_reproducibility.py::TestWriteRoCrate` with 8 unit tests covering metadata file creation, JSON-LD structure, skill version, CreateAction provenance, PropertyValue params, hasPart registration, description, and completed_at override
- Added docstring warning to `write_ro_crate()` that callers must not place sensitive files in `output_dir` before calling, since `rglob("*")` packages everything into the crate metadata