### PR TITLE
fix(ci): unblock skill-lint and nutrigx test

### DIFF
--- a/skills/hla-typing/SKILL.md
+++ b/skills/hla-typing/SKILL.md
@@ -47,7 +47,8 @@ metadata:
       config: []
     always: false
     homepage: https://github.com/ClawBio/ClawBio
-    os: [macos, linux]
+    emoji: 🧬
+    os: [darwin, linux]
     install:
       - kind: pip
         package: pandas

--- a/skills/nutrigx_advisor/tests/test_nutrigx.py
+++ b/skills/nutrigx_advisor/tests/test_nutrigx.py
@@ -149,7 +149,7 @@ def test_empty_input_exits_cleanly(tmp_path):
     empty_file = tmp_path / "empty.txt"
     empty_file.write_text("")
     result = subprocess.run(
-        ["/usr/local/bin/python3.11", str(SKILL_DIR / "nutrigx_advisor.py"),
+        [sys.executable, str(SKILL_DIR / "nutrigx_advisor.py"),
          "--input", str(empty_file), "--output", str(tmp_path / "out")],
         capture_output=True, text=True,
     )


### PR DESCRIPTION
## Summary
- `skill-lint` on `hla-typing`: switch `os: [macos, linux]` → `[darwin, linux]` and add `emoji: 🧬`. The linter requires Node.js `process.platform` values.
- `test (3.10/3.11/3.12)` on `nutrigx_advisor`: replace hardcoded `/usr/local/bin/python3.11` in `test_empty_input_exits_cleanly` with `sys.executable` so the test works on hosted GH runners (where Python lives under `/opt/hostedtoolcache`).

Both failures were pre-existing on `main` and were making every open PR show red CI regardless of its own content.

## Verified locally
- `python3 scripts/lint_skills.py` → **47/47 skills discoverable, 0 errors, 0 warnings**
- `pytest skills/nutrigx_advisor/tests/test_nutrigx.py::test_empty_input_exits_cleanly -v` → **PASSED**

## Test plan
- [ ] `skill-lint` job passes on this PR
- [ ] `test (3.10)`, `test (3.11)`, `test (3.12)` all pass
- [ ] Verify `hla-typing` appears as Pass in the OpenClaw discovery table in the job summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)