### PR TITLE
feat(commons): add reproducibility module

### DIFF
--- a/clawbio/common/__init__.py
+++ b/clawbio/common/__init__.py
@@ -1,4 +1,4 @@
-"""ClawBio common utilities — shared parsers, profiles, reports, checksums."""
+"""ClawBio common utilities — shared parsers, profiles, reports, checksums, reproducibility."""
 
 from clawbio.common.parsers import (
     detect_format,
@@ -20,6 +20,11 @@ from clawbio.common.scrna_io import (
     load_10x_mtx_data,
     resolve_input_source,
 )
+from clawbio.common.reproducibility import (
+    write_checksums,
+    write_environment_yml,
+    write_commands_sh,
+)
 
 __all__ = [
     "detect_format",
@@ -38,4 +43,7 @@ __all__ = [
     "load_count_adata",
     "load_10x_mtx_data",
     "resolve_input_source",
+    "write_checksums",
+    "write_environment_yml",
+    "write_commands_sh",
 ]

--- a/clawbio/common/reproducibility.py
+++ b/clawbio/common/reproducibility.py
@@ -1,0 +1,119 @@
+"""Reproducibility helpers for ClawBio skills.
+
+Provides write_checksums and write_environment_yml, both writing into
+<output_dir>/reproducibility/.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clawbio.common.checksums import sha256_file
+
+
+def write_checksums(
+    paths: list[Path | str],
+    output_dir: Path | str,
+    anchor: Path | str | None = None,
+) -> Path:
+    """Write sha256sum-compatible checksums for output files.
+
+    Each line: '<sha256>  <label>'
+    - If anchor is None, label is the bare filename.
+    - If anchor is given, label is the path relative to anchor.
+
+    Files that do not exist are silently skipped.
+    Creates reproducibility/ if it doesn't exist.
+    Returns the path of the written checksums.sha256 file.
+    """
+    output_dir = Path(output_dir)
+    repro_dir = output_dir / "reproducibility"
+    repro_dir.mkdir(parents=True, exist_ok=True)
+
+    anchor_path = Path(anchor) if anchor is not None else None
+    lines: list[str] = []
+    for p in paths:
+        p = Path(p)
+        if not p.exists():
+            continue
+        if anchor_path is not None:
+            try:
+                label = str(p.relative_to(anchor_path))
+            except ValueError:
+                label = p.name
+        else:
+            label = p.name
+        lines.append(f"{sha256_file(p)}  {label}")
+
+    checksum_path = repro_dir / "checksums.sha256"
+    checksum_path.write_text("\n".join(lines) + ("\n" if lines else ""))
+    return checksum_path
+
+
+def write_environment_yml(
+    output_dir: Path | str,
+    env_name: str,
+    pip_deps: list[str],
+    conda_deps: list[str] | None = None,
+    python_version: str = "3.10",
+) -> Path:
+    """Write reproducibility/environment.yml for a ClawBio skill.
+
+    Args:
+        output_dir:     Skill output directory.
+        env_name:       Conda environment name (e.g. 'clawbio-cell-detection').
+        pip_deps:       Packages to install via pip (e.g. ['cellpose>=4.0']).
+        conda_deps:     Extra conda packages beyond python (e.g. ['numpy', 'scipy']).
+                        Do not include 'python=X.Y' here — use python_version instead.
+        python_version: Python version string (default '3.10').
+
+    Returns the path of the written environment.yml file.
+    """
+    output_dir = Path(output_dir)
+    repro_dir = output_dir / "reproducibility"
+    repro_dir.mkdir(parents=True, exist_ok=True)
+
+    # Strip any python= entries from conda_deps to avoid duplicating the python line.
+    filtered_conda = [d for d in (conda_deps or []) if not d.lower().startswith("python=")]
+    conda_lines = "\n".join(f"  - {dep}" for dep in filtered_conda)
+    conda_block = f"\n{conda_lines}" if conda_lines else ""
+
+    # Only emit the pip block when there are pip deps — empty pip: is invalid YAML for conda.
+    if pip_deps:
+        pip_lines = "\n".join(f"      - {dep}" for dep in pip_deps)
+        pip_block = f"  - pip:\n{pip_lines}\n"
+    else:
+        pip_block = ""
+
+    content = f"""name: {env_name}
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python={python_version}{conda_block}
+  - pip
+{pip_block}"""
+    path = repro_dir / "environment.yml"
+    path.write_text(content)
+    return path
+
+
+def write_commands_sh(output_dir: Path | str, command: str) -> Path:
+    """Write reproducibility/commands.sh containing the exact command to reproduce a run.
+
+    Args:
+        output_dir: Skill output directory.
+        command:    The full CLI command string (may be multi-line with continuations).
+
+    Creates reproducibility/ if it doesn't exist.
+    Returns the path of the written commands.sh file.
+    """
+    output_dir = Path(output_dir)
+    repro_dir = output_dir / "reproducibility"
+    repro_dir.mkdir(parents=True, exist_ok=True)
+
+    content = f"#!/usr/bin/env bash\n{command}\n"
+    path = repro_dir / "commands.sh"
+    path.write_text(content)
+    path.chmod(path.stat().st_mode | 0o111)
+    return path

--- a/clawbio/tests/test_reproducibility.py
+++ b/clawbio/tests/test_reproducibility.py
@@ -1,0 +1,216 @@
+"""Tests for clawbio.common.reproducibility — write_checksums and write_environment_yml."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from clawbio.common.checksums import sha256_file
+from clawbio.common.reproducibility import write_checksums, write_environment_yml, write_commands_sh
+
+
+# ---------------------------------------------------------------------------
+# TestWriteChecksums
+# ---------------------------------------------------------------------------
+
+
+class TestWriteChecksums:
+    def test_creates_checksums_file(self, tmp_path):
+        """write_checksums creates reproducibility/checksums.sha256."""
+        f = tmp_path / "out.csv"
+        f.write_bytes(b"data")
+        write_checksums([f], tmp_path)
+        assert (tmp_path / "reproducibility" / "checksums.sha256").exists()
+
+    def test_returns_path(self, tmp_path):
+        """Returns the path of the written checksums file."""
+        f = tmp_path / "out.csv"
+        f.write_bytes(b"data")
+        result = write_checksums([f], tmp_path)
+        assert result == tmp_path / "reproducibility" / "checksums.sha256"
+
+    def test_creates_reproducibility_dir_if_missing(self, tmp_path):
+        """reproducibility/ is created automatically."""
+        f = tmp_path / "out.csv"
+        f.write_bytes(b"data")
+        assert not (tmp_path / "reproducibility").exists()
+        write_checksums([f], tmp_path)
+        assert (tmp_path / "reproducibility").exists()
+
+    def test_format_filename_only_by_default(self, tmp_path):
+        """Default (no anchor): line is '<hash>  <filename>'."""
+        f = tmp_path / "masks.tif"
+        f.write_bytes(b"pixels")
+        write_checksums([f], tmp_path)
+        line = (tmp_path / "reproducibility" / "checksums.sha256").read_text().splitlines()[0]
+        assert line == f"{sha256_file(f)}  {f.name}"
+
+    def test_format_relative_path_with_anchor(self, tmp_path):
+        """With anchor, line uses path relative to anchor."""
+        sub = tmp_path / "figures"
+        sub.mkdir()
+        f = sub / "plot.png"
+        f.write_bytes(b"png")
+        write_checksums([f], tmp_path, anchor=tmp_path)
+        line = (tmp_path / "reproducibility" / "checksums.sha256").read_text().splitlines()[0]
+        assert line == f"{sha256_file(f)}  figures/plot.png"
+
+    def test_multiple_files_produce_multiple_lines(self, tmp_path):
+        """Each file gets its own line."""
+        paths = []
+        for name in ("a.tif", "b.csv", "c.npy"):
+            p = tmp_path / name
+            p.write_bytes(name.encode())
+            paths.append(p)
+        write_checksums(paths, tmp_path)
+        lines = (tmp_path / "reproducibility" / "checksums.sha256").read_text().splitlines()
+        assert len(lines) == 3
+
+    def test_skips_missing_files(self, tmp_path):
+        """Files that don't exist are silently skipped."""
+        real = tmp_path / "real.csv"
+        real.write_bytes(b"x")
+        ghost = tmp_path / "ghost.tif"
+        write_checksums([real, ghost], tmp_path)
+        text = (tmp_path / "reproducibility" / "checksums.sha256").read_text()
+        assert "real.csv" in text
+        assert "ghost.tif" not in text
+
+    def test_digest_matches_sha256_file(self, tmp_path):
+        """Digest written matches sha256_file from commons."""
+        f = tmp_path / "verify.bin"
+        f.write_bytes(b"clawbio")
+        write_checksums([f], tmp_path)
+        written = (tmp_path / "reproducibility" / "checksums.sha256").read_text().strip()
+        assert written.split("  ")[0] == sha256_file(f)
+
+    def test_empty_list_produces_empty_file(self, tmp_path):
+        """Empty path list writes an empty checksums file without error."""
+        write_checksums([], tmp_path)
+        assert (tmp_path / "reproducibility" / "checksums.sha256").read_text() == ""
+
+
+# ---------------------------------------------------------------------------
+# TestWriteEnvironmentYml
+# ---------------------------------------------------------------------------
+
+
+class TestWriteEnvironmentYml:
+    def test_creates_environment_yml(self, tmp_path):
+        """write_environment_yml creates reproducibility/environment.yml."""
+        write_environment_yml(tmp_path, "clawbio-test", ["numpy", "scipy"])
+        assert (tmp_path / "reproducibility" / "environment.yml").exists()
+
+    def test_returns_path(self, tmp_path):
+        """Returns the path of the written environment.yml."""
+        result = write_environment_yml(tmp_path, "clawbio-test", ["numpy"])
+        assert result == tmp_path / "reproducibility" / "environment.yml"
+
+    def test_creates_reproducibility_dir_if_missing(self, tmp_path):
+        """reproducibility/ is created automatically."""
+        assert not (tmp_path / "reproducibility").exists()
+        write_environment_yml(tmp_path, "clawbio-test", ["numpy"])
+        assert (tmp_path / "reproducibility").exists()
+
+    def test_name_appears_in_file(self, tmp_path):
+        """The env name is written as 'name: <env_name>'."""
+        write_environment_yml(tmp_path, "clawbio-cell-detection", ["numpy"])
+        text = (tmp_path / "reproducibility" / "environment.yml").read_text()
+        assert "name: clawbio-cell-detection" in text
+
+    def test_pip_deps_appear_in_file(self, tmp_path):
+        """Each pip dependency appears in the file."""
+        write_environment_yml(tmp_path, "clawbio-test", ["cellpose>=4.0", "tifffile"])
+        text = (tmp_path / "reproducibility" / "environment.yml").read_text()
+        assert "cellpose>=4.0" in text
+        assert "tifffile" in text
+
+    def test_channels_present(self, tmp_path):
+        """Standard conda channels are included."""
+        write_environment_yml(tmp_path, "clawbio-test", ["numpy"])
+        text = (tmp_path / "reproducibility" / "environment.yml").read_text()
+        assert "conda-forge" in text
+
+    def test_conda_deps_separate_from_pip(self, tmp_path):
+        """conda_deps kwarg lists packages outside the pip block."""
+        write_environment_yml(tmp_path, "clawbio-test", ["cellpose>=4.0"],
+                              conda_deps=["numpy"])
+        text = (tmp_path / "reproducibility" / "environment.yml").read_text()
+        assert "numpy" in text
+
+    def test_empty_pip_deps_produces_valid_yaml(self, tmp_path):
+        """Empty pip_deps must not emit 'pip: null' — should omit the pip block."""
+        import yaml
+        write_environment_yml(tmp_path, "clawbio-test", pip_deps=[])
+        text = (tmp_path / "reproducibility" / "environment.yml").read_text()
+        parsed = yaml.safe_load(text)
+        deps = parsed["dependencies"]
+        for item in deps:
+            if isinstance(item, dict):
+                assert item.get("pip") is not None, "pip key must not be null"
+
+    def test_python_version_not_duplicated_when_in_conda_deps(self, tmp_path):
+        """python= in conda_deps must not produce a duplicate python= line."""
+        write_environment_yml(tmp_path, "clawbio-test", ["cellpose"],
+                              conda_deps=["python=3.11", "numpy"],
+                              python_version="3.11")
+        text = (tmp_path / "reproducibility" / "environment.yml").read_text()
+        assert text.count("python=3.11") == 1
+
+
+# ---------------------------------------------------------------------------
+# TestWriteCommandsSh
+# ---------------------------------------------------------------------------
+
+
+class TestWriteCommandsSh:
+    def test_creates_commands_sh(self, tmp_path):
+        """write_commands_sh creates reproducibility/commands.sh."""
+        write_commands_sh(tmp_path, "python skill.py --demo")
+        assert (tmp_path / "reproducibility" / "commands.sh").exists()
+
+    def test_returns_path(self, tmp_path):
+        """Returns the path of the written commands.sh."""
+        result = write_commands_sh(tmp_path, "python skill.py --demo")
+        assert result == tmp_path / "reproducibility" / "commands.sh"
+
+    def test_creates_reproducibility_dir_if_missing(self, tmp_path):
+        """reproducibility/ is created automatically."""
+        assert not (tmp_path / "reproducibility").exists()
+        write_commands_sh(tmp_path, "python skill.py")
+        assert (tmp_path / "reproducibility").exists()
+
+    def test_command_appears_in_file(self, tmp_path):
+        """The command string appears verbatim in the file."""
+        cmd = "python skills/cell-detection/cell_detection.py --demo --output /tmp/out"
+        write_commands_sh(tmp_path, cmd)
+        text = (tmp_path / "reproducibility" / "commands.sh").read_text()
+        assert cmd in text
+
+    def test_has_shebang(self, tmp_path):
+        """File starts with a bash shebang."""
+        write_commands_sh(tmp_path, "python skill.py")
+        text = (tmp_path / "reproducibility" / "commands.sh").read_text()
+        assert text.startswith("#!/")
+
+    def test_is_executable_bash(self, tmp_path):
+        """Shebang targets bash or env bash."""
+        write_commands_sh(tmp_path, "python skill.py")
+        first_line = (tmp_path / "reproducibility" / "commands.sh").read_text().splitlines()[0]
+        assert "bash" in first_line
+
+    def test_multiline_command(self, tmp_path):
+        """Multi-line commands are written intact."""
+        cmd = "python skill.py \\\n  --input data.csv \\\n  --output /tmp/out"
+        write_commands_sh(tmp_path, cmd)
+        text = (tmp_path / "reproducibility" / "commands.sh").read_text()
+        assert cmd in text
+
+    def test_file_is_executable(self, tmp_path):
+        """commands.sh must have the executable bit set."""
+        import stat
+        write_commands_sh(tmp_path, "python skill.py")
+        mode = (tmp_path / "reproducibility" / "commands.sh").stat().st_mode
+        assert mode & stat.S_IXUSR, "owner execute bit not set"


### PR DESCRIPTION
## Summary

- Adds `clawbio/common/reproducibility.py` with three shared helpers for writing the `reproducibility/` bundle:
  - `write_checksums(paths, output_dir, anchor)` — sha256sum-compatible `checksums.sha256`; supports relative-path labels via `anchor`
  - `write_environment_yml(output_dir, env_name, pip_deps, conda_deps)` — `environment.yml` with configurable conda/pip deps
  - `write_commands_sh(output_dir, command)` — `commands.sh` with bash shebang
- All three auto-create `reproducibility/` and return the written path
- Consolidates logic currently duplicated across `methylation-clock`, `rnaseq-de`, `protocols-io`, and `scrna-orchestrator` — skills migrate in follow-up PRs

## Test plan

- [x] 23 tests in `clawbio/tests/test_reproducibility.py` covering all three functions
- [x] Existing `clawbio/tests/test_checksums.py` still passes
- [x] Red-green TDD cycle followed for all new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)