### PR TITLE
Add seq-wrangler skill - resolves #10

### DIFF
--- a/skills/seq-wrangler/README.md
+++ b/skills/seq-wrangler/README.md
@@ -1,0 +1,102 @@
+# 🧬 Seq Wrangler
+
+**ClawBio skill** — FASTQ QC, alignment, and BAM processing pipeline for NGS data.
+
+Part of the [ClawBio](https://github.com/ClawBio/ClawBio) bioinformatics AI agent skill library.
+
+## Quick Start
+
+```bash
+# Demo (no external tools needed)
+python skills/seq-wrangler/seq_wrangler.py --demo --output /tmp/demo
+
+# Single sample paired-end
+python skills/seq-wrangler/seq_wrangler.py \
+    --r1 sample_R1.fastq.gz \
+    --r2 sample_R2.fastq.gz \
+    --index ref/hg38 \
+    --aligner bowtie2 \
+    --output results/
+
+# Batch mode via samplesheet
+python skills/seq-wrangler/seq_wrangler.py \
+    --samplesheet samples.csv \
+    --index ref/hg38 \
+    --output results/
+```
+
+## What it produces
+```bash
+output/
+├── report.md # Full alignment and QC report
+├── summary.json # Per-sample stats as JSON
+├── bam/
+│ └── sample_sorted.bam # Final sorted, markdup BAM + .bai index
+├── alignment/
+│ └── sample.sam # Intermediate SAM (only with --keep-sam)
+└── reproducibility/
+├── commands.sh # Reproduce this exact run
+├── environment.yml # Conda environment
+├── checksums.sha256 # SHA-256 of all input files
+└── run_metadata.json # Full run parameters
+```
+
+## Options
+
+| Flag | Description | Default |
+|---|---|---|
+| `--r1` | FASTQ R1 or single-end FASTQ | — |
+| `--r2` | FASTQ R2 for paired-end | — |
+| `--samplesheet` | CSV with columns `sample,fastq1,fastq2` | — |
+| `--index` | Aligner index prefix | required |
+| `--aligner` | `bwa`, `bowtie2`, or `minimap2` | `bwa` |
+| `--genome-build` | `GRCh38` or `GRCh37` | `GRCh38` |
+| `--output` | Output directory | required |
+| `--threads` | Number of threads | auto |
+| `--mapq` | MAPQ filter threshold | `20` |
+| `--trim` | Run fastp trimming before alignment | off |
+| `--remove-duplicates` | Remove duplicates with `samtools markdup -r` | off |
+| `--keep-sam` | Keep intermediate SAM files | off |
+| `--run-fastqc` | Run FastQC if available | off |
+| `--run-multiqc` | Run MultiQC aggregation if available | off |
+| `--demo` | Run with synthetic data, no tools needed | off |
+
+## Pipeline steps
+
+1. **FastQC** — per-sample quality assessment (optional)
+2. **fastp** — adapter trimming and QC (optional, `--trim`)
+3. **Alignment** — BWA MEM / Bowtie2 / Minimap2
+4. **samtools view** — filter by MAPQ threshold
+5. **samtools sort -n** — sort by read name
+6. **samtools fixmate** — fix mate-pair information
+7. **samtools sort** — coordinate sort
+8. **samtools markdup** — mark (or remove) PCR duplicates
+9. **samtools index** — index final BAM
+10. **samtools flagstat / coverage / stats** — alignment statistics
+11. **MultiQC** — aggregated QC report (optional)
+12. **Report** — Markdown report + reproducibility bundle
+
+## Dependencies
+
+Install via conda (recommended):
+
+```bash
+conda install -c bioconda samtools bowtie2 bwa minimap2 fastqc fastp multiqc
+```
+
+Or use the included environment file:
+
+```bash
+conda env create -f skills/seq-wrangler/reproducibility/environment.yml
+conda activate clawbio-seq-wrangler
+```
+
+## Run Tests
+
+```bash
+python -m pytest skills/seq-wrangler/tests/ -v
+```
+
+## Author
+
+Contributed by [Daniel Garbozo](https://github.com/DanielGarbozo)  — resolves [Issue #10](https://github.com/ClawBio/ClawBio/issues/10).

--- a/skills/seq-wrangler/SKILL.md
+++ b/skills/seq-wrangler/SKILL.md
@@ -1,50 +1,277 @@
 ---
 name: seq-wrangler
-description: Sequence QC, alignment, and BAM processing. Wraps FastQC, BWA/Bowtie2, SAMtools for automated read-to-BAM pipelines.
+description: "NGS read QC, alignment, and BAM processing pipeline. Wraps FastQC, BWA/Bowtie2/Minimap2, SAMtools, and MultiQC for automated read-to-BAM workflows."
 version: 0.1.0
+author: Daniel Garbozo
+domain: genomics
+license: MIT
+emoji: "🦖"
+os: [darwin, linux]
+inputs:
+  - name: r1
+    type: file
+    format: fastq.gz
+    description: "FASTQ R1 or single-end reads"
+    required: true
+  - name: r2
+    type: file
+    format: fastq.gz
+    description: "FASTQ R2 for paired-end mode"
+    required: false
+  - name: samplesheet
+    type: file
+    format: csv
+    description: "CSV with columns sample, fastq1, fastq2"
+    required: false
+  - name: index
+    type: string
+    description: "Aligner index prefix (bowtie2-build / bwa index output)"
+    required: true
+outputs:
+  - name: report
+    type: file
+    format: md
+    description: "Alignment QC report with flagstat, coverage, and insert size"
+  - name: bam
+    type: file
+    format: bam
+    description: "Sorted, duplicate-marked BAM with .bai index"
+dependencies:
+  python: ">=3.10"
+  packages: []
+tags:
+  - fastq
+  - alignment
+  - bam
+  - qc
+  - bowtie2
+  - bwa
+  - minimap2
+  - samtools
+  - ngs
+  - genomics
+demo_data:
+  - path: examples/demo-results/report.md
+    description: Pre-generated demo report for two synthetic samples
+endpoints:
+  cli: python skills/seq-wrangler/seq_wrangler.py --r1 {r1} --r2 {r2} --index {index} --output {output_dir}
 metadata:
   openclaw:
     requires:
-      bins:
-        - python3
-        - samtools
-      anyBins:
-        - bwa
-        - bowtie2
-        - minimap2
-      env: []
-      config: []
-    always: false
-    emoji: "🦖"
+      always: false
     homepage: https://github.com/ClawBio/ClawBio
     os: [darwin, linux]
-    install:
-      - kind: brew
-        formula: samtools
-        bins: [samtools]
-      - kind: brew
-        formula: bwa
-        bins: [bwa]
+    emoji: "🦖"
+    install: []
+    trigger_keywords:
+      - "align reads"
+      - "align fastq"
+      - "map reads"
+      - "paired-end alignment"
+      - "bwa mem"
+      - "bowtie2"
+      - "minimap2"
+      - "fastq to bam"
+      - "read qc"
+      - "trim adapters"
+      - "coverage of bam"
+      - "flagstat"
+      - "sort and index bam"
+      - "process fastq"
 ---
 
 # 🦖 Seq Wrangler
 
-You are the **Seq Wrangler**, a specialised agent for sequence data QC, alignment, and processing.
+You are the **Seq Wrangler**, a specialised agent for sequence data QC, alignment, and BAM processing.
+
+## Trigger
+
+**Fire this skill when the user says any of:**
+- "align reads", "align fastq", "align paired-end"
+- "run QC on my reads"
+- "map reads to reference"
+- "process my fastq files"
+- "sort and index this BAM"
+- "what is the coverage of this BAM"
+- "trim adapters and align"
+- "bowtie2", "bwa mem", "minimap2"
+
+**Do NOT fire when:**
+- User wants variant annotation from a BAM/VCF (route to `vcf-annotator`)
+- User wants differential expression from a BAM (route to `rnaseq-de`)
+- User wants methylation analysis (route to `methylation-clock`)
+
+## Why This Exists
+
+Without this skill, aligning FASTQ reads to a reference genome requires manually coordinating 6+ tools (FastQC, fastp, BWA/Bowtie2/Minimap2, samtools sort/fixmate/markdup/index), managing intermediate files, and producing no reproducibility record. Seq Wrangler automates the full read-to-BAM pipeline, enforces MAPQ filtering, marks duplicates, computes per-sample statistics, and generates a reproducibility bundle in a single command.
+
 
 ## Core Capabilities
 
 1. **Read QC**: Run FastQC, parse results, flag quality issues
-2. **Adapter Trimming**: Trim adapters with fastp or Trimmomatic
+2. **Adapter Trimming**: Trim adapters with fastp (optional)
 3. **Alignment**: Align reads to reference genomes (BWA-MEM2, Bowtie2, Minimap2)
-4. **BAM Processing**: Sort, index, mark duplicates, compute coverage statistics
-5. **MultiQC Report**: Aggregate QC metrics across samples
-6. **Pipeline Generation**: Export the full workflow as a shell script or Nextflow pipeline
+4. **BAM Processing**: MAPQ filter → name sort → fixmate → coordinate sort → markdup → index
+5. **Statistics**: flagstat, per-chromosome coverage, insert size (paired-end)
+6. **MultiQC Report**: Aggregate QC metrics across samples (optional)
+7. **Pipeline Generation**: Export the full workflow as a shell script or Nextflow pipeline
+8. **Reproducibility Bundle**: commands.sh, environment.yml, checksums.sha256, run_metadata.json
+9. **Demo Mode**: Synthetic data run, no external tools required
+
+## Input Formats
+
+| Format | Extension | Required fields |
+|--------|-----------|----------------|
+| FASTQ (SE) | `.fastq.gz`, `.fq.gz` | Single-end reads |
+| FASTQ (PE) | `.fastq.gz`, `.fq.gz` | R1 + R2 paired reads |
+| Samplesheet | `.csv` | `sample`, `fastq1`, `fastq2` (optional) |
+| Aligner index | prefix | Pre-built BWA/Bowtie2/Minimap2 index |
+
+## Workflow
+
+1. Validate input files and tools
+2. Run FastQC on all FASTQs (if `--run-fastqc`)
+3. Trim adapters with fastp (if `--trim`)
+4. Align reads with selected aligner → SAM
+5. Filter by MAPQ threshold with `samtools view`
+6. Sort by read name with `samtools sort -n`
+7. Fix mate-pair information with `samtools fixmate`
+8. Coordinate sort with `samtools sort`
+9. Mark (or remove) duplicates with `samtools markdup`
+10. Index final BAM with `samtools index`
+11. Compute flagstat, coverage, insert size
+12. Aggregate with MultiQC (if `--run-multiqc`)
+13. Generate Markdown report and reproducibility bundle
+
+## CLI Reference
+
+```bash
+# Demo (no external tools needed)
+python skills/seq-wrangler/seq_wrangler.py --demo --output /tmp/demo
+
+# Single sample paired-end
+python skills/seq-wrangler/seq_wrangler.py \
+  --r1 sample_R1.fastq.gz \
+  --r2 sample_R2.fastq.gz \
+  --index ref/hg38 \
+  --aligner bowtie2 \
+  --output results/
+
+# Single sample single-end
+python skills/seq-wrangler/seq_wrangler.py \
+  --r1 sample.fastq.gz \
+  --index ref/hg38 \
+  --aligner bwa \
+  --output results/
+
+# Batch mode via samplesheet
+python skills/seq-wrangler/seq_wrangler.py \
+  --samplesheet samples.csv \
+  --index ref/hg38 \
+  --output results/
+
+# With trimming and duplicate removal
+python skills/seq-wrangler/seq_wrangler.py \
+  --r1 sample_R1.fastq.gz --r2 sample_R2.fastq.gz \
+  --index ref/hg38 --aligner bowtie2 \
+  --trim --remove-duplicates --keep-sam \
+  --output results/
+```
+
+## Demo
+
+```bash
+python skills/seq-wrangler/seq_wrangler.py --demo --output /tmp/demo
+```
+
+Expected output: Markdown report with synthetic flagstat (97.5% mapped, 8.7% duplicates) and coverage statistics for two demo samples (CTRL_REP1 paired-end, TREAT_REP1 single-end). No external tools required.
+
+## Output Structure
+```bash
+output/
+├── report.md # Full alignment and QC report
+├── summary.json # Per-sample statistics as JSON
+├── bam/
+│ └── sample_sorted.bam # Final sorted, markdup BAM
+│ └── sample_sorted.bam.bai # BAM index
+├── alignment/
+│ └── sample.sam # Intermediate SAM (only with --keep-sam)
+├── fastqc/ # FastQC reports (if --run-fastqc)
+├── trimmed/ # Trimmed FASTQs (if --trim)
+├── multiqc/ # MultiQC report (if --run-multiqc)
+└── reproducibility/
+│ └── commands.sh # Exact command to reproduce this run
+│ └── environment.yml # Conda environment spec 
+│ └── checksums.sha256 # SHA-256 of all input files
+│ └── run_metadata.json # Full run parameters and timestamp
+```
 
 ## Dependencies
 
+**Required:**
 - `samtools` (BAM manipulation)
-- `bwa` or `bowtie2` or `minimap2` (alignment)
-- Optional: `fastqc`, `fastp`, `multiqc`, `picard`
+- One of: `bwa`, `bowtie2`, or `minimap2` (alignment)
+
+**Optional:**
+- `fastqc`: per-sample read QC
+- `fastp`: adapter trimming
+- `multiqc`: aggregated QC report
+
+Install via conda:
+```bash
+conda install -c bioconda samtools bowtie2 bwa minimap2 fastqc fastp multiqc
+```
+
+## Gotchas
+
+- **Memory for samtools sort**: Uses 2G RAM per thread by default. On machines
+  with <8G RAM, use `--threads 2` or `--threads 3` to avoid OOM errors.
+
+- **`python3` vs `python` on Windows**: Tests use `sys.executable` instead of
+  `python3` for cross-platform compatibility. On Windows, `python3` may not
+  exist in PATH.
+
+- **Index prefix vs file**: `--index` expects the aligner index **prefix**
+  (e.g. `hg38_chr22`), not a `.fa` or `.bt2` file path. Build with
+  `bowtie2-build genome.fa prefix` first.
+
+- **SAM files are deleted by default**: Use `--keep-sam` to retain intermediate
+  SAM files. They can be 10x larger than the final BAM.
+
+- **MAPQ filter removes unaligned reads**: Default `--mapq 20` filters out
+  reads that did not align or aligned poorly. Lower this value if you expect
+  low-quality data.
+
+- **GRCh37 vs GRCh38**: The `--genome-build` flag is for metadata and reporting
+  only. It does not affect alignment — always build your index from the correct
+  reference genome.
+
+## Agent Boundary
+
+The agent (LLM) dispatches the FASTQ files and explains results.
+The skill (Python) executes all tool calls and generates files.
+The agent must NOT invent flagstat percentages, coverage values, or
+insert size statistics.
+
+## Safety
+
+- Local-first: no data is uploaded to external servers
+- Network calls: none
+- Disclaimer: Seq Wrangler is a research and educational tool. Results must be validated before use in clinical or production settings
+- No hardcoded credentials or absolute paths
+- MAPQ filtering applied by default (≥20) to reduce spurious alignments
+
+## Integration with Bio Orchestrator
+
+**Trigger conditions:**
+- User provides FASTQ files and asks for alignment or QC
+- Keywords: `align`, `fastq`, `bam`, `coverage`, `paired-end`, `bowtie2`, `bwa`
+
+**Chaining partners:**
+- → `rnaseq-de`: pass final BAM for differential expression
+- → `methylation-clock`: pass BAM for methylation analysis
+- → `equity-scorer`: pass BAM for population equity metrics
+- → `acmg`: pass aligned BAM for variant calling upstream
 
 ## Example Queries
 
@@ -52,7 +279,15 @@ You are the **Seq Wrangler**, a specialised agent for sequence data QC, alignmen
 - "Align paired-end reads to GRCh38 and sort the output BAM"
 - "What is the mean coverage of this BAM file?"
 - "Trim adapters and re-align these reads"
+- "Process this samplesheet of 10 samples with bowtie2 and remove duplicates"
+- "Run the seq-wrangler demo so I can see what the output looks like"
+- "Align these single-end reads with minimap2 and keep the SAM file"
 
-## Status
+## Citations
 
-**Planned** -- implementation targeting Week 4-5 (Mar 20 - Apr 2).
+- Li H. et al. (2009) The Sequence Alignment/Map format and SAMtools. *Bioinformatics*
+- Langmead B. & Salzberg S. (2012) Fast gapped-read alignment with Bowtie 2. *Nature Methods*
+- Li H. & Durbin R. (2009) Fast and accurate short read alignment with BWA. *Bioinformatics*
+- Li H. (2018) Minimap2: pairwise alignment for nucleotide sequences. *Bioinformatics*
+- Chen S. et al. (2018) fastp: an ultra-fast all-in-one FASTQ preprocessor. *Bioinformatics*
+- Ewels P. et al. (2016) MultiQC: summarize analysis results for multiple tools. *Bioinformatics*

--- a/skills/seq-wrangler/examples/demo-results/report.md
+++ b/skills/seq-wrangler/examples/demo-results/report.md
@@ -1,0 +1,86 @@
+# Seq Wrangler Report
+
+**Date**: 2026-04-19 04:31 UTC
+**Tool**: ClawBio Seq Wrangler v0.1.0
+**Mode**: Demo (synthetic data)
+
+---
+
+## Run parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Aligner | bwa |
+| MAPQ threshold | ≥20 |
+| Duplicate handling | Mark only |
+| Samples processed | 2 |
+
+---
+
+## Results per sample
+
+### CTRL_REP1 (Paired-end)
+
+**Alignment statistics**
+
+| Metric | Value |
+|--------|-------|
+| Total reads | 10,000,000 |
+| Mapped reads | 9,750,000 (97.5%) |
+| Duplicates | 850,000 |
+| Properly paired | 9,500,000 |
+
+**Coverage (top chromosomes)**
+
+| Chromosome | Mean depth | Breadth |
+|------------|------------|---------|
+| chr1 | 28.4x | 97.0% |
+| chr2 | 27.9x | 96.0% |
+| chrX | 14.2x | 91.0% |
+| chrM | 1842.0x | 100.0% |
+
+**Insert size**: mean 312.4 bp | median 305.0 bp | std 48.2 bp
+
+**BAM**: `examples/demo-results/bam/CTRL_REP1_sorted.bam`
+
+### TREAT_REP1 (Single-end)
+
+**Alignment statistics**
+
+| Metric | Value |
+|--------|-------|
+| Total reads | 8,500,000 |
+| Mapped reads | 8,200,000 (96.5%) |
+| Duplicates | 600,000 |
+
+**Coverage (top chromosomes)**
+
+| Chromosome | Mean depth | Breadth |
+|------------|------------|---------|
+| chr1 | 24.1x | 95.0% |
+| chr2 | 23.8x | 94.0% |
+| chrX | 23.5x | 94.0% |
+| chrM | 1560.0x | 100.0% |
+
+**BAM**: `examples/demo-results/bam/TREAT_REP1_sorted.bam`
+
+
+---
+
+## Methods
+
+- **QC**: FastQC per-sample quality assessment
+- **Trimming**: fastp (if --trim flag used)
+- **Alignment**: bwa with MAPQ ≥ 20 filter
+- **BAM processing**: samtools sort -n → fixmate → coordinate-sort → markdup (mark only) → index
+- **Coverage**: samtools coverage (per-chromosome mean depth and breadth)
+- **Insert size**: samtools stats IS histogram (paired-end only)
+- **MultiQC**: aggregated QC report across samples (if --run-multiqc)
+
+## Input checksums
+
+- `demo_ctrl_R1.fastq.gz`: demo data (no file on disk)- `demo_treat_R1.fastq.gz`: demo data (no file on disk)
+
+## Disclaimer
+
+> ClawBio Seq Wrangler is a research and educational tool. Results must be validated before use in clinical or production settings.

--- a/skills/seq-wrangler/seq_wrangler.py
+++ b/skills/seq-wrangler/seq_wrangler.py
@@ -1,0 +1,874 @@
+#!/usr/bin/env python3
+"""
+ClawBio Seq Wrangler
+NGS QC, alignment, and BAM processing pipeline.
+Wraps FastQC, BWA/Bowtie2/Minimap2, SAMtools, and MultiQC.
+
+Usage:
+    # Single sample SE
+    python seq_wrangler.py --r1 sample.fastq.gz --index /ref/hg38 --output results/
+
+    # Single sample PE
+    python seq_wrangler.py --r1 sample_R1.fastq.gz --r2 sample_R2.fastq.gz --index /ref/hg38 --output results/
+
+    # Batch mode (samplesheet CSV)
+    python seq_wrangler.py --samplesheet samples.csv --index /ref/hg38 --output results/
+
+    # Demo mode (no external tools needed)
+    python seq_wrangler.py --demo --output demo_results/
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+# Constants
+
+DEFAULT_MAPQ = 20
+DEFAULT_THREADS = os.cpu_count() or 4
+SUPPORTED_ALIGNERS = ("bwa", "bowtie2", "minimap2")
+SAFETY_DISCLAIMER = (
+    "ClawBio Seq Wrangler is a research and educational tool. "
+    "Results must be validated before use in clinical or production settings."
+)
+
+DEMO_FLAGSTAT = {
+    "CTRL_REP1": {
+        "total": 10_000_000, "mapped": 9_750_000, "mapped_pct": 97.5,
+        "duplicates": 850_000, "dup_pct": 8.7,
+        "paired": True, "properly_paired": 9_500_000,
+    },
+    "TREAT_REP1": {
+        "total": 8_500_000, "mapped": 8_200_000, "mapped_pct": 96.5,
+        "duplicates": 600_000, "dup_pct": 7.3,
+        "paired": False, "properly_paired": 0,
+    },
+}
+
+DEMO_COVERAGE = {
+    "CTRL_REP1": [
+        {"chr": "chr1", "mean_depth": 28.4, "breadth": 0.97},
+        {"chr": "chr2", "mean_depth": 27.9, "breadth": 0.96},
+        {"chr": "chrX", "mean_depth": 14.2, "breadth": 0.91},
+        {"chr": "chrM", "mean_depth": 1842.0, "breadth": 1.00},
+    ],
+    "TREAT_REP1": [
+        {"chr": "chr1", "mean_depth": 24.1, "breadth": 0.95},
+        {"chr": "chr2", "mean_depth": 23.8, "breadth": 0.94},
+        {"chr": "chrX", "mean_depth": 23.5, "breadth": 0.94},
+        {"chr": "chrM", "mean_depth": 1560.0, "breadth": 1.00},
+    ],
+}
+
+DEMO_INSERT_SIZE = {
+    "CTRL_REP1": {"mean": 312.4, "std": 48.2, "median": 305.0},
+}
+
+DEMO_SAMPLES = [
+    {"sample": "CTRL_REP1", "fastq_1": "demo_ctrl_R1.fastq.gz", "fastq_2": "demo_ctrl_R2.fastq.gz"},
+    {"sample": "TREAT_REP1", "fastq_1": "demo_treat_R1.fastq.gz", "fastq_2": ""},
+]
+
+
+
+# Utility
+
+def sha256_file(filepath: Path) -> str:
+    h = hashlib.sha256()
+    with open(filepath, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def run_command(
+    cmd: List[str],
+    description: str,
+    critical: bool = True,
+    capture_output: bool = True,
+) -> subprocess.CompletedProcess:
+    print(f"  [{description}] {' '.join(str(c) for c in cmd[:7])}...")
+    try:
+        result = subprocess.run(
+            [str(c) for c in cmd],
+            capture_output=capture_output,
+            text=True if capture_output else False,
+            timeout=7200,
+            check=False,
+        )
+        if result.returncode != 0:
+            stderr_tail = ""
+            if capture_output and result.stderr:
+                lines = result.stderr.strip().split("\n")
+                stderr_tail = "\n".join(f"  STDERR: {l}" for l in lines[-5:])
+            if critical:
+                msg = f"{description} failed (exit {result.returncode})."
+                if stderr_tail:
+                    msg += f"\n{stderr_tail}"
+                raise RuntimeError(msg)
+            else:
+                print(f"  WARNING: {description} returned non-zero exit {result.returncode}", file=sys.stderr)
+                if stderr_tail:
+                    print(stderr_tail, file=sys.stderr)
+        return result
+    except FileNotFoundError:
+        print(f"  ERROR: '{cmd[0]}' not found. Is it installed and on PATH?", file=sys.stderr)
+        sys.exit(1)
+    except subprocess.TimeoutExpired:
+        print(f"  ERROR: {description} timed out after 2 hours.", file=sys.stderr)
+        sys.exit(1)
+
+
+def check_tool(name: str) -> bool:
+    return shutil.which(name) is not None
+
+
+def detect_threads() -> int:
+    count = os.cpu_count()
+    return max(1, count - 1) if count and count > 1 else 1
+
+
+def load_samplesheet(path: Path) -> List[Dict[str, str]]:
+    samples = []
+    with open(path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        if not {"sample", "fastq_1"}.issubset(set(reader.fieldnames or [])):
+            raise ValueError(f"Samplesheet must have columns: sample, fastq_1. Found: {reader.fieldnames}")
+        for i, row in enumerate(reader, start=2):
+            sample = row["sample"].strip()
+            fq1 = row["fastq_1"].strip()
+            fq2 = row.get("fastq_2", "").strip()
+            if not sample or not fq1:
+                print(f"  WARNING: Skipping empty row at line {i}.", file=sys.stderr)
+                continue
+            samples.append({"sample": sample, "fastq_1": fq1, "fastq_2": fq2})
+    if not samples:
+        raise ValueError(f"No valid samples found in: {path}")
+    return samples
+
+
+def validate_input_files(samples: List[Dict[str, str]]) -> None:
+    for s in samples:
+        fq1 = Path(s["fastq_1"])
+        if not fq1.exists():
+            raise FileNotFoundError(f"FASTQ file not found for sample {s['sample']}: {fq1}")
+        if s["fastq_2"]:
+            fq2 = Path(s["fastq_2"])
+            if not fq2.exists():
+                raise FileNotFoundError(f"FASTQ R2 not found for sample {s['sample']}: {fq2}")
+
+
+def validate_tools(aligner: str, trim: bool, run_multiqc_flag: bool) -> None:
+    if not check_tool("samtools"):
+        raise EnvironmentError("Required tool missing: samtools")
+    if not check_tool(aligner):
+        raise EnvironmentError(f"Required aligner missing: {aligner}")
+    if trim and not check_tool("fastp"):
+        print("  WARNING: --trim requested but fastp is not installed; trimming will be skipped.", file=sys.stderr)
+    if run_multiqc_flag and not check_tool("multiqc"):
+        print("  WARNING: --run-multiqc requested but multiqc is not installed; MultiQC will be skipped.", file=sys.stderr)
+
+
+
+# Step 1 — FastQC
+
+def run_fastqc(fastqs: List[Path], output_dir: Path, threads: int) -> Optional[Path]:
+    if not check_tool("fastqc"):
+        print("  WARNING: fastqc not found — skipping.", file=sys.stderr)
+        return None
+    output_dir.mkdir(parents=True, exist_ok=True)
+    cmd = ["fastqc", "-t", str(threads), "-o", str(output_dir)] + [str(f) for f in fastqs]
+    run_command(cmd, "FastQC", critical=False)
+    return output_dir
+
+
+
+# Step 2 — fastp trimming (optional)
+
+def run_fastp_SE(fastq: Path, output_dir: Path, threads: int) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stem = fastq.name.replace(".fastq.gz", "").replace(".fq.gz", "")
+    trimmed = output_dir / f"{stem}_trimmed.fastq.gz"
+    run_command([
+        "fastp", "-i", str(fastq), "-o", str(trimmed),
+        "-j", str(output_dir / f"{stem}_fastp.json"),
+        "-h", str(output_dir / f"{stem}_fastp.html"),
+        "-w", str(threads),
+    ], f"fastp SE: {fastq.name}")
+    return trimmed
+
+
+def run_fastp_PE(r1: Path, r2: Path, output_dir: Path, threads: int) -> Tuple[Path, Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stem = r1.name.replace(".fastq.gz", "").replace(".fq.gz", "").replace("_R1", "")
+    t1 = output_dir / r1.name.replace(".fastq.gz", "_trimmed.fastq.gz").replace(".fq.gz", "_trimmed.fq.gz")
+    t2 = output_dir / r2.name.replace(".fastq.gz", "_trimmed.fastq.gz").replace(".fq.gz", "_trimmed.fq.gz")
+    run_command([
+        "fastp", "-i", str(r1), "-I", str(r2),
+        "-o", str(t1), "-O", str(t2),
+        "-j", str(output_dir / f"{stem}_fastp.json"),
+        "-h", str(output_dir / f"{stem}_fastp.html"),
+        "-w", str(threads),
+    ], f"fastp PE: {r1.name}")
+    return t1, t2
+
+
+
+# Step 3 — Alignment
+
+def align_SE(sample: str, fastq: Path, index: str, aligner: str, output_dir: Path, threads: int) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    sam = output_dir / f"{sample}.sam"
+    if aligner == "bwa":
+        cmd = ["bwa", "mem", "-t", str(threads), index, str(fastq)]
+        with open(sam, "w", encoding="utf-8") as out_f:
+            result = subprocess.run(cmd, stdout=out_f, stderr=subprocess.PIPE, text=True, check=False)
+        if result.returncode != 0:
+            raise RuntimeError(f"bwa failed: {result.stderr[-500:]}")
+    elif aligner == "bowtie2":
+        run_command(["bowtie2", "-p", str(threads), "-x", index, "-U", str(fastq), "-S", str(sam)],
+                    f"bowtie2 SE: {sample}")
+    elif aligner == "minimap2":
+        cmd = ["minimap2", "-ax", "sr", "-t", str(threads), index, str(fastq)]
+        with open(sam, "w", encoding="utf-8") as out_f:
+            result = subprocess.run(cmd, stdout=out_f, stderr=subprocess.PIPE, text=True, check=False)
+        if result.returncode != 0:
+            raise RuntimeError(f"minimap2 failed: {result.stderr[-500:]}")
+    else:
+        raise ValueError(f"Unsupported aligner: {aligner}")
+    return sam
+
+
+def align_PE(sample: str, r1: Path, r2: Path, index: str, aligner: str, output_dir: Path, threads: int) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    sam = output_dir / f"{sample}.sam"
+    if aligner == "bwa":
+        cmd = ["bwa", "mem", "-t", str(threads), index, str(r1), str(r2)]
+        with open(sam, "w", encoding="utf-8") as out_f:
+            result = subprocess.run(cmd, stdout=out_f, stderr=subprocess.PIPE, text=True, check=False)
+        if result.returncode != 0:
+            raise RuntimeError(f"bwa failed: {result.stderr[-500:]}")
+    elif aligner == "bowtie2":
+        run_command(["bowtie2", "-p", str(threads), "-x", index, "-1", str(r1), "-2", str(r2), "-S", str(sam)],
+                    f"bowtie2 PE: {sample}")
+    elif aligner == "minimap2":
+        cmd = ["minimap2", "-ax", "sr", "-t", str(threads), index, str(r1), str(r2)]
+        with open(sam, "w", encoding="utf-8") as out_f:
+            result = subprocess.run(cmd, stdout=out_f, stderr=subprocess.PIPE, text=True, check=False)
+        if result.returncode != 0:
+            raise RuntimeError(f"minimap2 failed: {result.stderr[-500:]}")
+    else:
+        raise ValueError(f"Unsupported aligner: {aligner}")
+    return sam
+
+
+
+# Step 4 — BAM processing
+
+def sam_to_sorted_bam(sam: Path, output_dir: Path, mapq: int, threads: int, keep_sam: bool = False) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    sample = sam.stem
+    tmp_bam = output_dir / f"{sample}.tmp.bam"
+    sorted_bam = output_dir / f"{sample}_sorted.tmp.bam"
+
+    run_command(["samtools", "view", "-@", str(threads), "-b", "-q", str(mapq), str(sam), "-o", str(tmp_bam)],
+                f"samtools view MAPQ≥{mapq}: {sample}")
+    run_command(["samtools", "sort", "-@", str(threads), "-m", "2G", "-n", "-o", str(sorted_bam), str(tmp_bam)],
+                f"samtools sort -n: {sample}")
+
+    tmp_bam.unlink(missing_ok=True)
+    if not keep_sam:
+        sam.unlink(missing_ok=True)
+    return sorted_bam
+
+
+def run_fixmate(name_sorted_bam: Path, threads: int) -> Path:
+    out = name_sorted_bam.parent / name_sorted_bam.name.replace("_sorted.tmp", "_fixmate.tmp")
+    run_command(["samtools", "fixmate", "-@", str(threads), "-m", str(name_sorted_bam), str(out)],
+                f"samtools fixmate: {name_sorted_bam.stem}")
+    name_sorted_bam.unlink(missing_ok=True)
+    return out
+
+
+def run_coordinate_sort(bam: Path, threads: int, sample: str) -> Path:
+    out = bam.parent / f"{sample}_resort.tmp.bam"
+    run_command(["samtools", "sort", "-@", str(threads), "-m", "2G", "-o", str(out), str(bam)],
+                f"samtools coordinate sort: {sample}")
+    bam.unlink(missing_ok=True)
+    return out
+
+
+def run_markdup(bam: Path, output_dir: Path, threads: int, remove_dups: bool = False) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stem = bam.stem.replace("_fixmate.tmp", "").replace("_sorted.tmp", "").replace("_resort.tmp", "")
+    out_bam = output_dir / f"{stem}_sorted.bam"
+    cmd = ["samtools", "markdup", "-@", str(threads)]
+    if remove_dups:
+        cmd.append("-r")
+    cmd += [str(bam), str(out_bam)]
+    run_command(cmd, f"samtools markdup: {stem}")
+    bam.unlink(missing_ok=True)
+    return out_bam
+
+
+def index_bam(bam: Path, threads: int) -> None:
+    run_command(["samtools", "index", "-@", str(threads), str(bam)], f"samtools index: {bam.name}")
+
+
+def get_flagstat(bam: Path) -> Dict:
+    result = run_command(["samtools", "flagstat", str(bam)], f"samtools flagstat: {bam.name}")
+    stats: Dict = {"raw": result.stdout}
+    for line in result.stdout.splitlines():
+        if "in total" in line:
+            stats["total"] = int(line.split(" + ")[0].strip())
+        elif "mapped (" in line and "primary mapped" not in line:
+            parts = line.split(" + ")
+            stats["mapped"] = int(parts[0].strip())
+            pct_str = line.split("(")[-1].split("%")[0].strip()
+            try:
+                stats["mapped_pct"] = float(pct_str)
+            except ValueError:
+                stats["mapped_pct"] = 0.0
+        elif "duplicates" in line:
+            stats["duplicates"] = int(line.split(" + ")[0].strip())
+        elif "properly paired" in line:
+            stats["properly_paired"] = int(line.split(" + ")[0].strip())
+    return stats
+
+
+def get_coverage(bam: Path) -> List[Dict]:
+    result = run_command(["samtools", "coverage", str(bam)], f"samtools coverage: {bam.name}")
+    rows: List[Dict] = []
+    lines = result.stdout.strip().splitlines()
+    if not lines:
+        return rows
+    headers = lines[0].lstrip("#").split("\t")
+    for line in lines[1:]:
+        fields = line.split("\t")
+        row = dict(zip(headers, fields))
+        covbases = float(row.get("covbases", 0) or 0)
+        endpos = float(row.get("endpos", 1) or 1)
+        rows.append({
+            "chr": row.get("rname", ""),
+            "mean_depth": float(row.get("meandepth", 0) or 0),
+            "breadth": covbases / max(endpos, 1),
+        })
+    return rows
+
+
+def get_insert_size(bam: Path) -> Optional[Dict]:
+    result = run_command(["samtools", "stats", str(bam)], f"samtools stats: {bam.name}", critical=False)
+    if result.returncode != 0:
+        return None
+
+    # Weighted moments to avoid huge memory usage
+    total_n = 0
+    sum_x = 0.0
+    sum_x2 = 0.0
+    weighted_values: List[Tuple[int, int]] = []
+
+    for line in result.stdout.splitlines():
+        if line.startswith("IS\t"):
+            parts = line.split("\t")
+            if len(parts) >= 3:
+                try:
+                    size = int(parts[1])
+                    count = int(parts[2])
+                except ValueError:
+                    continue
+                if count <= 0:
+                    continue
+                weighted_values.append((size, count))
+                total_n += count
+                sum_x += size * count
+                sum_x2 += (size ** 2) * count
+
+    if total_n == 0:
+        return None
+
+    mean = sum_x / total_n
+    variance = max((sum_x2 / total_n) - (mean ** 2), 0.0)
+    std = variance ** 0.5
+
+    # Exact weighted median from histogram
+    weighted_values.sort(key=lambda x: x[0])
+    midpoint = (total_n + 1) / 2
+    acc = 0
+    median = weighted_values[-1][0]
+    for size, count in weighted_values:
+        acc += count
+        if acc >= midpoint:
+            median = size
+            break
+
+    return {"mean": round(mean, 2), "std": round(std, 2), "median": float(median)}
+
+
+def process_sample(
+    sample: str,
+    fq1: Path,
+    fq2: Optional[Path],
+    index: str,
+    aligner: str,
+    output_dir: Path,
+    threads: int,
+    mapq: int,
+    remove_dups: bool,
+    trim: bool,
+    keep_sam: bool
+) -> Dict:
+    is_pe = fq2 is not None
+    print(f"\n{'='*50}")
+    print(f"  Sample: {sample} ({'PE' if is_pe else 'SE'})")
+    print(f"{'='*50}")
+
+    align_dir = output_dir / "alignment"
+    bam_dir = output_dir / "bam"
+    trim_dir = output_dir / "trimmed"
+
+    if trim:
+        if not check_tool("fastp"):
+            print("  WARNING: fastp not found — skipping trimming.", file=sys.stderr)
+        else:
+            if is_pe:
+                fq1, fq2 = run_fastp_PE(fq1, fq2, trim_dir, threads)
+            else:
+                fq1 = run_fastp_SE(fq1, trim_dir, threads)
+
+    if is_pe:
+        sam = align_PE(sample, fq1, fq2, index, aligner, align_dir, threads)
+    else:
+        sam = align_SE(sample, fq1, index, aligner, align_dir, threads)
+
+    name_sorted = sam_to_sorted_bam(sam, bam_dir, mapq, threads, keep_sam=keep_sam)
+    fixmated = run_fixmate(name_sorted, threads)
+    resorted = run_coordinate_sort(fixmated, threads, sample)
+    final_bam = run_markdup(resorted, bam_dir, threads, remove_dups=remove_dups)
+    index_bam(final_bam, threads)
+
+    flagstat = get_flagstat(final_bam)
+    coverage = get_coverage(final_bam)
+    insert_size = get_insert_size(final_bam) if is_pe else None
+
+    return {
+        "sample": sample,
+        "is_pe": is_pe,
+        "bam": str(final_bam),
+        "flagstat": flagstat,
+        "coverage": coverage,
+        "insert_size": insert_size,
+    }
+
+
+
+# Step 5 — MultiQC
+
+def run_multiqc(search_dir: Path, output_dir: Path) -> Optional[Path]:
+    if not check_tool("multiqc"):
+        print("  WARNING: multiqc not found — skipping.", file=sys.stderr)
+        return None
+    output_dir.mkdir(parents=True, exist_ok=True)
+    run_command(["multiqc", str(search_dir), "-o", str(output_dir), "--force"], "MultiQC", critical=False)
+    report = output_dir / "multiqc_report.html"
+    return report if report.exists() else None
+
+
+
+# Step 6 — Report
+
+def generate_report(
+    output_dir: Path,
+    sample_stats: List[Dict],
+    input_files: List[Path],
+    is_demo: bool,
+    aligner: str,
+    mapq: int,
+    remove_dups: bool,
+) -> Path:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    report_path = output_dir / "report.md"
+
+    sample_sections = []
+    for s in sample_stats:
+        name = s["sample"]
+        fs = s["flagstat"]
+        read_type = "Paired-end" if s["is_pe"] else "Single-end"
+
+        def fmt_int(v: object) -> str:
+            return f"{v:,}" if isinstance(v, int) else str(v)
+
+        flagstat_lines = [
+            f"| Total reads | {fmt_int(fs.get('total', 'N/A'))} |",
+            f"| Mapped reads | {fmt_int(fs.get('mapped', 'N/A'))} ({fs.get('mapped_pct', 0):.1f}%) |",
+            f"| Duplicates | {fmt_int(fs.get('duplicates', 'N/A'))} |",
+        ]
+        if s["is_pe"]:
+            flagstat_lines.append(f"| Properly paired | {fmt_int(fs.get('properly_paired', 'N/A'))} |")
+
+        flagstat_table = "\n".join(["| Metric | Value |", "|--------|-------|"] + flagstat_lines)
+
+        cov_rows = s.get("coverage", [])[:5]
+        cov_lines = [
+            f"| {r['chr']} | {r['mean_depth']:.1f}x | {r['breadth']*100:.1f}% |"
+            for r in cov_rows
+        ]
+        cov_table = "\n".join([
+            "| Chromosome | Mean depth | Breadth |",
+            "|------------|------------|---------|",
+        ] + (cov_lines if cov_lines else ["| — | — | — |"]))
+
+        is_section = ""
+        if s["is_pe"] and s.get("insert_size"):
+            ins = s["insert_size"]
+            is_section = (
+                f"\n**Insert size**: mean {ins['mean']} bp | "
+                f"median {ins['median']} bp | std {ins['std']} bp\n"
+            )
+
+        sample_sections.append(f"""
+### {name} ({read_type})
+
+**Alignment statistics**
+
+{flagstat_table}
+
+**Coverage (top chromosomes)**
+
+{cov_table}
+{is_section}
+**BAM**: `{s['bam']}`
+""")
+
+    checksum_lines = []
+    for fp in input_files:
+        if fp.exists():
+            checksum_lines.append(f"- `{fp.name}`: `{sha256_file(fp)}`")
+        else:
+            checksum_lines.append(f"- `{fp.name}`: demo data (no file on disk)")
+
+    report = f"""# Seq Wrangler Report
+
+**Date**: {now}  
+**Tool**: ClawBio Seq Wrangler v0.1.0  
+**Mode**: {"Demo (synthetic data)" if is_demo else "Full pipeline"}
+
+---
+
+## Run parameters
+
+| Parameter | Value |
+|-----------|-------|
+| Aligner | {aligner} |
+| MAPQ threshold | ≥{mapq} |
+| Duplicate handling | {"Remove (-r)" if remove_dups else "Mark only"} |
+| Samples processed | {len(sample_stats)} |
+
+---
+
+## Results per sample
+{"".join(sample_sections)}
+
+---
+
+## Methods
+
+- **QC**: FastQC per-sample quality assessment
+- **Trimming**: fastp (if --trim flag used)
+- **Alignment**: {aligner} with MAPQ ≥ {mapq} filter
+- **BAM processing**: samtools sort -n → fixmate → coordinate-sort → markdup{" (-r remove)" if remove_dups else " (mark only)"} → index
+- **Coverage**: samtools coverage (per-chromosome mean depth and breadth)
+- **Insert size**: samtools stats IS histogram (paired-end only)
+- **MultiQC**: aggregated QC report across samples (if --run-multiqc)
+
+## Input checksums
+
+{"".join(checksum_lines) if checksum_lines else "- demo data"}
+
+## Disclaimer
+
+> {SAFETY_DISCLAIMER}
+"""
+    report_path.write_text(report, encoding="utf-8")
+    print(f"  Saved: {report_path}")
+    return report_path
+
+
+
+# Step 7 — Reproducibility bundle
+
+def write_reproducibility_bundle(output_dir: Path, input_files: List[Path], args: argparse.Namespace, is_demo: bool) -> None:
+    repro_dir = output_dir / "reproducibility"
+    repro_dir.mkdir(parents=True, exist_ok=True)
+
+    if is_demo:
+        cmd_line = f"python seq_wrangler.py --demo --output {args.output}"
+    else:
+        parts = ["python seq_wrangler.py"]
+        if args.samplesheet:
+            parts.append(f"--samplesheet {args.samplesheet}")
+        elif args.r1:
+            parts.append(f"--r1 {args.r1}")
+            if args.r2:
+                parts.append(f"--r2 {args.r2}")
+        parts.append(f"--index {args.index}")
+        parts.append(f"--aligner {args.aligner}")
+        parts.append(f"--genome-build {args.genome_build}")
+        parts.append(f"--output {args.output}")
+        parts.append(f"--threads {args.threads}")
+        parts.append(f"--mapq {args.mapq}")
+        if args.remove_duplicates:
+            parts.append("--remove-duplicates")
+        if args.trim:
+            parts.append("--trim")
+        if args.run_fastqc:
+            parts.append("--run-fastqc")
+        if args.keep_sam:
+            parts.append("--keep-sam")
+        if args.run_multiqc:
+            parts.append("--run-multiqc")
+        cmd_line = " \\\n    ".join(parts)
+
+    commands_sh = f"""#!/usr/bin/env bash
+set -euo pipefail
+
+# Generated: {datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")}
+samtools --version | head -1 || true
+bwa 2>&1 | head -1 || true
+bowtie2 --version | head -1 || true
+minimap2 --version | head -1 || true
+fastqc --version || true
+fastp --version || true
+multiqc --version || true
+
+{cmd_line}
+"""
+    cmd_path = repro_dir / "commands.sh"
+    cmd_path.write_text(commands_sh, encoding="utf-8")
+    cmd_path.chmod(0o755)
+
+    env_yml = """name: clawbio-seq-wrangler
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - python>=3.10
+  - samtools
+  - bwa
+  - bowtie2
+  - minimap2
+  - fastqc
+  - fastp
+  - multiqc
+"""
+    (repro_dir / "environment.yml").write_text(env_yml, encoding="utf-8")
+
+    checksums_path = repro_dir / "checksums.sha256"
+    lines = []
+    for fp in input_files:
+        if fp.exists():
+            lines.append(f"{sha256_file(fp)}  {fp}")
+    checksums_path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+    run_metadata = {
+        "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+        "is_demo": is_demo,
+        "args": vars(args),
+        "n_input_files": len(input_files),
+    }
+    (repro_dir / "run_metadata.json").write_text(json.dumps(run_metadata, indent=2), encoding="utf-8")
+
+
+
+# Pipeline runners
+
+def resolve_samples_from_args(args: argparse.Namespace) -> List[Dict[str, str]]:
+    if args.samplesheet:
+        samples = load_samplesheet(Path(args.samplesheet))
+    else:
+        sample_name = args.sample_name or re.sub(r'[_\.]R[12][_\.].*|[_\.]R[12]$', '', Path(args.r1).stem.replace('.fastq', '').replace('.fq', ''))
+        samples = [{
+            "sample": sample_name,
+            "fastq_1": args.r1,
+            "fastq_2": args.r2 or "",
+        }]
+    return samples
+
+
+def run_pipeline(args: argparse.Namespace) -> None:
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    samples = resolve_samples_from_args(args)
+    validate_input_files(samples)
+    validate_tools(args.aligner, args.trim, args.run_multiqc)
+
+    input_fastqs: List[Path] = []
+    for s in samples:
+        input_fastqs.append(Path(s["fastq_1"]))
+        if s["fastq_2"]:
+            input_fastqs.append(Path(s["fastq_2"]))
+
+    if args.run_fastqc:
+        run_fastqc(input_fastqs, output_dir / "fastqc", args.threads)
+
+    sample_stats: List[Dict] = []
+    for s in samples:
+        fq1 = Path(s["fastq_1"])
+        fq2 = Path(s["fastq_2"]) if s["fastq_2"] else None
+        stats = process_sample(
+            sample=s["sample"],
+            fq1=fq1,
+            fq2=fq2,
+            index=args.index,
+            aligner=args.aligner,
+            output_dir=output_dir,
+            threads=args.threads,
+            mapq=args.mapq,
+            remove_dups=args.remove_duplicates,
+            trim=args.trim,
+            keep_sam=args.keep_sam
+        )
+        sample_stats.append(stats)
+
+    if args.run_multiqc:
+        run_multiqc(output_dir, output_dir / "multiqc")
+
+    report_path = generate_report(
+        output_dir=output_dir,
+        sample_stats=sample_stats,
+        input_files=input_fastqs,
+        is_demo=False,
+        aligner=args.aligner,
+        mapq=args.mapq,
+        remove_dups=args.remove_duplicates,
+    )
+
+    (output_dir / "summary.json").write_text(json.dumps(sample_stats, indent=2), encoding="utf-8")
+    write_reproducibility_bundle(output_dir, input_fastqs, args, is_demo=False)
+
+    print("\nDone.")
+    print(f"Report: {report_path}")
+
+
+def run_demo(args: argparse.Namespace) -> None:
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    sample_stats = []
+    for s in DEMO_SAMPLES:
+        sample = s["sample"]
+        is_pe = bool(s["fastq_2"])
+        sample_stats.append({
+            "sample": sample,
+            "is_pe": is_pe,
+            "bam": str(output_dir / "bam" / f"{sample}_sorted.bam"),
+            "flagstat": DEMO_FLAGSTAT[sample],
+            "coverage": DEMO_COVERAGE[sample],
+            "insert_size": DEMO_INSERT_SIZE.get(sample),
+        })
+
+    input_files = [Path(x["fastq_1"]) for x in DEMO_SAMPLES]
+    report_path = generate_report(
+        output_dir=output_dir,
+        sample_stats=sample_stats,
+        input_files=input_files,
+        is_demo=True,
+        aligner=args.aligner,
+        mapq=args.mapq,
+        remove_dups=args.remove_duplicates,
+    )
+
+    (output_dir / "summary.json").write_text(json.dumps(sample_stats, indent=2), encoding="utf-8")
+    write_reproducibility_bundle(output_dir, input_files, args, is_demo=True)
+
+    print("\nDemo complete.")
+    print(f"Report: {report_path}")
+
+
+
+# CLI
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Seq Wrangler: FASTQ QC, alignment, and BAM processing for read-to-BAM workflows.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    io_group = parser.add_argument_group("Input mode")
+    io_group.add_argument("--samplesheet", type=str, default=None, help="CSV with columns: sample,fastq_1,fastq_2")
+    io_group.add_argument("--r1", type=str, default=None, help="FASTQ R1 (or SE FASTQ)")
+    io_group.add_argument("--r2", type=str, default=None, help="FASTQ R2 for paired-end")
+    io_group.add_argument("--sample-name", type=str, default=None, help="Sample name for single-sample mode")
+
+    parser.add_argument("--index", type=str, default=None, help="Aligner index prefix (required unless --demo)")
+    parser.add_argument("--aligner", choices=SUPPORTED_ALIGNERS, default="bwa", help="Aligner backend")
+    parser.add_argument("--genome-build", choices=["GRCh38", "GRCh37"], default="GRCh38",
+                        help="Human genome build label for metadata/reporting")
+    parser.add_argument("--keep-sam", action="store_true", 
+                        help="Keep intermediate SAM files (default: delete after BAM conversion)")
+
+    parser.add_argument("--output", type=str, required=True, help="Output directory")
+    parser.add_argument("--threads", type=int, default=detect_threads(), help="Threads")
+    parser.add_argument("--mapq", type=int, default=DEFAULT_MAPQ, help="MAPQ filter threshold")
+
+    parser.add_argument("--trim", action="store_true", help="Run fastp trimming before alignment")
+    parser.add_argument("--remove-duplicates", action="store_true",
+                        help="Use samtools markdup -r (remove duplicates)")
+    parser.add_argument("--run-fastqc", action="store_true", help="Run FastQC if available")
+    parser.add_argument("--run-multiqc", action="store_true", help="Run MultiQC aggregation if available")
+
+    parser.add_argument("--demo", action="store_true", help="Run with synthetic demo data (no external tools)")
+    return parser
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    if args.demo:
+        return
+
+    if not args.index:
+        raise ValueError("--index is required unless --demo is used.")
+
+    using_samplesheet = args.samplesheet is not None
+    using_single = args.r1 is not None or args.r2 is not None
+
+    if using_samplesheet and using_single:
+        raise ValueError("Use either --samplesheet OR --r1/--r2, not both.")
+
+    if not using_samplesheet and not args.r1:
+        raise ValueError("Provide --samplesheet OR --r1 (and optional --r2).")
+
+    if args.r2 and not args.r1:
+        raise ValueError("--r2 requires --r1.")
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    try:
+        validate_args(args)
+        print(f"Seq Wrangler starting | Aligner={args.aligner} | Build={args.genome_build} | Threads={args.threads}")
+        if args.demo:
+            run_demo(args)
+        else:
+            run_pipeline(args)
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/seq-wrangler/tests/test_seq_wrangler.py
+++ b/skills/seq-wrangler/tests/test_seq_wrangler.py
@@ -1,0 +1,117 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import seq_wrangler as sw
+from pathlib import Path
+import json
+import types
+import pytest
+
+import seq_wrangler as sw
+
+
+def test_load_samplesheet_mixed_se_pe(tmp_path: Path):
+    p = tmp_path / "samples.csv"
+    p.write_text(
+        "sample,fastq_1,fastq_2\n"
+        "CTRL,a_R1.fastq.gz,a_R2.fastq.gz\n"
+        "TREAT,b.fastq.gz,\n",
+        encoding="utf-8"
+    )
+    rows = sw.load_samplesheet(p)
+    assert len(rows) == 2
+    assert rows[0]["sample"] == "CTRL"
+    assert rows[0]["fastq_2"] == "a_R2.fastq.gz"
+    assert rows[1]["sample"] == "TREAT"
+    assert rows[1]["fastq_2"] == ""
+
+
+def test_load_samplesheet_missing_required_columns(tmp_path: Path):
+    p = tmp_path / "bad.csv"
+    p.write_text("sample,foo\nS1,x.fastq.gz\n", encoding="utf-8")
+    with pytest.raises(ValueError):
+        sw.load_samplesheet(p)
+
+
+def test_detect_threads_positive():
+    assert sw.detect_threads() >= 1
+
+
+def test_check_tool_false_for_nonexistent():
+    assert sw.check_tool("definitely_not_a_real_binary_123") is False
+
+
+def test_sha256_file(tmp_path: Path):
+    p = tmp_path / "x.txt"
+    p.write_text("abc", encoding="utf-8")
+    h = sw.sha256_file(p)
+    assert len(h) == 64
+    assert h == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+
+
+def test_run_command_non_critical_failure():
+    result = sw.run_command(
+        [sys.executable, "-c", "import sys; sys.exit(3)"],
+        "fail-non-critical",
+        critical=False,
+    )
+    assert result.returncode == 3
+
+
+def test_validate_args_demo_ok():
+    args = types.SimpleNamespace(
+        demo=True, index=None, samplesheet=None, r1=None, r2=None
+    )
+    sw.validate_args(args)  # no exception
+
+
+def test_validate_args_requires_index_when_not_demo():
+    args = types.SimpleNamespace(
+        demo=False, index=None, samplesheet=None, r1="a.fastq.gz", r2=None
+    )
+    with pytest.raises(ValueError):
+        sw.validate_args(args)
+
+
+def test_validate_args_samplesheet_xor_single():
+    args = types.SimpleNamespace(
+        demo=False, index="/ref/hg38", samplesheet="samples.csv", r1="a.fastq.gz", r2=None
+    )
+    with pytest.raises(ValueError):
+        sw.validate_args(args)
+
+
+def test_generate_report_and_demo_outputs(tmp_path: Path):
+    args = types.SimpleNamespace(
+        output=str(tmp_path),
+        aligner="bwa",
+        mapq=20,
+        remove_duplicates=False,
+        samplesheet=None,
+        r1=None,
+        r2=None,
+        index=None,
+        threads=2,
+        trim=False,
+        run_fastqc=False,
+        run_multiqc=False,
+        demo=True,
+        genome_build="GRCh38",
+    )
+
+    sw.run_demo(args)
+
+    report = tmp_path / "report.md"
+    summary = tmp_path / "summary.json"
+    repro_cmd = tmp_path / "reproducibility" / "commands.sh"
+    repro_env = tmp_path / "reproducibility" / "environment.yml"
+
+    assert report.exists()
+    assert summary.exists()
+    assert repro_cmd.exists()
+    assert repro_env.exists()
+
+    data = json.loads(summary.read_text(encoding="utf-8"))
+    assert isinstance(data, list)
+    assert len(data) == 2
+    assert data[0]["sample"] in {"CTRL_REP1", "TREAT_REP1"}


### PR DESCRIPTION
Implements the Seq Wrangler skill for automated read-to-BAM NGS workflows.

Closes #10

## Summary
- FASTQ QC with FastQC (optional, `--run-fastqc`)
- Adapter trimming with fastp (optional, `--trim`)
- Alignment with BWA MEM / Bowtie2 / Minimap2 (`--aligner`)
- BAM processing: MAPQ filter → name sort → fixmate → coordinate sort → markdup → index
- Per-sample statistics: flagstat, coverage (per-chromosome), insert size (PE only)
- MultiQC aggregated report (optional, `--run-multiqc`)
- Reproducibility bundle: `commands.sh`, `environment.yml`, `checksums.sha256`, `run_metadata.json`
- Demo mode with synthetic data — no external tools required (`--demo`)

## Skill affected

New skill: `seq-wrangler`

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology)
- [x] Tests included and passing (`pytest -v`)
- [x] Demo data included for reviewers to test
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

```bash
platform linux -- Python 3.13.12, pytest-9.0.3
collected 10 items

skills/seq-wrangler/tests/test_seq_wrangler.py::test_load_samplesheet_mixed_se_pe PASSED
skills/seq-wrangler/tests/test_seq_wrangler.py::test_load_samplesheet_missing_required_columns PASSED
skills/seq-wrangler/tests/test_seq_wrangler.py::test_detect_threads_positive PASSED
skills/seq-wrangler/tests/test_seq_wrangler.py::test_check_tool_false_for_nonexistent PASSED
skills/seq-wrangler/tests/test_seq_wrangler.py::test_sha256_file PASSED
skills/seq-wrangler/tests/test_seq_wrangler.py::test_run_command_non_critical_failure PASSED
skills/seq-wrangler/tests/test_seq_wrangler.py::test_validate_args_demo_ok PASSED
skills/seq-wrangler/tests/test_seq_wrangler.py::test_validate_args_requires_index_when_not_demo PASSED
skills/seq-wrangler/tests/test_seq_wrangler.py::test_validate_args_samplesheet_xor_single PASSED
skills/seq-wrangler/tests/test_seq_wrangler.py::test_generate_report_and_demo_outputs PASSED

10 passed in 0.21s
```