### PR TITLE
feat(multiqc-reporter): add multiqc-reporter skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ When the user asks a question, match it to a skill and act:
 | Protein structure, AlphaFold, PDB, Boltz | `skills/struct-predictor/` | Read SKILL.md, apply methodology |
 | Reproducibility, Nextflow, Singularity, Conda export | `skills/repro-enforcer/` | Read SKILL.md, apply methodology |
 | Sequence QC, FASTQ, alignment, BAM, trimming | `skills/seq-wrangler/` | Read SKILL.md, apply methodology |
+| MultiQC, aggregate QC, QC report, FastQC summary, multi-sample QC, sequencing QC report, combine QC results | `skills/multiqc-reporter/` | Run `multiqc_reporter.py` |
 | Lab notebook, experiments, protocols, inventory, Labstep | `skills/labstep/` | Run `labstep.py` |
 | ClinPGx database, gene-drug lookup, PharmGKB query, CPIC guideline database, FDA drug label PGx, "look up gene on ClinPGx" | `skills/clinpgx/` | Run `clinpgx.py` |
 | GWAS polygenic risk scores, PRS, "what's my risk for diabetes", PGS Catalog, polygenic | `skills/gwas-prs/` | Run `gwas_prs.py` |
@@ -205,6 +206,11 @@ python skills/wes-clinical-report-es/wes_clinical_report_es.py \
 python skills/wes-clinical-report-es/wes_clinical_report_es.py \
   --report-dir <reports_dir> --output-dir <pdf_dir> --samples Sample3
 python skills/wes-clinical-report-es/wes_clinical_report_es.py --demo
+
+# MultiQC — aggregate QC reports across samples and tools
+python skills/multiqc-reporter/multiqc_reporter.py \
+  --input <dir> [<dir2> ...] --output <report_dir>
+python skills/multiqc-reporter/multiqc_reporter.py --demo --output /tmp/multiqc_demo
 ```
 
 ## Demo Data
@@ -239,6 +245,7 @@ For instant demos when the user has no data:
 | CellposeSAM demo (synthetic 512×512 fluorescence nuclei image, ~67 cells) | `--demo` flag | cell-detection |
 | WES demo report (8 P/LP variants, 6 PGx, synthetic) | `skills/wes-clinical-report-en/examples/demo_WES_Report.md` | wes-clinical-report-en |
 | WES demo report (same, for Spanish output) | `skills/wes-clinical-report-es/examples/demo_WES_Report.md` | wes-clinical-report-es |
+| MultiQC demo (synthetic FastQC, 3 samples — SAMPLE_01/02/03) | `--demo` flag | multiqc-reporter |
 | Corpas 30x chr20 SNPs + indels (WGS) | `corpas-30x/subsets/chr20_snps_indels.vcf.gz` | variant-annotation, equity-scorer |
 | Corpas 30x SV calls (WGS) | `corpas-30x/subsets/sv_calls.vcf.gz` | variant-annotation |
 | Corpas 30x CNV calls (WGS) | `corpas-30x/subsets/cnv_calls.vcf.gz` | variant-annotation |
@@ -265,6 +272,9 @@ python skills/equity-scorer/equity_scorer.py \
 # NutriGx demo
 python skills/nutrigx_advisor/nutrigx_advisor.py \
   --input skills/nutrigx_advisor/synthetic_patient.txt --output /tmp/nutrigx_demo
+
+# MultiQC demo
+python skills/multiqc-reporter/multiqc_reporter.py --demo --output /tmp/multiqc_demo
 
 # scRNA demo
 python skills/scrna-orchestrator/scrna_orchestrator.py --demo --output /tmp/scrna_demo

--- a/skills/multiqc-reporter/SKILL.md
+++ b/skills/multiqc-reporter/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: multiqc-reporter
+description: >-
+  Aggregates QC reports from any bioinformatics tool outputs (FastQC, fastp,
+  STAR, Picard, samtools, etc.) into a single MultiQC HTML report plus a
+  ClawBio markdown summary with per-sample QC metrics.
+version: 0.1.0
+author: Cameron Lloyd
+domain: genomics
+license: MIT
+
+inputs:
+  - name: input_dirs
+    type: directory
+    format: [any]
+    description: One or more directories containing tool QC output files
+    required: true
+
+outputs:
+  - name: report
+    type: file
+    format: md
+    description: ClawBio markdown summary with per-sample QC table
+  - name: html_report
+    type: file
+    format: html
+    description: Standard MultiQC interactive HTML report
+
+dependencies:
+  python: ">=3.11"
+  packages: []
+  external:
+    - multiqc>=1.20
+
+tags: [qc, fastqc, multiqc, sequencing, alignment, rna-seq, wgs, wes, aggregation]
+
+demo_data:
+  - path: "--demo flag"
+    description: Synthetic FastQC output for 3 samples (generated at runtime into a tempdir)
+
+endpoints:
+  cli: python skills/multiqc-reporter/multiqc_reporter.py --input {input_dirs} --output {output_dir}
+
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - python3
+        - multiqc
+      env: []
+      config: []
+    always: false
+    emoji: "📊"
+    homepage: https://github.com/ClawBio/ClawBio
+    os: [darwin, linux]
+    install:
+      - kind: pip
+        package: multiqc
+        bins: [multiqc]
+    trigger_keywords:
+      - multiqc
+      - aggregate QC
+      - QC report
+      - FastQC summary
+      - multi-sample QC
+      - sequencing QC report
+      - combine QC
+      - QC aggregation
+---
+
+# 📊 MultiQC
+
+You are **MultiQC Reporter**, a specialised ClawBio agent for aggregating
+bioinformatics QC reports across samples and tools into a single summary.
+
+## Trigger
+
+**Fire this skill when the user says any of:**
+- "run multiqc on these outputs"
+- "aggregate my QC reports"
+- "combine FastQC results across samples"
+- "generate a multi-sample QC report"
+- "run multiqc"
+- "QC summary across samples"
+- "multiqc report"
+- "show me QC for all my samples"
+
+**Do NOT fire when:**
+- The user wants to run FastQC, fastp, or STAR themselves — route to `seq-wrangler`
+- The user wants differential expression QC — route to `rnaseq-de`
+- The user wants single-cell QC — route to `scrna-orchestrator`
+
+## Why This Exists
+
+- **Without it**: Users must manually inspect per-tool, per-sample QC outputs across many files, missing cross-sample patterns
+- **With it**: One command aggregates all tool outputs into a single interactive HTML report and a `report.md` table of per-sample metrics
+- **Why ClawBio**: Adds a structured `report.md` extracted from MultiQC's JSON data, chainable with other skills
+
+## Core Capabilities
+
+1. **Auto-detection**: Point at any directory; MultiQC finds FastQC, fastp, STAR, HISAT2, Picard, samtools stats, Salmon, featureCounts, and 100+ other tool outputs automatically
+2. **Markdown table**: Reads `multiqc_data/multiqc_data.json` for per-sample metrics and renders them in `report.md`
+3. **Demo mode**: `--demo` runs without user data — generates synthetic FastQC output for 3 samples so MultiQC renders its full plot suite
+
+## Scope
+
+**One skill, one task.** This skill aggregates existing QC outputs via MultiQC.
+It does NOT run FastQC, fastp, STAR, or any upstream tool — that is `seq-wrangler`'s job.
+
+## Input Formats
+
+| Format | Extension | Notes |
+|--------|-----------|-------|
+| FastQC output | `fastqc_data.txt` or `*_fastqc.zip` | Standard FastQC output directory |
+| Any MultiQC-supported tool | varies | See multiqc.info for full list of 100+ tools |
+
+## Workflow
+
+When the user asks to aggregate QC reports:
+
+1. **Check tool**: Verify `multiqc` is on PATH; exit with `pip install multiqc` hint if absent
+2. **Validate**: Confirm all `--input` directories exist
+3. **Run**: Execute `multiqc <dirs> --outdir <output>` (MultiQC defaults)
+4. **Parse**: Read `multiqc_data/multiqc_data.json` for per-sample metrics
+5. **Report**: Write `report.md` with run metadata, per-sample QC table, and disclaimer
+6. **Reproducibility**: Write `reproducibility/commands.sh`, `environment.yml`, and `checksums.sha256`
+
+## CLI Reference
+
+```bash
+# Standard — scan one or more directories
+python skills/multiqc-reporter/multiqc_reporter.py \
+  --input <dir> [<dir2> ...] --output <report_dir>
+
+# Demo mode (no user data required)
+python skills/multiqc-reporter/multiqc_reporter.py --demo --output /tmp/multiqc_demo
+```
+
+## Algorithm / Methodology
+
+1. Shell out to `multiqc` CLI with `--outdir` only (default MultiQC behaviour)
+2. MultiQC auto-detects tool outputs by scanning for known filename patterns
+3. Parse `multiqc_data/multiqc_data.json` (`report_general_stats_data`): flatten `{tool: {sample: metrics}}` → `{sample: {metric: value}}`
+4. Render per-sample markdown table; fall back to a note if the JSON is absent
+
+## Example Queries
+
+- "Run MultiQC on my FastQC output directory"
+- "Aggregate QC for all samples in /data/qc_outputs/"
+- "Give me a multi-sample QC report"
+- "Show me a demo of the MultiQC skill"
+
+## Example Output
+
+```markdown
+# MultiQC Report
+
+**Date**: 2026-04-13 10:32 UTC
+**Input directories**: /data/fastqc_out
+
+## Per-Sample QC
+
+| Sample | percent_duplicates | percent_gc | total_sequences |
+|--------|--------------------|------------|-----------------|
+| SAMPLE_01 | 5.5 | 49 | 1000000 |
+| SAMPLE_02 | 15.0 | 50 | 920000 |
+| SAMPLE_03 | 7.5 | 48 | 880000 |
+
+## Outputs
+
+- `multiqc_report.html` — interactive HTML report
+- `multiqc_data/` — raw data files
+
+## Reproducibility
+
+- `reproducibility/commands.sh` — replay this ClawBio MultiQC run
+- `reproducibility/environment.yml` — suggested conda environment
+- `reproducibility/checksums.sha256` — key outputs
+
+---
+
+*ClawBio is a research and educational tool. It is not a medical device and does not provide clinical diagnoses. Consult a healthcare professional before making any medical decisions.*
+```
+
+## Output Structure
+
+```
+output_dir/
+├── report.md                        # ClawBio markdown summary
+├── multiqc_report.html              # Standard MultiQC HTML
+├── multiqc_data/
+│   ├── multiqc_data.json            # Structured stats (default MultiQC output)
+│   └── ...
+├── reproducibility/
+│   ├── commands.sh                  # Exact replay command
+│   ├── environment.yml              # Suggested env (multiqc via pip)
+│   └── checksums.sha256             # Output digests
+```
+
+## Dependencies
+
+**External binary** (not a Python package import):
+- `multiqc >= 1.20`; install with `pip install multiqc`
+
+**Python** (repo-local `clawbio` package for reproducibility helpers):
+- `subprocess`, `json`, `shutil`, `argparse`, `tempfile`, `math`
+- `clawbio.common.reproducibility` — `commands.sh`, `environment.yml`, `checksums.sha256`
+
+## Gotchas
+
+- **You will want to parse tool-specific files directly.** Do not. MultiQC's auto-detection handles this; let it do its job. Parsing FastQC text yourself will miss 99 other supported tools.
+- **`report_general_stats_data` metric keys are already short** (e.g. `percent_duplicates`, `percent_gc`) — no further processing needed. If the table looks empty, check that `multiqc_data/multiqc_data.json` exists and that `report_general_stats_data` is non-empty.
+- **`--demo` creates files in a `tempfile.TemporaryDirectory` that is deleted after `run_multiqc` returns.** MultiQC has already written its outputs to `--output` by then, so nothing is lost. Don't move the `with` block boundary.
+- **MultiQC exits 0 even if it found no recognised files** — it just produces an empty report. The skill does not treat this as an error; the user will see an empty table in `report.md` and an HTML report noting no modules were found.
+- **Static PNG/SVG/PDF plots are not produced by this skill** — it never passes MultiQC `--export`. Interactive plots remain in `multiqc_report.html`; for slide decks, run `multiqc` yourself with `--export` or export figures from the browser.
+
+## Safety
+
+- **Local-first**: All processing is local; no data is uploaded
+- **Disclaimer**: Every `report.md` includes the ClawBio medical disclaimer
+- **No hallucinated metrics**: All values in the table come directly from `multiqc_data/multiqc_data.json`
+
+## Agent Boundary
+
+The agent (LLM) dispatches and explains results. The skill (Python + MultiQC CLI) executes.
+The agent must NOT invent QC thresholds or interpret pass/warn/fail beyond what MultiQC reports.
+
+## Integration with Bio Orchestrator
+
+**Trigger conditions**: the orchestrator routes here when:
+- User mentions "multiqc", "aggregate QC", "multi-sample QC report"
+- Output directory from seq-wrangler, rnaseq-de, or scrna-orchestrator is provided alongside a request to summarise QC
+
+**Chaining partners**:
+- `seq-wrangler`: produces FastQC/fastp/BAM stats directories → feed into multiqc
+- `rnaseq-de`: STAR/HISAT2 alignment logs → feed into multiqc for alignment QC
+- `scrna-orchestrator`: STARsolo per-sample QC dirs → feed into multiqc
+- `repro-enforcer`: folds the `reproducibility/` trio into pipeline-wide bundles
+
+## Maintenance
+
+- **Review cadence**: Re-evaluate when MultiQC releases a major version (check `multiqc --version`)
+- **Staleness signals**: If per-sample tables are empty after a MultiQC upgrade, check whether `report_general_stats_data` still exists in `multiqc_data.json`
+- **Deprecation**: Archive to `skills/_deprecated/` if MultiQC adds a native ClawBio integration
+
+## Citations
+
+- Ewels P, Magnusson M, Lundin S, Käller M. MultiQC: Summarize analysis results for multiple tools and samples in a single report. *Bioinformatics* (2016). https://doi.org/10.1093/bioinformatics/btw354

--- a/skills/multiqc-reporter/multiqc_reporter.py
+++ b/skills/multiqc-reporter/multiqc_reporter.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""
+multiqc_reporter.py — ClawBio MultiQC skill
+============================================
+Wraps the multiqc CLI to aggregate QC reports from any bioinformatics tool
+outputs, then generates a ClawBio-style markdown summary from the JSON data.
+
+Usage
+-----
+    python skills/multiqc-reporter/multiqc_reporter.py \
+        --input <dir> [<dir2> ...] --output <report_dir>
+
+    python skills/multiqc-reporter/multiqc_reporter.py --demo --output /tmp/multiqc_demo
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from clawbio.common.reproducibility import (  # noqa: E402
+    write_checksums,
+    write_commands_sh,
+    write_environment_yml,
+)
+
+DISCLAIMER = (
+    "ClawBio is a research and educational tool. "
+    "It is not a medical device and does not provide clinical diagnoses. "
+    "Consult a healthcare professional before making any medical decisions."
+)
+
+
+def check_multiqc() -> str:
+    path = shutil.which("multiqc")
+    if not path:
+        print("ERROR: multiqc not found on PATH.\nInstall with:  pip install multiqc", file=sys.stderr)
+        sys.exit(1)
+    return path
+
+
+def validate_input_dirs(dirs: list[str]) -> list[Path]:
+    paths: list[Path] = []
+    for d in dirs:
+        p = Path(d)
+        if not p.is_dir():
+            print(f"ERROR: Input directory not found: {d}", file=sys.stderr)
+            sys.exit(1)
+        paths.append(p)
+    return paths
+
+
+def run_multiqc(input_dirs: list[Path], output_dir: Path) -> None:
+    cmd = ["multiqc"] + [str(d) for d in input_dirs] + ["--outdir", str(output_dir)]
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        print("ERROR: multiqc exited with a non-zero status.", file=sys.stderr)
+        sys.exit(result.returncode)
+
+
+def parse_general_stats(output_dir: Path) -> dict[str, dict[str, object]]:
+    """Flatten multiqc_data.json report_general_stats_data into {sample: {metric: value}}."""
+    stats_file = output_dir / "multiqc_data" / "multiqc_data.json"
+    if not stats_file.exists():
+        return {}
+    raw: dict = json.loads(stats_file.read_text())
+    samples: dict[str, dict[str, object]] = {}
+    for _tool, tool_samples in raw.get("report_general_stats_data", {}).items():
+        if not isinstance(tool_samples, dict):
+            continue
+        for sample, metrics in tool_samples.items():
+            if isinstance(metrics, dict):
+                samples.setdefault(sample, {}).update(metrics)
+    return samples
+
+
+def write_report(
+    output_dir: Path,
+    input_dirs: list[Path],
+    samples: dict[str, dict[str, object]],
+) -> None:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    input_str = ", ".join(str(d) for d in input_dirs)
+
+    lines: list[str] = [
+        "# MultiQC Report",
+        "",
+        f"**Date**: {now}  ",
+        f"**Input directories**: {input_str}  ",
+        "",
+        "## Per-Sample QC",
+        "",
+    ]
+
+    if samples:
+        all_metrics = sorted({k for s in samples.values() for k in s})
+        lines.append("| Sample | " + " | ".join(all_metrics) + " |")
+        lines.append("|--------|" + "|".join(["-----"] * len(all_metrics)) + "|")
+        for sample in sorted(samples):
+            vals = [str(samples[sample].get(m, "—")) for m in all_metrics]
+            lines.append(f"| {sample} | " + " | ".join(vals) + " |")
+    else:
+        lines.append(
+            "_No general stats data found in `multiqc_data/multiqc_data.json`. "
+            "Check MultiQC logs and that modules produced parseable output._"
+        )
+
+    lines += [
+        "",
+        "## Outputs",
+        "",
+        "- `multiqc_report.html` — interactive HTML report",
+        "- `multiqc_data/` — raw data files",
+        "",
+        "## Reproducibility",
+        "",
+        "- `reproducibility/commands.sh` — replay this ClawBio MultiQC run",
+        "- `reproducibility/environment.yml` — suggested conda environment",
+        "- `reproducibility/checksums.sha256` — key outputs",
+        "",
+        "---",
+        "",
+        f"*{DISCLAIMER}*",
+    ]
+
+    (output_dir / "report.md").write_text("\n".join(lines) + "\n")
+
+
+def make_demo_fastqc_files(dest: Path) -> None:
+    """Write minimal FastQC stubs for 3 samples so MultiQC populates general stats."""
+    samples = [
+        ("SAMPLE_01", 1_000_000, 49, 5.5),
+        ("SAMPLE_02", 920_000, 50, 15.0),
+        ("SAMPLE_03", 880_000, 48, 7.5),
+    ]
+    for name, total, pct_gc, pct_dup in samples:
+        sample_dir = dest / f"{name}_fastqc"
+        sample_dir.mkdir(parents=True, exist_ok=True)
+        pct_dedup = 100.0 - pct_dup
+        content = (
+            f"##FastQC\t0.11.9\n"
+            f">>Basic Statistics\tpass\n"
+            f"#Measure\tValue\n"
+            f"Filename\t{name}.fastq.gz\n"
+            f"File type\tConventional base calls\n"
+            f"Encoding\tSanger / Illumina 1.9\n"
+            f"Total Sequences\t{total}\n"
+            f"Sequences flagged as poor quality\t0\n"
+            f"Sequence length\t150\n"
+            f"%GC\t{pct_gc}\n"
+            f">>END_MODULE\n"
+            f">>Per base sequence quality\tpass\n"
+            f">>END_MODULE\n"
+            f">>Per sequence quality scores\tpass\n"
+            f">>END_MODULE\n"
+            f">>Per base sequence content\tpass\n"
+            f">>END_MODULE\n"
+            f">>Per sequence GC content\tpass\n"
+            f">>END_MODULE\n"
+            f">>Per base N content\tpass\n"
+            f">>END_MODULE\n"
+            f">>Sequence Length Distribution\tpass\n"
+            f">>END_MODULE\n"
+            f">>Sequence Duplication Levels\tpass\n"
+            f"#Total Deduplicated Percentage\t{pct_dedup:.1f}\n"
+            f">>END_MODULE\n"
+            f">>Overrepresented sequences\tpass\n"
+            f">>END_MODULE\n"
+            f">>Adapter Content\tpass\n"
+            f">>END_MODULE\n"
+        )
+        (sample_dir / "fastqc_data.txt").write_text(content)
+
+
+def _multiqc_pip_spec() -> str:
+    try:
+        from importlib.metadata import version
+        return f"multiqc=={version('multiqc')}"
+    except Exception:
+        return "multiqc"
+
+
+def _output_paths_to_checksum(output_dir: Path) -> list[Path]:
+    paths: list[Path] = []
+    for rel in ("report.md", "multiqc_report.html"):
+        p = output_dir / rel
+        if p.is_file():
+            paths.append(p)
+    mdir = output_dir / "multiqc_data"
+    if mdir.is_dir():
+        paths.extend(p for p in sorted(mdir.rglob("*")) if p.is_file())
+    return paths
+
+
+def cli_command_for_repro(output_dir: Path, *, demo: bool, input_dirs: list[Path]) -> str:
+    script = str((_PROJECT_ROOT / "skills" / "multiqc-reporter" / "multiqc_reporter.py").resolve())
+    parts = [sys.executable, script]
+    if demo:
+        parts.append("--demo")
+    else:
+        parts += ["--input"] + [str(p.resolve()) for p in input_dirs]
+    parts += ["--output", str(output_dir.resolve())]
+    return " ".join(parts)
+
+
+def write_reproducibility_bundle(output_dir: Path, *, demo: bool, input_dirs: list[Path]) -> None:
+    write_commands_sh(output_dir, cli_command_for_repro(output_dir, demo=demo, input_dirs=input_dirs))
+    write_environment_yml(output_dir, "clawbio-multiqc-reporter", pip_deps=[_multiqc_pip_spec()], python_version="3.11")
+    write_checksums(_output_paths_to_checksum(output_dir), output_dir, anchor=output_dir)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Aggregate QC reports with MultiQC and generate a ClawBio markdown summary"
+    )
+    parser.add_argument("--input", nargs="+", metavar="DIR",
+        help="One or more directories to scan (MultiQC auto-detects tool outputs)")
+    parser.add_argument("--output", required=True, metavar="DIR",
+        help="Output directory for report.md, HTML report, and data files")
+    parser.add_argument("--demo", action="store_true",
+        help="Run with synthetic FastQC demo data (no --input required)")
+    args = parser.parse_args()
+
+    if not args.demo and not args.input:
+        parser.error("--input is required unless --demo is used")
+
+    check_multiqc()
+
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.demo:
+        with tempfile.TemporaryDirectory() as tmp:
+            make_demo_fastqc_files(Path(tmp))
+            run_multiqc([Path(tmp)], output_dir)
+        input_dirs_display: list[Path] = [Path("(demo synthetic FastQC data)")]
+    else:
+        input_dirs_display = validate_input_dirs(args.input)
+        run_multiqc(input_dirs_display, output_dir)
+
+    samples = parse_general_stats(output_dir)
+    write_report(output_dir, input_dirs_display, samples)
+    write_reproducibility_bundle(output_dir, demo=args.demo, input_dirs=[] if args.demo else input_dirs_display)
+    print(f"Report written to: {output_dir / 'report.md'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/multiqc-reporter/tests/test_multiqc_reporter.py
+++ b/skills/multiqc-reporter/tests/test_multiqc_reporter.py
@@ -1,0 +1,150 @@
+"""
+test_multiqc_reporter.py — Tests for the MultiQC skill
+=======================================================
+All tests run offline — no MultiQC installation required.
+subprocess.run is mocked throughout.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SKILL_DIR))
+
+import multiqc_reporter  # noqa: E402
+
+
+def test_multiqc_not_found():
+    """check_multiqc() exits with code 1 when multiqc not on PATH."""
+    with patch("multiqc_reporter.shutil.which", return_value=None):
+        with pytest.raises(SystemExit) as exc:
+            multiqc_reporter.check_multiqc()
+    assert exc.value.code == 1
+
+
+def test_missing_input_dir(tmp_path):
+    """validate_input_dirs() exits with code 1 when a directory does not exist."""
+    missing = str(tmp_path / "does_not_exist")
+    with pytest.raises(SystemExit) as exc:
+        multiqc_reporter.validate_input_dirs([missing])
+    assert exc.value.code == 1
+
+
+def test_cli_args_forwarded(tmp_path):
+    """run_multiqc() invokes multiqc with only input dirs and --outdir (defaults)."""
+    with patch("multiqc_reporter.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0)
+        multiqc_reporter.run_multiqc(
+            input_dirs=[tmp_path],
+            output_dir=tmp_path,
+        )
+    cmd = mock_run.call_args[0][0]
+    assert "--export" not in cmd
+    assert "--data-format" not in cmd
+    assert cmd[:2] == ["multiqc", str(tmp_path)]
+    assert cmd[-2:] == ["--outdir", str(tmp_path)]
+
+
+def test_report_md_written(tmp_path):
+    """write_report() creates report.md containing the ClawBio disclaimer."""
+    multiqc_reporter.write_report(
+        output_dir=tmp_path,
+        input_dirs=[tmp_path / "input"],
+        samples={},
+    )
+    report = tmp_path / "report.md"
+    assert report.exists()
+    assert multiqc_reporter.DISCLAIMER in report.read_text()
+
+
+def test_per_sample_table(tmp_path):
+    """parse_general_stats() reads multiqc_data.json and write_report() renders a table."""
+    stats_dir = tmp_path / "multiqc_data"
+    stats_dir.mkdir()
+    fixture = {
+        "report_general_stats_data": {
+            "fastqc": {
+                "SAMPLE_01": {"percent_duplicates": 5.5, "percent_gc": 49},
+                "SAMPLE_02": {"percent_duplicates": 15.0, "percent_gc": 50},
+            }
+        }
+    }
+    (stats_dir / "multiqc_data.json").write_text(json.dumps(fixture))
+
+    samples = multiqc_reporter.parse_general_stats(tmp_path)
+
+    assert "SAMPLE_01" in samples
+    assert "SAMPLE_02" in samples
+
+    multiqc_reporter.write_report(
+        output_dir=tmp_path,
+        input_dirs=[tmp_path / "input"],
+        samples=samples,
+    )
+    report_text = (tmp_path / "report.md").read_text()
+    assert "SAMPLE_01" in report_text
+    assert "SAMPLE_02" in report_text
+
+
+def test_demo_mode(tmp_path):
+    """make_demo_fastqc_files() creates 3 SAMPLE_XX dirs each with fastqc_data.txt."""
+    multiqc_reporter.make_demo_fastqc_files(tmp_path)
+    sample_dirs = [d for d in tmp_path.iterdir() if d.is_dir()]
+    assert len(sample_dirs) == 3
+    for d in sample_dirs:
+        assert (d / "fastqc_data.txt").exists(), f"fastqc_data.txt missing in {d}"
+        assert d.name.startswith("SAMPLE_")
+
+
+def test_write_reproducibility_bundle(tmp_path):
+    """write_reproducibility_bundle writes the three reproducibility files."""
+    out = tmp_path / "run"
+    out.mkdir()
+    (out / "report.md").write_text("# mock\n")
+    (out / "multiqc_data").mkdir()
+    (out / "multiqc_data" / "multiqc_data.json").write_text("{}")
+
+    inp = tmp_path / "qc_in"
+    inp.mkdir()
+    multiqc_reporter.write_reproducibility_bundle(out, demo=False, input_dirs=[inp])
+
+    repro = out / "reproducibility"
+    assert (repro / "commands.sh").exists()
+    assert (repro / "environment.yml").exists()
+    assert (repro / "checksums.sha256").exists()
+    assert "report.md" in (repro / "checksums.sha256").read_text()
+    assert "multiqc_data/multiqc_data.json" in (repro / "checksums.sha256").read_text()
+    cmd = (repro / "commands.sh").read_text()
+    assert "multiqc-reporter/multiqc_reporter.py" in cmd
+    assert "--input" in cmd
+    env_yml = (repro / "environment.yml").read_text()
+    assert "clawbio-multiqc-reporter" in env_yml
+    assert "python=3.11" in env_yml
+
+
+def test_write_reproducibility_bundle_demo(tmp_path):
+    """Demo runs write --demo in commands.sh and omit --input."""
+    out = tmp_path / "run"
+    out.mkdir()
+    (out / "report.md").write_text("# mock\n")
+    multiqc_reporter.write_reproducibility_bundle(out, demo=True, input_dirs=[])
+    cmd = (out / "reproducibility" / "commands.sh").read_text()
+    assert "--demo" in cmd
+    assert "--input" not in cmd
+
+
+def test_cli_command_for_repro_demo(tmp_path):
+    """cli_command_for_repro uses --demo when demo=True."""
+    cmd = multiqc_reporter.cli_command_for_repro(
+        tmp_path / "out",
+        demo=True,
+        input_dirs=[],
+    )
+    assert "--demo" in cmd
+    assert "--input" not in cmd


### PR DESCRIPTION
Closes #135

## Summary

- Adds `skills/multiqc-reporter/` — wraps the MultiQC CLI to aggregate QC reports from any bioinformatics tool outputs (FastQC, fastp, STAR, Picard, samtools, etc.) into an interactive HTML report plus a ClawBio `report.md` with a per-sample metrics table
- Adds routing, CLI reference, and demo data entry to `CLAUDE.md`

## Skill affected

New skill: `multiqc-reporter`

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology)
- [x] Tests included and passing (`pytest -v`)
- [x] Demo data included for reviewers to test
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

```
collected 9 items

skills/multiqc-reporter/tests/test_multiqc_reporter.py::test_multiqc_not_found PASSED
skills/multiqc-reporter/tests/test_multiqc_reporter.py::test_missing_input_dir PASSED
skills/multiqc-reporter/tests/test_multiqc_reporter.py::test_cli_args_forwarded PASSED
skills/multiqc-reporter/tests/test_multiqc_reporter.py::test_report_md_written PASSED
skills/multiqc-reporter/tests/test_multiqc_reporter.py::test_per_sample_table PASSED
skills/multiqc-reporter/tests/test_multiqc_reporter.py::test_demo_mode PASSED
skills/multiqc-reporter/tests/test_multiqc_reporter.py::test_write_reproducibility_bundle PASSED
skills/multiqc-reporter/tests/test_multiqc_reporter.py::test_write_reproducibility_bundle_demo PASSED
skills/multiqc-reporter/tests/test_multiqc_reporter.py::test_cli_command_for_repro_demo PASSED

9 passed in 0.06s
```