### PR TITLE
fix: add missing metadata

### DIFF
--- a/skills/archaic-introgression/SKILL.md
+++ b/skills/archaic-introgression/SKILL.md
@@ -24,6 +24,21 @@ trigger_keywords:
   - Sprime
   - hmmix
   - introgressed segments
+
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - python3
+      env: []
+      config: []
+    always: false
+    emoji: "🦴"
+    os: [darwin, linux]
+    install:
+      - kind: pip
+        package: numpy
+        bins: []
 ---
 
 # Archaic Introgression Detector

--- a/skills/mendelian-randomisation/SKILL.md
+++ b/skills/mendelian-randomisation/SKILL.md
@@ -58,6 +58,7 @@ metadata:
       env: []
       config: []
     always: false
+    emoji: "🫛"
     homepage: https://github.com/ClawBio/ClawBio
     os: [darwin, linux]
     install:


### PR DESCRIPTION
## Summary

- Adds missing `emoji: "🫛"` field to `metadata.openclaw` in `skills/mendelian-randomisation/SKILL.md`
- Adds missing `metadata.openclaw` block to `skills/archaic-introgression/SKILL.md`
- Fixes CI lint failures for both skills

## Skill affected

mendelian-randomisation, archaic-introgression

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology)
- [ ] Tests included and passing (`pytest -v`)
- [ ] Demo data included for reviewers to test
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

Frontmatter-only fixes — no logic changed, no tests required.