### PR TITLE
chore: add lint target and document in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ python clawbio.py run pharmgx --demo        # Run flagship skill demo
 | `python -m pytest -v` | Run all tests |
 | `python -m pytest skills/<name>/tests/ -v` | Run tests for one skill |
 | `python scripts/generate_catalog.py` | Regenerate `skills/catalog.json` |
+| `python scripts/lint_skills.py` | Run SKILL.md conformance linter |
 | `make test` | Alias for `python -m pytest -v` |
 | `make demo` | Run PharmGx demo |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,7 @@ Even skills without Python scripts are usable — an AI agent reads the SKILL.md
 - Tests must pass on Python 3.10, 3.11, and 3.12
 - Include demo output in the PR description so reviewers can verify
 - Update `skills/catalog.json` if you changed any SKILL.md YAML frontmatter
+- When opening a PR, use `.github/PULL_REQUEST_TEMPLATE.md` as the body — fill in every section, do not leave placeholders
 
 ## Safety Boundaries
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: demo test list demo-all
+.PHONY: demo test list demo-all lint
 
 demo:
 	python clawbio.py run pharmgx --demo
@@ -8,6 +8,9 @@ test:
 
 list:
 	python clawbio.py list
+
+lint:
+	python scripts/lint_skills.py
 
 demo-all:
 	python clawbio.py run pharmgx --demo


### PR DESCRIPTION
## Summary

- Add `lint` target to Makefile (`python scripts/lint_skills.py`)
- Document `python scripts/lint_skills.py` in AGENTS.md command reference
- Instruct agents to use `.github/PULL_REQUEST_TEMPLATE.md` when opening PRs

## Skill affected

None — tooling and docs only

## Checklist

- [ ] SKILL.md is present and complete (YAML frontmatter + methodology)
- [ ] Tests included and passing (`pytest -v`)
- [ ] Demo data included for reviewers to test
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

```
$ make lint
python scripts/lint_skills.py
```

Linter runs cleanly against all existing skills.