### PR TITLE
fix(commons): remove defaults channel from write_environment_yml

### DIFF
--- a/clawbio/common/reproducibility.py
+++ b/clawbio/common/reproducibility.py
@@ -88,7 +88,6 @@ def write_environment_yml(
     content = f"""name: {env_name}
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - python={python_version}{conda_block}
   - pip


### PR DESCRIPTION
## Summary

- Removes `defaults` from the conda channels list in `write_environment_yml` — all ClawBio skills use only `conda-forge` (or `bioconda`) packages, so `defaults` was never needed and exposes users to Anaconda's commercial licensing terms

## Skill affected

`clawbio/common/reproducibility.py` (shared commons module used by all skills)

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology)
- [x] Tests included and passing (`pytest -v`)
- [x] Demo data included for reviewers to test
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

```
89 passed in 0.31s
```

Verified with `conda env create --dry-run` — all packages resolve from `conda-forge` only.