### PR TITLE
fix: resolve f-string backslash SyntaxError on Python <3.12

### DIFF
--- a/skills/methylation-clock/methylation_clock.py
+++ b/skills/methylation-clock/methylation_clock.py
@@ -273,6 +273,13 @@ def write_report(
         missing_df.groupby("clock").size().to_dict() if not missing_df.empty else {}
     )
 
+    summary_block = "\n".join(summary_rows) if summary_rows else "| (none) | 0 | n/a | n/a |"
+    missing_block = (
+        "No missing clock features were reported by PyAging."
+        if not missing_counts
+        else "\n".join([f"- {clock}: {count}" for clock, count in sorted(missing_counts.items())])
+    )
+
     report = f"""# ClawBio Methylation Clock Report
 
 **Date**: {now}
@@ -293,11 +300,11 @@ def write_report(
 
 | Clock | Non-missing | Mean | Std |
 |---|---:|---:|---:|
-{"\n".join(summary_rows) if summary_rows else "| (none) | 0 | n/a | n/a |"}
+{summary_block}
 
 ## Missing Features
 
-{"No missing clock features were reported by PyAging." if not missing_counts else "\n".join([f"- {clock}: {count}" for clock, count in sorted(missing_counts.items())])}
+{missing_block}
 
 ## Reproducibility
 


### PR DESCRIPTION
## Summary

- Pre-compute `"\n".join(...)` strings before the f-string in `write_report()` (lines 296, 300)
- Fixes `SyntaxError: f-string expression part cannot include a backslash` on Python <3.12

Closes #117

## Test plan

- [ ] Run `python skills/methylation-clock/methylation_clock.py --input skills/methylation-clock/data/GSE139307_small.csv.gz --output /tmp/test` on Python 3.11
- [ ] Verify report.md is generated with correct summary table and missing features section

🤖 Generated with [Claude Code](https://claude.com/claude-code)