### PR TITLE
feat(cell-detection): wire commons reproducibility module

### DIFF
--- a/skills/cell-detection/SKILL.md
+++ b/skills/cell-detection/SKILL.md
@@ -81,7 +81,7 @@ Manual cell counting and segmentation are slow, inconsistent, and hard to reprod
 3. **Segment** with `CellposeModel()` — no `channels` argument needed
 4. **Metrics** via `skimage.measure.regionprops`
 5. **Figures** — overlay + size distribution histogram
-6. **Report** — `report.md` + `{stem}_measurements.csv` + `commands.sh`
+6. **Report** — `report.md` + `{stem}_measurements.csv` + reproducibility bundle (`commands.sh`, `environment.yml`, `checksums.sha256`)
 
 ## CLI Reference
 
@@ -133,10 +133,15 @@ Expected output: report.md with ~67 cells detected from a synthetic 512×512 blo
 output_dir/
 ├── report.md
 ├── {stem}_measurements.csv
+├── {stem}_cp_masks.tif
+├── {stem}_seg.npy
 ├── figures/
+│   ├── {stem}_cp_outlines.png
 │   └── {stem}_histogram.png
 └── reproducibility/
-    └── commands.sh
+    ├── checksums.sha256
+    ├── commands.sh
+    └── environment.yml
 ```
 
 ## Dependencies
@@ -152,7 +157,7 @@ output_dir/
 
 - Local-first: no image data leaves the machine
 - Every report includes the ClawBio medical disclaimer
-- `commands.sh` records the exact invocation for reproducibility
+- Reproducibility bundle (`commands.sh`, `environment.yml`, `checksums.sha256`) records the exact invocation, dependencies, and output integrity
 
 ## Integration with Bio Orchestrator
 

--- a/skills/cell-detection/cell_detection.py
+++ b/skills/cell-detection/cell_detection.py
@@ -8,6 +8,17 @@ from pathlib import Path
 
 import numpy as np
 
+# Add project root so clawbio.common is importable when running as a script.
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from clawbio.common.reproducibility import (
+    write_checksums,
+    write_commands_sh,
+    write_environment_yml,
+)
+
 
 DISCLAIMER = (
     "*ClawBio is a research and educational tool. "
@@ -346,7 +357,6 @@ def main() -> None:
 
     output_dir = Path(args.output)
     output_dir.mkdir(parents=True, exist_ok=True)
-    (output_dir / "reproducibility").mkdir(exist_ok=True)
 
     # Build input image
     if args.demo:
@@ -417,7 +427,25 @@ def main() -> None:
     write_report(metrics, meta, output_dir, outlines_filename=outlines_filename, masks_filename=masks_filename, seg_filename=seg_filename, csv_filename=f"{stem}_measurements.csv", histogram_filename=f"{stem}_histogram.png")
 
     # Reproducibility
-    (output_dir / "reproducibility" / "commands.sh").write_text(f"#!/bin/bash\n{cmd}\n")
+    write_commands_sh(output_dir, cmd)
+    write_environment_yml(
+        output_dir,
+        env_name="clawbio-cell-detection",
+        pip_deps=["cellpose>=4.0", "tifffile", "Pillow", "numpy", "matplotlib", "scikit-image", "scipy"],
+        python_version="3.10",
+    )
+    write_checksums(
+        [
+            output_dir / "report.md",
+            output_dir / masks_filename,
+            output_dir / seg_filename,
+            csv_path,
+            output_dir / "figures" / outlines_filename,
+            output_dir / "figures" / f"{stem}_histogram.png",
+        ],
+        output_dir,
+        anchor=output_dir,
+    )
 
     print(f"[cell-detection] Done — {len(metrics)} cells detected.")
     print(f"[cell-detection] Report: {output_dir / 'report.md'}")

--- a/skills/cell-detection/tests/test_cell_detection.py
+++ b/skills/cell-detection/tests/test_cell_detection.py
@@ -495,3 +495,68 @@ class TestFlowCellprobThresholds:
         args = parser.parse_args([])
         assert args.flow_threshold == 0.4
         assert args.cellprob_threshold == 0.0
+
+
+# ---------------------------------------------------------------------------
+# TestReproducibility
+# ---------------------------------------------------------------------------
+
+
+class TestReproducibility:
+    """Reproducibility artefacts written by main()."""
+
+    @pytest.fixture
+    def demo_output(self, tmp_path):
+        """Run main() --demo with segmentation and outline-saving mocked."""
+        masks = np.zeros((64, 64), dtype=np.uint16)
+        masks[10:20, 10:20] = 1
+        fake_flows = [np.zeros((64, 64))]
+
+        def _fake_seg(img, diameter, use_gpu, **kwargs):
+            return masks, fake_flows
+
+        def _fake_outlines(img, masks, flows, output_dir, stem="image"):
+            fig_dir = Path(output_dir) / "figures"
+            fig_dir.mkdir(parents=True, exist_ok=True)
+            fname = f"{stem}_cp_outlines.png"
+            (fig_dir / fname).write_bytes(b"\x89PNG\r\n")
+            return fname
+
+        with patch.object(cell_detection, "run_segmentation", side_effect=_fake_seg), \
+             patch.object(cell_detection, "save_outlines", side_effect=_fake_outlines):
+            with patch("sys.argv", ["cell_detection.py", "--demo", "--output", str(tmp_path)]):
+                cell_detection.main()
+        return tmp_path
+
+    def test_checksums_file_created(self, demo_output):
+        assert (demo_output / "reproducibility" / "checksums.sha256").exists()
+
+    def test_checksums_lists_report(self, demo_output):
+        content = (demo_output / "reproducibility" / "checksums.sha256").read_text()
+        assert "report.md" in content
+
+    def test_checksums_lists_csv(self, demo_output):
+        content = (demo_output / "reproducibility" / "checksums.sha256").read_text()
+        assert ".csv" in content
+
+    def test_environment_yml_created(self, demo_output):
+        assert (demo_output / "reproducibility" / "environment.yml").exists()
+
+    def test_environment_yml_has_cellpose(self, demo_output):
+        text = (demo_output / "reproducibility" / "environment.yml").read_text()
+        assert "cellpose" in text
+
+    def test_environment_yml_has_env_name(self, demo_output):
+        text = (demo_output / "reproducibility" / "environment.yml").read_text()
+        assert "clawbio-cell-detection" in text
+
+    def test_commands_sh_created(self, demo_output):
+        assert (demo_output / "reproducibility" / "commands.sh").exists()
+
+    def test_commands_sh_is_executable(self, demo_output):
+        path = demo_output / "reproducibility" / "commands.sh"
+        assert path.stat().st_mode & 0o111
+
+    def test_commands_sh_contains_cell_detection(self, demo_output):
+        text = (demo_output / "reproducibility" / "commands.sh").read_text()
+        assert "cell_detection" in text


### PR DESCRIPTION
## Summary

- Migrates `cell_detection.py` from ad-hoc `commands.sh`-only output to the shared `clawbio.common.reproducibility` module
- Now writes all three artefacts: `checksums.sha256`, `commands.sh`, and `environment.yml`
- Updates `SKILL.md` output structure, workflow step, and safety note to reflect the full bundle

## Skill affected

cell-detection

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology)
- [x] Tests included and passing (`pytest -v`)
- [x] Demo data included for reviewers to test
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

```
64 passed in 4.83s
```

New `TestReproducibility` class (9 tests) covers all three artefacts — checksums, commands.sh, and environment.yml.