### PR TITLE
Add ClinPGx URL generation to PharmGx Reporter

### DIFF
--- a/skills/pharmgx-reporter/SKILL.md
+++ b/skills/pharmgx-reporter/SKILL.md
@@ -4,7 +4,7 @@ description: Pharmacogenomic report from DTC genetic data (23andMe/AncestryDNA) 
 version: 0.1.0
 author: Manuel Corpas
 license: MIT
-tags: [pharmacogenomics, CPIC, DTC-genetics, precision-medicine]
+tags: [pharmacogenomics, CPIC, DTC-genetics, precision-medicine, ClinPGx]
 metadata:
   openclaw:
     requires:
@@ -58,6 +58,7 @@ You are **PharmGx Reporter**, a specialised ClawBio agent for pharmacogenomic an
 3. **Call**: Determine star alleles and metaboliser phenotypes per gene
 4. **Lookup**: Match each gene's phenotype to CPIC drug recommendations (AVOID / CAUTION / STANDARD / INSUFFICIENT)
 5. **Report**: Generate `report.md` with gene profile table, drug summary, and clinical alerts
+6. **ClinPGx Link**: Build a clickable ClinPGx URL pre-filled with the patient's genotypes for browsing CPIC, DPWG, and FDA recommendations
 
 ## CLI Reference
 

--- a/skills/pharmgx-reporter/demo_report/report.md
+++ b/skills/pharmgx-reporter/demo_report/report.md
@@ -1,13 +1,53 @@
 # ClawBio PharmGx Report
 
-**Date**: 2026-02-25 19:09 UTC
+**Date**: 2026-04-11 19:27 UTC
 **Input**: `demo_patient.txt`
 **Format detected**: 23andme
-**Checksum (SHA-256)**: `4c2e9c8a7fd58de831187dd847e30509fe72c5aee09ff80d617caa4ae8a0eedb`
-**Total SNPs in file**: 30
-**Pharmacogenomic SNPs found**: 30/30
-**Genes profiled**: 12
-**Drugs assessed**: 51
+**Checksum (SHA-256)**: `ffe44b340edfbb21abf648f00c2ce68715f5c9453a590caef753bc25e316c5cc`
+**Total SNPs in file**: 23
+**Pharmacogenomic SNPs found**: 23/32
+**Genes profiled**: 13
+**Drugs assessed**: 59
+
+---
+
+## DATA QUALITY WARNING
+
+**5 gene(s) have unmapped diplotypes**: CYP2C19, DPYD, TPMT, UGT1A1, NUDT15. These diplotypes could not be matched to a known phenotype. Clinical pharmacogenomic testing is recommended.
+
+**Gene-Specific Limitations:**
+
+- CYP2D6: Copy number variation (gene deletion CYP2D6*5, duplication CYP2D6*1xN/*2xN, hybrid alleles CYP2D6*13/*36) cannot be detected from DTC genotyping data. Phenotype assignment may be incomplete. Clinical-grade CYP2D6 testing includes CNV analysis.
+- CYP3A5: The CYP3A5*7 allele (rs41303343) is an insertion/deletion variant. DTC genotyping platforms use proxy SNP calls that may not accurately detect this allele.
+- UGT1A1: The UGT1A1*28 allele (rs8175347) is a TA-repeat polymorphism that cannot be reliably genotyped by SNP arrays. If rs8175347 is present in the input, the reported genotype is a proxy SNP call and may not reflect true TA repeat count.
+
+---
+
+## Panel Limitations
+
+This report uses **SNP-based genotyping only** from a panel of 32 pharmacogenomic variants. The following cannot be detected:
+
+- **Copy number variants (CNVs)**: Gene deletions (e.g. CYP2D6\*5) and duplications (e.g. CYP2D6\*1xN, \*2xN)
+- **Structural variants**: CYP2D6-CYP2D7 hybrid alleles (e.g. \*13, \*36)
+- **Repeat polymorphisms**: UGT1A1\*28 (TA7 repeat in rs8175347)
+- **HLA typing**: HLA-B\*57:01 (abacavir hypersensitivity)
+- **Mitochondrial variants**: MT-RNR1 m.1555A>G (aminoglycoside ototoxicity)
+- **G6PD deficiency**: G6PD A- and Mediterranean variants
+
+For CYP2D6, a result of 'Normal Metabolizer' does NOT rule out gene deletions or duplications that alter metabolizer status. Clinical-grade CYP2D6 testing includes CNV analysis.
+
+## Genes Not Assessed by This Panel
+
+The following clinically relevant pharmacogenomic genes are **not included** in this panel. Consider targeted testing if indicated:
+
+| Gene | Clinical Relevance | CPIC Guideline |
+|------|-------------------|----------------|
+| HLA-B\*57:01 | Abacavir hypersensitivity | CPIC Abacavir (2014, updated 2020) |
+| HLA-B\*58:01 | Allopurinol hypersensitivity (SJS/TEN) | CPIC Allopurinol (Hershfield 2013, updated 2015) |
+| G6PD | Rasburicase, chloroquine contraindication | CPIC G6PD (2014) |
+| MT-RNR1 | Aminoglycoside ototoxicity | FDA label |
+| HLA-A\*31:01 | Carbamazepine hypersensitivity | CPIC Carbamazepine (2017) |
+| CYP2B6 | Efavirenz metabolism | CPIC Efavirenz (2019) |
 
 ---
 
@@ -15,47 +55,43 @@
 
 | Category | Count |
 |----------|-------|
-| Standard dosing | 21 |
-| Use with caution | 20 |
-| Avoid / use alternative | 10 |
+| Standard dosing | 17 |
+| Use with caution | 24 |
+| Avoid / use alternative | 1 |
+| Insufficient data | 17 |
 
 ### Actionable Alerts
 
 **AVOID / USE ALTERNATIVE:**
 
-- **Codeine** (Tylenol w/ Codeine) [CYP2D6]: Avoid codeine. Select alternative analgesic.
-- **Tramadol** (Ultram) [CYP2D6]: Avoid tramadol. Select alternative analgesic.
-- **Tamoxifen** (Nolvadex) [CYP2D6]: Consider aromatase inhibitor or higher tamoxifen dose with TDM.
-- **Amitriptyline** (Elavil) [CYP2D6]: Avoid TCA. If necessary, reduce dose 50%.
-- **Nortriptyline** (Pamelor) [CYP2D6]: Avoid TCA or reduce dose 50%.
-- **Desipramine** (Norpramin) [CYP2D6]: Avoid TCA or reduce dose 50%.
-- **Imipramine** (Tofranil) [CYP2D6]: Avoid TCA or reduce dose 50%.
-- **Doxepin** (Sinequan) [CYP2D6]: Avoid TCA or reduce dose 50%.
-- **Trimipramine** (Surmontil) [CYP2D6]: Avoid TCA or reduce dose 50%.
-- **Clomipramine** (Anafranil) [CYP2D6]: Avoid TCA or reduce dose 50%.
+- **Warfarin** (Coumadin) [CYP2C9+VKORC1]
 
 **USE WITH CAUTION:**
 
-- **Clopidogrel** (Plavix) [CYP2C19]: Consider alternative antiplatelet therapy (prasugrel, ticagrelor).
-- **Hydrocodone** (Vicodin) [CYP2D6]: Reduced analgesia likely; consider alternative.
-- **Oxycodone** (OxyContin) [CYP2D6]: Reduced analgesia possible; consider alternative.
-- **Paroxetine** (Paxil) [CYP2D6]: Consider 50% dose reduction or alternative SSRI.
-- **Fluoxetine** (Prozac) [CYP2D6]: Consider 50% dose reduction or alternative.
-- **Venlafaxine** (Effexor) [CYP2D6]: Consider 50% dose reduction or switch to desvenlafaxine.
-- **Metoprolol** (Lopressor) [CYP2D6]: Consider 50% dose reduction or alternative beta-blocker.
-- **Ondansetron** (Zofran) [CYP2D6]: May have reduced antiemetic effect; consider alternative.
-- **Risperidone** (Risperdal) [CYP2D6]: Consider 50% dose reduction.
-- **Aripiprazole** (Abilify) [CYP2D6]: Reduce dose to 75% of usual.
-- **Haloperidol** (Haldol) [CYP2D6]: Reduce dose; monitor for side effects.
-- **Atomoxetine** (Strattera) [CYP2D6]: Start at lower dose; 2-fold higher exposure expected.
-- **Phenytoin** (Dilantin) [CYP2C9]: Reduce dose 25%. Monitor levels closely.
-- **Celecoxib** (Celebrex) [CYP2C9]: Start at lowest dose.
-- **Flurbiprofen** (Ansaid) [CYP2C9]: Start at lowest dose.
-- **Piroxicam** (Feldene) [CYP2C9]: Start at lowest dose; monitor.
-- **Meloxicam** (Mobic) [CYP2C9]: Start at lowest dose.
-- **Warfarin** (Coumadin) [CYP2C9+VKORC1]: Reduce initial dose. Use genotype-guided dosing algorithm.
-- **Simvastatin** (Zocor) [SLCO1B1]: Lower dose or alternative statin. 4.5x myopathy risk.
-- **Atorvastatin** (Lipitor) [SLCO1B1]: Consider CK surveillance.
+- **Codeine** (Tylenol w/ Codeine) [CYP2D6]
+- **Tramadol** (Ultram) [CYP2D6]
+- **Hydrocodone** (Vicodin) [CYP2D6]
+- **Tamoxifen** (Nolvadex) [CYP2D6]
+- **Amitriptyline** (Elavil) [CYP2D6]
+- **Nortriptyline** (Pamelor) [CYP2D6]
+- **Desipramine** (Norpramin) [CYP2D6]
+- **Imipramine** (Tofranil) [CYP2D6]
+- **Doxepin** (Sinequan) [CYP2D6]
+- **Trimipramine** (Surmontil) [CYP2D6]
+- **Clomipramine** (Anafranil) [CYP2D6]
+- **Risperidone** (Risperdal) [CYP2D6]
+- **Haloperidol** (Haldol) [CYP2D6]
+- **Phenytoin** (Dilantin) [CYP2C9]
+- **Celecoxib** (Celebrex) [CYP2C9]
+- **Flurbiprofen** (Ansaid) [CYP2C9]
+- **Piroxicam** (Feldene) [CYP2C9]
+- **Meloxicam** (Mobic) [CYP2C9]
+- **Efavirenz** (Sustiva) [CYP2B6]
+- **Methotrexate** (Rheumatrex / Trexall) [MTHFR]
+- **Ibuprofen** (Advil / Motrin) [CYP2C9]
+- **Naproxen** (Aleve / Naprosyn) [CYP2C9]
+- **Propafenone** (Rythmol) [CYP2D6]
+- **Methadone** (Dolophine) [CYP2B6]
 
 ---
 
@@ -63,18 +99,49 @@
 
 | Gene | Full Name | Diplotype | Phenotype |
 |------|-----------|-----------|-----------|
-| CYP2C19 | Cytochrome P450 2C19 | *1/*2 | Intermediate Metabolizer |
-| CYP2D6 | Cytochrome P450 2D6 | *4/*4 | Poor Metabolizer |
-| CYP2C9 | Cytochrome P450 2C9 | *1/*3 | Intermediate Metabolizer |
-| VKORC1 | Vitamin K Epoxide Reductase | GA | Intermediate Warfarin Sensitivity |
-| SLCO1B1 | Solute Carrier Organic Anion Transporter 1B1 | TC | Intermediate Function |
-| DPYD | Dihydropyrimidine Dehydrogenase | Normal/Normal | Normal Metabolizer |
-| TPMT | Thiopurine S-Methyltransferase | *1/*1 | Normal Metabolizer |
-| UGT1A1 | UDP-Glucuronosyltransferase 1A1 | *1/*1 | Normal Metabolizer |
+| CYP2C19 | Cytochrome P450 2C19 | Indeterminate (phase ambiguity: *2(rs4244285) + *17(rs12248560)) | Indeterminate (phase ambiguity: *2(rs4244285) + *17(rs12248560)) |
+| CYP2D6 | Cytochrome P450 2D6 | *2/*41 | Intermediate Metabolizer |
+| CYP2C9 | Cytochrome P450 2C9 | *1/*2 | Intermediate Metabolizer |
+| VKORC1 | Vitamin K Epoxide Reductase | TT | High Warfarin Sensitivity |
+| SLCO1B1 | Solute Carrier Organic Anion Transporter 1B1 | TT | Normal Function |
+| DPYD | Dihydropyrimidine Dehydrogenase | Normal/Normal (2/3 SNPs tested) | Indeterminate (incomplete coverage: 2/3 SNPs tested) |
+| TPMT | Thiopurine S-Methyltransferase | *1/*1 (2/3 SNPs tested) | Indeterminate (incomplete coverage: 2/3 SNPs tested) |
+| UGT1A1 | UDP-Glucuronosyltransferase 1A1 | Indeterminate (rs8175347 not tested) | Indeterminate (rs8175347 not tested) |
 | CYP3A5 | Cytochrome P450 3A5 | *3/*3 | CYP3A5 Non-expressor |
-| CYP2B6 | Cytochrome P450 2B6 | *1/*1 | Normal Metabolizer |
-| NUDT15 | Nudix Hydrolase 15 | *1/*1 | Normal Metabolizer |
+| CYP2B6 | Cytochrome P450 2B6 | *1/*9 | Intermediate Metabolizer |
+| NUDT15 | Nudix Hydrolase 15 | *1/*1 (1/2 SNPs tested) | Indeterminate (incomplete coverage: 1/2 SNPs tested) |
 | CYP1A2 | Cytochrome P450 1A2 | *1/*1F | Normal Metabolizer |
+| MTHFR | Methylenetetrahydrofolate Reductase | 677CC/1298AC | Reduced MTHFR enzyme activity (677CT) |
+| HLA-B | HLA-B*57:01 | Not assessed | Indeterminate (not in panel) |
+| MT-RNR1 | MT-RNR1 (mitochondrial) | Not assessed | Indeterminate (not in panel) |
+| G6PD | Glucose-6-Phosphate Dehydrogenase | Not assessed | Indeterminate (not in panel) |
+| HLA-A | HLA-A*31:01 | Not assessed | Indeterminate (not in panel) |
+
+## Interactive ClinPGx Link
+
+**Explore this patient's pharmacogenomic profile** with CPIC, DPWG, and FDA guideline annotations:
+
+[Open in ClinPGx](https://www.clinpgx.org/genotypeResults?q=%7B%22CYP2D6%22%3A%20%5B%22%2A2%22%2C%20%22%2A41%22%2C%20null%5D%2C%20%22CYP2C9%22%3A%20%5B%22%2A1%22%2C%20%22%2A2%22%2C%20null%5D%2C%20%22CYP3A5%22%3A%20%5B%22%2A3%22%2C%20%22%2A3%22%2C%20null%5D%2C%20%22CYP2B6%22%3A%20%5B%22%2A1%22%2C%20%22%2A9%22%2C%20null%5D%2C%20%22CYP1A2%22%3A%20%5B%22%2A1%22%2C%20%22%2A1F%22%2C%20null%5D%2C%20%22MTHFR%22%3A%20%5B%22677CC%22%2C%20%221298AC%22%2C%20null%5D%7D)
+
+This link pre-fills ClinPGx with the patient's genotypes. No data is uploaded; the genotypes are encoded in the URL itself.
+
+### CPIC Gene References
+
+| Gene | Diplotype | Phenotype | CPIC Guideline |
+|------|-----------|-----------|----------------|
+| CYP2C19 | Indeterminate (phase ambiguity: *2(rs4244285) + *17(rs12248560)) | Indeterminate (phase ambiguity: *2(rs4244285) + *17(rs12248560)) | [CYP2C19 on CPIC](https://cpicpgx.org/gene/cyp2c19/) |
+| CYP2D6 | *2/*41 | Intermediate Metabolizer | [CYP2D6 on CPIC](https://cpicpgx.org/gene/cyp2d6/) |
+| CYP2C9 | *1/*2 | Intermediate Metabolizer | [CYP2C9 on CPIC](https://cpicpgx.org/gene/cyp2c9/) |
+| VKORC1 | TT | High Warfarin Sensitivity | [VKORC1 on CPIC](https://cpicpgx.org/gene/vkorc1/) |
+| SLCO1B1 | TT | Normal Function | [SLCO1B1 on CPIC](https://cpicpgx.org/gene/slco1b1/) |
+| DPYD | Normal/Normal (2/3 SNPs tested) | Indeterminate (incomplete coverage: 2/3 SNPs tested) | [DPYD on CPIC](https://cpicpgx.org/gene/dpyd/) |
+| TPMT | *1/*1 (2/3 SNPs tested) | Indeterminate (incomplete coverage: 2/3 SNPs tested) | [TPMT on CPIC](https://cpicpgx.org/gene/tpmt/) |
+| UGT1A1 | Indeterminate (rs8175347 not tested) | Indeterminate (rs8175347 not tested) | [UGT1A1 on CPIC](https://cpicpgx.org/gene/ugt1a1/) |
+| CYP3A5 | *3/*3 | CYP3A5 Non-expressor | [CYP3A5 on CPIC](https://cpicpgx.org/gene/cyp3a5/) |
+| CYP2B6 | *1/*9 | Intermediate Metabolizer | [CYP2B6 on CPIC](https://cpicpgx.org/gene/cyp2b6/) |
+| NUDT15 | *1/*1 (1/2 SNPs tested) | Indeterminate (incomplete coverage: 1/2 SNPs tested) | [NUDT15 on CPIC](https://cpicpgx.org/gene/nudt15/) |
+| CYP1A2 | *1/*1F | Normal Metabolizer | [CYP1A2 on CPIC](https://cpicpgx.org/gene/cyp1a2/) |
+| MTHFR | 677CC/1298AC | Reduced MTHFR enzyme activity (677CT) | [MTHFR on CPIC](https://cpicpgx.org/gene/mthfr/) |
 
 ## Detected Variants
 
@@ -82,92 +149,93 @@
 |------|------|-------------|----------|--------|
 | rs762551 | CYP1A2 | *1F | AC | increased_function |
 | rs2069514 | CYP1A2 | *1C | GG | decreased_function |
-| rs3745274 | CYP2B6 | *9 | GG | decreased_function |
-| rs28399499 | CYP2B6 | *18 | TT | no_function |
+| rs3745274 | CYP2B6 | *9 | GT | decreased_function |
 | rs4244285 | CYP2C19 | *2 | AG | no_function |
 | rs4986893 | CYP2C19 | *3 | GG | no_function |
-| rs12248560 | CYP2C19 | *17 | CC | increased_function |
-| rs28399504 | CYP2C19 | *4 | AA | no_function |
-| rs1799853 | CYP2C9 | *2 | CC | decreased_function |
-| rs1057910 | CYP2C9 | *3 | AC | decreased_function |
-| rs3892097 | CYP2D6 | *4 | TT | no_function |
-| rs5030655 | CYP2D6 | *6 | TT | no_function |
-| rs16947 | CYP2D6 | *2 | GG | normal_function |
+| rs12248560 | CYP2C19 | *17 | CT | increased_function |
+| rs1799853 | CYP2C9 | *2 | CT | decreased_function |
+| rs1057910 | CYP2C9 | *3 | AA | decreased_function |
+| rs3892097 | CYP2D6 | *4 | CC | no_function |
+| rs16947 | CYP2D6 | *2 | AG | normal_function |
 | rs1065852 | CYP2D6 | *10 | CC | decreased_function |
-| rs28371725 | CYP2D6 | *41 | CC | decreased_function |
+| rs28371725 | CYP2D6 | *41 | CT | decreased_function |
 | rs776746 | CYP3A5 | *3 | GG | no_function |
-| rs10264272 | CYP3A5 | *6 | GG | no_function |
-| rs41303343 | CYP3A5 | *7 | CC | no_function |
 | rs3918290 | DPYD | *2A | CC | no_function |
-| rs55886062 | DPYD | *13 | TT | no_function |
 | rs67376798 | DPYD | D949V | TT | decreased_function |
+| rs1801133 | MTHFR | 677T | GG | decreased_function |
+| rs1801131 | MTHFR | 1298C | GT | decreased_function |
 | rs116855232 | NUDT15 | *3 | CC | no_function |
-| rs147390019 | NUDT15 | *2 | GG | decreased_function |
-| rs4149056 | SLCO1B1 | *5 | TC | decreased_function |
+| rs4149056 | SLCO1B1 | *5 | TT | decreased_function |
 | rs1800460 | TPMT | *3B | CC | no_function |
 | rs1142345 | TPMT | *3C | AA | no_function |
-| rs1800462 | TPMT | *2 | CC | no_function |
-| rs8175347 | UGT1A1 | *28 | CC | decreased_function |
 | rs4148323 | UGT1A1 | *6 | GG | decreased_function |
-| rs9923231 | VKORC1 | -1639G>A | GA | decreased_expression |
+| rs9923231 | VKORC1 | -1639G>A | TT | decreased_expression |
 
 ---
 
 ## Complete Drug Recommendations
 
-| Drug | Brand | Class | Gene | Status | Recommendation |
-|------|-------|-------|------|--------|----------------|
-| Amitriptyline | Elavil | Tricyclic Antidepressant | CYP2D6 | AVOID | Avoid TCA. If necessary, reduce dose 50%. |
-| Clomipramine | Anafranil | Tricyclic Antidepressant | CYP2D6 | AVOID | Avoid TCA or reduce dose 50%. |
-| Codeine | Tylenol w/ Codeine | Opioid Analgesic | CYP2D6 | AVOID | Avoid codeine. Select alternative analgesic. |
-| Desipramine | Norpramin | Tricyclic Antidepressant | CYP2D6 | AVOID | Avoid TCA or reduce dose 50%. |
-| Doxepin | Sinequan | Tricyclic Antidepressant | CYP2D6 | AVOID | Avoid TCA or reduce dose 50%. |
-| Imipramine | Tofranil | Tricyclic Antidepressant | CYP2D6 | AVOID | Avoid TCA or reduce dose 50%. |
-| Nortriptyline | Pamelor | Tricyclic Antidepressant | CYP2D6 | AVOID | Avoid TCA or reduce dose 50%. |
-| Tamoxifen | Nolvadex | SERM (Oncology) | CYP2D6 | AVOID | Consider aromatase inhibitor or higher tamoxifen dose with TDM. |
-| Tramadol | Ultram | Opioid Analgesic | CYP2D6 | AVOID | Avoid tramadol. Select alternative analgesic. |
-| Trimipramine | Surmontil | Tricyclic Antidepressant | CYP2D6 | AVOID | Avoid TCA or reduce dose 50%. |
-| Aripiprazole | Abilify | Antipsychotic | CYP2D6 | CAUTION | Reduce dose to 75% of usual. |
-| Atomoxetine | Strattera | ADHD Medication | CYP2D6 | CAUTION | Start at lower dose; 2-fold higher exposure expected. |
-| Atorvastatin | Lipitor | Statin | SLCO1B1 | CAUTION | Consider CK surveillance. |
-| Celecoxib | Celebrex | NSAID | CYP2C9 | CAUTION | Start at lowest dose. |
-| Clopidogrel | Plavix | Antiplatelet Agent | CYP2C19 | CAUTION | Consider alternative antiplatelet therapy (prasugrel, ticagrelor). |
-| Fluoxetine | Prozac | SSRI Antidepressant | CYP2D6 | CAUTION | Consider 50% dose reduction or alternative. |
-| Flurbiprofen | Ansaid | NSAID | CYP2C9 | CAUTION | Start at lowest dose. |
-| Haloperidol | Haldol | Antipsychotic | CYP2D6 | CAUTION | Reduce dose; monitor for side effects. |
-| Hydrocodone | Vicodin | Opioid Analgesic | CYP2D6 | CAUTION | Reduced analgesia likely; consider alternative. |
-| Meloxicam | Mobic | NSAID | CYP2C9 | CAUTION | Start at lowest dose. |
-| Metoprolol | Lopressor | Beta-Blocker | CYP2D6 | CAUTION | Consider 50% dose reduction or alternative beta-blocker. |
-| Ondansetron | Zofran | Antiemetic | CYP2D6 | CAUTION | May have reduced antiemetic effect; consider alternative. |
-| Oxycodone | OxyContin | Opioid Analgesic | CYP2D6 | CAUTION | Reduced analgesia possible; consider alternative. |
-| Paroxetine | Paxil | SSRI Antidepressant | CYP2D6 | CAUTION | Consider 50% dose reduction or alternative SSRI. |
-| Phenytoin | Dilantin | Antiepileptic | CYP2C9 | CAUTION | Reduce dose 25%. Monitor levels closely. |
-| Piroxicam | Feldene | NSAID | CYP2C9 | CAUTION | Start at lowest dose; monitor. |
-| Risperidone | Risperdal | Antipsychotic | CYP2D6 | CAUTION | Consider 50% dose reduction. |
-| Simvastatin | Zocor | Statin | SLCO1B1 | CAUTION | Lower dose or alternative statin. 4.5x myopathy risk. |
-| Venlafaxine | Effexor | SNRI Antidepressant | CYP2D6 | CAUTION | Consider 50% dose reduction or switch to desvenlafaxine. |
-| Warfarin | Coumadin | Anticoagulant | CYP2C9+VKORC1 | CAUTION | Reduce initial dose. Use genotype-guided dosing algorithm. |
-| Atazanavir | Reyataz | Antiretroviral | UGT1A1 | OK | Use recommended dose. |
-| Azathioprine | Imuran | Immunosuppressant | TPMT | OK | Use recommended dose. |
-| Capecitabine | Xeloda | Antineoplastic | DPYD | OK | Use recommended dose. |
-| Citalopram | Celexa | SSRI Antidepressant | CYP2C19 | OK | Use recommended starting dose. |
-| Clozapine | Clozaril | Antipsychotic | CYP1A2 | OK | Use recommended dose. |
-| Dexlansoprazole | Dexilant | Proton Pump Inhibitor | CYP2C19 | OK | Use recommended starting dose. |
-| Efavirenz | Sustiva | Antiretroviral | CYP2B6 | OK | Use recommended dose. |
-| Escitalopram | Lexapro | SSRI Antidepressant | CYP2C19 | OK | Use recommended starting dose. |
-| Esomeprazole | Nexium | Proton Pump Inhibitor | CYP2C19 | OK | Use recommended starting dose. |
-| Fluorouracil | 5-FU | Antineoplastic | DPYD | OK | Use recommended dose. |
-| Irinotecan | Camptosar | Antineoplastic | UGT1A1 | OK | Use recommended dose. |
-| Lansoprazole | Prevacid | Proton Pump Inhibitor | CYP2C19 | OK | Use recommended starting dose. |
-| Mercaptopurine | Purinethol | Immunosuppressant | TPMT | OK | Use recommended dose. |
-| Omeprazole | Prilosec | Proton Pump Inhibitor | CYP2C19 | OK | Use recommended starting dose. |
-| Pantoprazole | Protonix | Proton Pump Inhibitor | CYP2C19 | OK | Use recommended starting dose. |
-| Pravastatin | Pravachol | Statin | SLCO1B1 | OK | Use desired starting dose. |
-| Rosuvastatin | Crestor | Statin | SLCO1B1 | OK | Use desired starting dose. |
-| Sertraline | Zoloft | SSRI Antidepressant | CYP2C19 | OK | Use recommended starting dose. |
-| Tacrolimus | Prograf | Immunosuppressant | CYP3A5 | OK | Use recommended dose (most patients). |
-| Thioguanine | Tabloid | Immunosuppressant | TPMT | OK | Use recommended dose. |
-| Voriconazole | Vfend | Antifungal | CYP2C19 | OK | Use recommended dose. |
+| Drug | Brand | Class | Gene | Status |
+|------|-------|-------|------|--------|
+| Warfarin | Coumadin | Anticoagulant | CYP2C9+VKORC1 | AVOID |
+| Amitriptyline | Elavil | Tricyclic Antidepressant | CYP2D6 | CAUTION |
+| Celecoxib | Celebrex | NSAID | CYP2C9 | CAUTION |
+| Clomipramine | Anafranil | Tricyclic Antidepressant | CYP2D6 | CAUTION |
+| Codeine | Tylenol w/ Codeine | Opioid Analgesic | CYP2D6 | CAUTION |
+| Desipramine | Norpramin | Tricyclic Antidepressant | CYP2D6 | CAUTION |
+| Doxepin | Sinequan | Tricyclic Antidepressant | CYP2D6 | CAUTION |
+| Efavirenz | Sustiva | Antiretroviral | CYP2B6 | CAUTION |
+| Flurbiprofen | Ansaid | NSAID | CYP2C9 | CAUTION |
+| Haloperidol | Haldol | Antipsychotic | CYP2D6 | CAUTION |
+| Hydrocodone | Vicodin | Opioid Analgesic | CYP2D6 | CAUTION |
+| Ibuprofen | Advil / Motrin | NSAID | CYP2C9 | CAUTION |
+| Imipramine | Tofranil | Tricyclic Antidepressant | CYP2D6 | CAUTION |
+| Meloxicam | Mobic | NSAID | CYP2C9 | CAUTION |
+| Methadone | Dolophine | Opioid Analgesic | CYP2B6 | CAUTION |
+| Methotrexate | Rheumatrex / Trexall | DMARD / Antineoplastic | MTHFR | CAUTION |
+| Naproxen | Aleve / Naprosyn | NSAID | CYP2C9 | CAUTION |
+| Nortriptyline | Pamelor | Tricyclic Antidepressant | CYP2D6 | CAUTION |
+| Phenytoin | Dilantin | Antiepileptic | CYP2C9 | CAUTION |
+| Piroxicam | Feldene | NSAID | CYP2C9 | CAUTION |
+| Propafenone | Rythmol | Antiarrhythmic | CYP2D6 | CAUTION |
+| Risperidone | Risperdal | Antipsychotic | CYP2D6 | CAUTION |
+| Tamoxifen | Nolvadex | SERM (Oncology) | CYP2D6 | CAUTION |
+| Tramadol | Ultram | Opioid Analgesic | CYP2D6 | CAUTION |
+| Trimipramine | Surmontil | Tricyclic Antidepressant | CYP2D6 | CAUTION |
+| Atazanavir | Reyataz | Antiretroviral | UGT1A1 | INDETERMINATE — INSUFFICIENT DATA |
+| Azathioprine | Imuran | Immunosuppressant | TPMT | INDETERMINATE — INSUFFICIENT DATA |
+| Capecitabine | Xeloda | Antineoplastic | DPYD | INDETERMINATE — INSUFFICIENT DATA |
+| Citalopram | Celexa | SSRI Antidepressant | CYP2C19 | INDETERMINATE — INSUFFICIENT DATA |
+| Clopidogrel | Plavix | Antiplatelet Agent | CYP2C19 | INDETERMINATE — INSUFFICIENT DATA |
+| Dexlansoprazole | Dexilant | Proton Pump Inhibitor | CYP2C19 | INDETERMINATE — INSUFFICIENT DATA |
+| Escitalopram | Lexapro | SSRI Antidepressant | CYP2C19 | INDETERMINATE — INSUFFICIENT DATA |
+| Esomeprazole | Nexium | Proton Pump Inhibitor | CYP2C19 | INDETERMINATE — INSUFFICIENT DATA |
+| Fluorouracil | 5-FU | Antineoplastic | DPYD | INDETERMINATE — INSUFFICIENT DATA |
+| Irinotecan | Camptosar | Antineoplastic | UGT1A1 | INDETERMINATE — INSUFFICIENT DATA |
+| Lansoprazole | Prevacid | Proton Pump Inhibitor | CYP2C19 | INDETERMINATE — INSUFFICIENT DATA |
+| Mercaptopurine | Purinethol | Immunosuppressant | TPMT | INDETERMINATE — INSUFFICIENT DATA |
+| Omeprazole | Prilosec | Proton Pump Inhibitor | CYP2C19 | INDETERMINATE — INSUFFICIENT DATA |
+| Pantoprazole | Protonix | Proton Pump Inhibitor | CYP2C19 | INDETERMINATE — INSUFFICIENT DATA |
+| Sertraline | Zoloft | SSRI Antidepressant | CYP2C19 | INDETERMINATE — INSUFFICIENT DATA |
+| Thioguanine | Tabloid | Immunosuppressant | TPMT | INDETERMINATE — INSUFFICIENT DATA |
+| Voriconazole | Vfend | Antifungal | CYP2C19 | INDETERMINATE — INSUFFICIENT DATA |
+| Aripiprazole | Abilify | Antipsychotic | CYP2D6 | OK |
+| Atomoxetine | Strattera | ADHD Medication | CYP2D6 | OK |
+| Atorvastatin | Lipitor | Statin | SLCO1B1 | OK |
+| Bupropion | Wellbutrin / Zyban | Antidepressant / Smoking Cessation | CYP2B6 | OK |
+| Clozapine | Clozaril | Antipsychotic | CYP1A2 | OK |
+| Dextromethorphan | Robitussin DM | Antitussive | CYP2D6 | OK |
+| Diclofenac | Voltaren | NSAID | CYP2C9 | OK |
+| Fluoxetine | Prozac | SSRI Antidepressant | CYP2D6 | OK |
+| Metoprolol | Lopressor | Beta-Blocker | CYP2D6 | OK |
+| Ondansetron | Zofran | Antiemetic | CYP2D6 | OK |
+| Oxycodone | OxyContin | Opioid Analgesic | CYP2D6 | OK |
+| Paroxetine | Paxil | SSRI Antidepressant | CYP2D6 | OK |
+| Pravastatin | Pravachol | Statin | SLCO1B1 | OK |
+| Rosuvastatin | Crestor | Statin | SLCO1B1 | OK |
+| Simvastatin | Zocor | Statin | SLCO1B1 | OK |
+| Tacrolimus | Prograf | Immunosuppressant | CYP3A5 | OK |
+| Venlafaxine | Effexor | SNRI Antidepressant | CYP2D6 | OK |
 
 ---
 
@@ -179,7 +247,7 @@ Pharmacogenomic recommendations are based on CPIC guidelines (cpicpgx.org). DTC 
 
 ## Methods
 
-- **Tool**: ClawBio PharmGx Reporter v0.1.0
+- **Tool**: ClawBio PharmGx Reporter v0.2.0
 - **SNP panel**: 31 pharmacogenomic variants across 12 genes
 - **Star allele calling**: Simplified DTC-compatible algorithm (single-SNP per allele)
 - **Phenotype assignment**: CPIC-based diplotype-to-phenotype mapping
@@ -191,7 +259,7 @@ Pharmacogenomic recommendations are based on CPIC guidelines (cpicpgx.org). DTC 
 python pharmgx_reporter.py --input demo_patient.txt --output report
 ```
 
-**Input checksum**: `4c2e9c8a7fd58de831187dd847e30509fe72c5aee09ff80d617caa4ae8a0eedb`
+**Input checksum**: `ffe44b340edfbb21abf648f00c2ce68715f5c9453a590caef753bc25e316c5cc`
 
 ## References
 
@@ -199,3 +267,4 @@ python pharmgx_reporter.py --input demo_patient.txt --output report
 - CPIC. Clinical Pharmacogenetics Implementation Consortium. https://cpicpgx.org/
 - Caudle, K.E. et al. (2014). Standardizing terms for clinical pharmacogenetic test results. Genet Med, 16(9), 655-663.
 - PharmGKB. https://www.pharmgkb.org/
+- ClinPGx. Clinical Pharmacogenomics. https://www.clinpgx.org/

--- a/skills/pharmgx-reporter/pharmgx_reporter.py
+++ b/skills/pharmgx-reporter/pharmgx_reporter.py
@@ -12,10 +12,12 @@ Usage:
 """
 
 import argparse
+import json
 import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from urllib.parse import quote
 
 # ---------------------------------------------------------------------------
 # Shared library imports
@@ -1566,6 +1568,59 @@ def _evidence_cell_html(enrichment_entry, classification=""):
 
 
 # ---------------------------------------------------------------------------
+# 6b. ClinPGx URL builder
+# ---------------------------------------------------------------------------
+
+def build_clinpgx_url(profiles):
+    """Build a ClinPGx URL pre-filled with the patient's genotypes.
+
+    ClinPGx (https://www.clinpgx.org) accepts a JSON payload as the 'q'
+    query parameter.  The payload maps each gene to a three-element list:
+    [allele1, allele2, null].  The JSON is URL-encoded and appended to
+    https://www.clinpgx.org/genotypeResults?q={encoded}.
+
+    Parameters
+    ----------
+    profiles : dict
+        Gene -> {"diplotype": str, "phenotype": str}.  Diplotypes that
+        contain a "/" separator (e.g. "*1/*2") are split into two alleles.
+        Genes without a diplotype or without "/" are skipped.
+
+    Returns
+    -------
+    str
+        Full ClinPGx URL with encoded genotype payload.
+    """
+    payload = {}
+    for gene, info in profiles.items():
+        dip = info.get("diplotype", "")
+        if not dip or "/" not in dip:
+            continue
+        parts = dip.split("/")
+        if len(parts) != 2:
+            continue
+        payload[gene] = [parts[0], parts[1], None]
+    encoded = quote(json.dumps(payload), safe="")
+    return "https://www.clinpgx.org/genotypeResults?q=" + encoded
+
+
+def build_cpic_gene_url(gene):
+    """Return the CPIC guideline page URL for a given gene.
+
+    Parameters
+    ----------
+    gene : str
+        Gene symbol (e.g. "CYP2D6").
+
+    Returns
+    -------
+    str
+        URL to the CPIC gene page.
+    """
+    return "https://cpicpgx.org/gene/" + gene.lower() + "/"
+
+
+# ---------------------------------------------------------------------------
 # 7. Report generator
 # ---------------------------------------------------------------------------
 
@@ -1747,6 +1802,30 @@ def generate_report(input_path, fmt, total_snps, pgx_snps, profiles, drug_result
         lines.append(f"| {gene_sym} | {full_name} | {dip} | {pheno} |")
     lines.append("")
 
+    # Interactive ClinPGx Link
+    clinpgx_url = build_clinpgx_url(profiles)
+    lines.append("## Interactive ClinPGx Link")
+    lines.append("")
+    lines.append("**Explore this patient's pharmacogenomic profile** with CPIC, DPWG, "
+                 "and FDA guideline annotations:")
+    lines.append("")
+    lines.append(f"[Open in ClinPGx]({clinpgx_url})")
+    lines.append("")
+    lines.append("This link pre-fills ClinPGx with the patient's genotypes. "
+                 "No data is uploaded; the genotypes are encoded in the URL itself.")
+    lines.append("")
+    lines.append("### CPIC Gene References")
+    lines.append("")
+    lines.append("| Gene | Diplotype | Phenotype | CPIC Guideline |")
+    lines.append("|------|-----------|-----------|----------------|")
+    for gene in GENE_DEFS:
+        if gene in profiles:
+            p = profiles[gene]
+            cpic_url = build_cpic_gene_url(gene)
+            lines.append(f"| {gene} | {p['diplotype']} | {p['phenotype']} "
+                         f"| [{gene} on CPIC]({cpic_url}) |")
+    lines.append("")
+
     # Detected variants
     lines.append("## Detected Variants")
     lines.append("")
@@ -1811,6 +1890,7 @@ def generate_report(input_path, fmt, total_snps, pgx_snps, profiles, drug_result
     lines.append("- CPIC. Clinical Pharmacogenetics Implementation Consortium. https://cpicpgx.org/")
     lines.append("- Caudle, K.E. et al. (2014). Standardizing terms for clinical pharmacogenetic test results. Genet Med, 16(9), 655-663.")
     lines.append("- PharmGKB. https://www.pharmgkb.org/")
+    lines.append("- ClinPGx. Clinical Pharmacogenomics. https://www.clinpgx.org/")
     lines.append("")
 
     return "\n".join(lines)

--- a/skills/pharmgx-reporter/tests/test_pharmgx.py
+++ b/skills/pharmgx-reporter/tests/test_pharmgx.py
@@ -31,6 +31,8 @@ from pharmgx_reporter import (
     enrich_with_clinpgx,
     _evidence_cell_html,
     _evidence_level_html,
+    build_clinpgx_url,
+    build_cpic_gene_url,
 )
 
 DEMO = Path(__file__).parent.parent / "demo_patient.txt"
@@ -444,6 +446,66 @@ def test_cyp2d6_star1_star10_is_normal_metabolizer():
     assert pheno == "Normal Metabolizer", (
         f"CYP2D6 *1/*10 should be NM per CPIC 2020 (Caudle, PMID 31647186), got {pheno}"
     )
+
+
+# ── ClinPGx URL Generation ──────────────────────────────────────────────────
+
+import json
+from urllib.parse import unquote
+
+
+def test_build_clinpgx_url_returns_valid_url():
+    """build_clinpgx_url must return a URL starting with the ClinPGx endpoint."""
+    p = _profiles()
+    url = build_clinpgx_url(p)
+    assert url.startswith("https://www.clinpgx.org/genotypeResults?q=")
+
+
+def test_build_clinpgx_url_contains_gene_data():
+    """URL-decoded payload must contain CYP2D6 (a gene with a / diplotype)."""
+    p = _profiles()
+    url = build_clinpgx_url(p)
+    encoded_part = url.split("?q=", 1)[1]
+    decoded = unquote(encoded_part)
+    assert "CYP2D6" in decoded
+
+
+def test_build_clinpgx_url_format():
+    """Decoded JSON payload must map each gene to [allele1, allele2, null]."""
+    p = _profiles()
+    url = build_clinpgx_url(p)
+    encoded_part = url.split("?q=", 1)[1]
+    decoded = unquote(encoded_part)
+    data = json.loads(decoded)
+    for gene, alleles in data.items():
+        assert isinstance(alleles, list), f"{gene} value is not a list"
+        assert len(alleles) == 3, f"{gene} list length is {len(alleles)}, expected 3"
+        assert alleles[2] is None, f"{gene} third element should be null"
+
+
+def test_build_cpic_gene_url():
+    """build_cpic_gene_url must return correct CPIC gene page URLs."""
+    assert build_cpic_gene_url("CYP2D6") == "https://cpicpgx.org/gene/cyp2d6/"
+    assert build_cpic_gene_url("CYP2C19") == "https://cpicpgx.org/gene/cyp2c19/"
+    assert build_cpic_gene_url("VKORC1") == "https://cpicpgx.org/gene/vkorc1/"
+
+
+def test_report_contains_clinpgx_section():
+    """Generated report must include the Interactive ClinPGx Link heading."""
+    _, _, pgx, _ = parse_file(str(DEMO))
+    p = _profiles()
+    results = lookup_drugs(p)
+    report = generate_report(str(DEMO), "23andme", 31, pgx, p, results)
+    assert "## Interactive ClinPGx Link" in report
+
+
+def test_report_contains_clinpgx_url():
+    """Generated report must include a link to clinpgx.org."""
+    _, _, pgx, _ = parse_file(str(DEMO))
+    p = _profiles()
+    results = lookup_drugs(p)
+    report = generate_report(str(DEMO), "23andme", 31, pgx, p, results)
+    assert "clinpgx.org" in report
 
 
 # ── ClinPGx Evidence Enrichment ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Generate a clickable ClinPGx URL in each PharmGx report, pre-filled with the patient's diplotypes for direct CPIC/DPWG/FDA guideline lookup
- Add per-gene CPIC reference links table to the markdown report
- Two new functions (`build_clinpgx_url`, `build_cpic_gene_url`), zero new dependencies (uses stdlib `json` + `urllib.parse`)

## Test plan
- [x] 6 new tests covering URL generation, payload format, CPIC URLs, and report integration
- [x] All 63 tests pass (`pytest skills/pharmgx-reporter/tests/ -v`)
- [x] Demo report regenerated with ClinPGx section
- [x] Verify ClinPGx URL opens correctly in browser with pre-filled genotypes