### PR TITLE
fix: portable commands.sh in reproducibility bundles — closes #143

### DIFF
--- a/clawbio/common/portable_commands.py
+++ b/clawbio/common/portable_commands.py
@@ -1,0 +1,187 @@
+"""
+clawbio.common.portable_commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Centralized, portable replay-command generation for ClawBio skills.
+
+Problem solved
+--------------
+Previously each skill wrote commands.sh independently, leading to:
+- Machine-specific absolute paths  (/home/sooraj/ClawBio/...)
+- cwd-dependent bare script names  (python lit_synthesizer.py)
+- Verbatim user paths that break on other machines
+
+Solution
+--------
+All skills call `build_portable_commands_sh()` which produces a
+self-anchoring bash script that:
+1. Locates the repo root relative to the script's own location
+2. Constructs the skill path from the repo root
+3. Resolves input/output paths relative to where commands.sh is executed
+
+Usage in a skill
+----------------
+    from clawbio.common.portable_commands import build_portable_commands_sh
+
+    commands = build_portable_commands_sh(
+        skill_name="lit-synthesizer",
+        script_name="lit_synthesizer.py",
+        args={"--query": query, "--output": "./report"},
+        generated_at=now,
+    )
+    (repro_dir / "commands.sh").write_text(commands)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+# Depth from reproducibility/ to repo root:
+# output/reproducibility/ -> output/ -> (anywhere) -> repo root
+# We anchor to SCRIPT_DIR and walk up to the repo root via a known marker.
+_ANCHOR_HEADER = """\
+#!/usr/bin/env bash
+# ClawBio reproducibility bundle — portable replay command
+# Generated: {generated_at}
+# Skill: {skill_name}
+#
+# How to replay:
+#   bash reproducibility/commands.sh
+# from anywhere inside the repository clone.
+
+set -euo pipefail
+
+# ── Locate repo root ──────────────────────────────────────────────────────────
+# Walk up from this script's directory until we find the repo marker (skills/).
+SCRIPT_DIR="$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
+while [[ ! -d "$REPO_ROOT/skills" && "$REPO_ROOT" != "/" ]]; do
+  REPO_ROOT="$(dirname "$REPO_ROOT")"
+done
+if [[ ! -d "$REPO_ROOT/skills" ]]; then
+  echo "ERROR: Could not locate repo root (no skills/ directory found)" >&2
+  exit 1
+fi
+
+# ── Skill script ──────────────────────────────────────────────────────────────
+SKILL_SCRIPT="$REPO_ROOT/skills/{skill_name}/{script_name}"
+if [[ ! -f "$SKILL_SCRIPT" ]]; then
+  echo "ERROR: Skill script not found: $SKILL_SCRIPT" >&2
+  exit 1
+fi
+
+"""
+
+_COMMAND_TEMPLATE = """\
+# ── Replay command ────────────────────────────────────────────────────────────
+python "$SKILL_SCRIPT" \\
+{args_block}
+"""
+
+
+def _format_value(val: Any) -> str:
+    """Return a shell-safe representation of a CLI argument value."""
+    if val is None:
+        return ""
+    s = str(val)
+    # If value contains spaces or special chars, quote it
+    if any(c in s for c in (" ", "\t", "$", "`", "\\", '"', "'")):
+        return f'"{s}"'
+    return s
+
+
+def _make_output_portable(output_path: str) -> str:
+    """
+    Convert an output path to a portable form.
+    - Absolute paths -> warn and use as-is (user chose absolute)
+    - Relative paths -> keep relative (portable)
+    - Paths that look like /tmp/... -> keep as-is (temp runs)
+    """
+    p = Path(output_path)
+    if p.is_absolute():
+        # Suggest keeping relative; we store as-is but add a comment
+        return str(output_path)
+    return str(output_path)
+
+
+def build_portable_commands_sh(
+    skill_name: str,
+    script_name: str,
+    args: dict[str, Any],
+    generated_at: str | None = None,
+) -> str:
+    """
+    Build a portable, self-anchoring commands.sh content string.
+
+    Parameters
+    ----------
+    skill_name:
+        The skill folder name, e.g. "lit-synthesizer"
+    script_name:
+        The Python script filename, e.g. "lit_synthesizer.py"
+    args:
+        Dict of CLI argument name -> value.
+        Use None value to emit a flag with no value (e.g. {"--demo": None}).
+        Example: {"--query": "CRISPR", "--output": "./report"}
+    generated_at:
+        ISO timestamp string. Defaults to current UTC time.
+
+    Returns
+    -------
+    str
+        Complete contents of commands.sh, ready to write to disk.
+    """
+    if generated_at is None:
+        generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    header = _ANCHOR_HEADER.format(
+        generated_at=generated_at,
+        skill_name=skill_name,
+        script_name=script_name,
+    )
+
+    # Build args block — each arg on its own indented line
+    arg_lines = []
+    for flag, value in args.items():
+        if value is None:
+            # Boolean flag, no value
+            arg_lines.append(f"    {flag}")
+        else:
+            formatted = _format_value(value)
+            arg_lines.append(f"    {flag} {formatted}")
+
+    args_block = " \\\n".join(arg_lines)
+
+    command = _COMMAND_TEMPLATE.format(args_block=args_block)
+
+    return header + command
+
+
+def write_portable_commands_sh(
+    repro_dir: "Path",
+    skill_name: str,
+    script_name: str,
+    args: dict[str, Any],
+    generated_at: str | None = None,
+) -> None:
+    """
+    Convenience wrapper: build and write commands.sh to repro_dir.
+
+    Parameters
+    ----------
+    repro_dir:
+        Path to the reproducibility/ directory (will be created if needed).
+    skill_name, script_name, args, generated_at:
+        Passed through to build_portable_commands_sh().
+    """
+    repro_dir = Path(repro_dir)
+    repro_dir.mkdir(parents=True, exist_ok=True)
+    content = build_portable_commands_sh(
+        skill_name=skill_name,
+        script_name=script_name,
+        args=args,
+        generated_at=generated_at,
+    )
+    (repro_dir / "commands.sh").write_text(content, encoding="utf-8")

--- a/clawbio/tests/test_portable_commands.py
+++ b/clawbio/tests/test_portable_commands.py
@@ -1,0 +1,246 @@
+"""
+Tests for clawbio.common.portable_commands
+Run with: pytest tests/test_portable_commands.py -v
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from clawbio.common.portable_commands import (
+    build_portable_commands_sh,
+    write_portable_commands_sh,
+)
+
+
+# ── build_portable_commands_sh tests ──────────────────────────────────────────
+
+class TestBuildPortableCommandsSh:
+
+    def test_returns_string(self):
+        result = build_portable_commands_sh(
+            skill_name="lit-synthesizer",
+            script_name="lit_synthesizer.py",
+            args={"--query": "CRISPR", "--output": "./report"},
+        )
+        assert isinstance(result, str)
+
+    def test_contains_shebang(self):
+        result = build_portable_commands_sh(
+            skill_name="lit-synthesizer",
+            script_name="lit_synthesizer.py",
+            args={"--query": "CRISPR"},
+        )
+        assert result.startswith("#!/usr/bin/env bash")
+
+    def test_contains_repo_root_anchor(self):
+        result = build_portable_commands_sh(
+            skill_name="lit-synthesizer",
+            script_name="lit_synthesizer.py",
+            args={"--query": "CRISPR"},
+        )
+        assert "BASH_SOURCE" in result
+        assert "REPO_ROOT" in result
+        assert 'skills' in result
+
+    def test_no_absolute_paths_in_output(self):
+        result = build_portable_commands_sh(
+            skill_name="lit-synthesizer",
+            script_name="lit_synthesizer.py",
+            args={"--query": "CRISPR", "--output": "./report"},
+        )
+        # output should be relative ./report not absolute
+        assert "./report" in result
+
+    def test_skill_name_in_script_path(self):
+        result = build_portable_commands_sh(
+            skill_name="vcf-annotator",
+            script_name="vcf_annotator.py",
+            args={"--demo": None},
+        )
+        assert "vcf-annotator/vcf_annotator.py" in result
+
+    def test_boolean_flag_no_value(self):
+        result = build_portable_commands_sh(
+            skill_name="lit-synthesizer",
+            script_name="lit_synthesizer.py",
+            args={"--demo": None},
+        )
+        assert "--demo" in result
+        # Should not have "--demo None"
+        assert "--demo None" not in result
+
+    def test_custom_generated_at(self):
+        ts = "2026-04-19 10:00 UTC"
+        result = build_portable_commands_sh(
+            skill_name="lit-synthesizer",
+            script_name="lit_synthesizer.py",
+            args={"--query": "test"},
+            generated_at=ts,
+        )
+        assert ts in result
+
+    def test_default_generated_at_present(self):
+        result = build_portable_commands_sh(
+            skill_name="lit-synthesizer",
+            script_name="lit_synthesizer.py",
+            args={"--query": "test"},
+        )
+        # Should contain a date
+        assert "202" in result  # year 202x
+
+    def test_multiple_args(self):
+        result = build_portable_commands_sh(
+            skill_name="vcf-annotator",
+            script_name="vcf_annotator.py",
+            args={
+                "--input": "variants.vcf",
+                "--output": "./report",
+            },
+        )
+        assert "--input" in result
+        assert "--output" in result
+        assert "variants.vcf" in result
+
+    def test_no_machine_specific_paths(self):
+        """Command must not embed /home/... or C:\\ style absolute paths."""
+        result = build_portable_commands_sh(
+            skill_name="lit-synthesizer",
+            script_name="lit_synthesizer.py",
+            args={"--output": "./report"},
+        )
+        assert "/home/" not in result
+        assert "C:\\" not in result
+        assert "/Users/" not in result
+
+    def test_uses_dollar_repo_root_variable(self):
+        """Script path must use $REPO_ROOT variable, not hardcoded path."""
+        result = build_portable_commands_sh(
+            skill_name="lit-synthesizer",
+            script_name="lit_synthesizer.py",
+            args={"--query": "test"},
+        )
+        assert '"$REPO_ROOT/skills/' in result
+
+    def test_set_euo_pipefail(self):
+        """Script should fail fast on errors."""
+        result = build_portable_commands_sh(
+            skill_name="lit-synthesizer",
+            script_name="lit_synthesizer.py",
+            args={"--query": "test"},
+        )
+        assert "set -euo pipefail" in result
+
+    def test_error_if_skills_not_found(self):
+        """Script should exit with error if repo root not found."""
+        result = build_portable_commands_sh(
+            skill_name="lit-synthesizer",
+            script_name="lit_synthesizer.py",
+            args={"--query": "test"},
+        )
+        assert "ERROR" in result
+        assert "exit 1" in result
+
+
+# ── write_portable_commands_sh tests ──────────────────────────────────────────
+
+class TestWritePortableCommandsSh:
+
+    def test_creates_commands_sh(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repro = Path(tmp) / "reproducibility"
+            write_portable_commands_sh(
+                repro_dir=repro,
+                skill_name="lit-synthesizer",
+                script_name="lit_synthesizer.py",
+                args={"--query": "CRISPR", "--output": "./report"},
+            )
+            assert (repro / "commands.sh").exists()
+
+    def test_creates_repro_dir_if_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repro = Path(tmp) / "new" / "reproducibility"
+            assert not repro.exists()
+            write_portable_commands_sh(
+                repro_dir=repro,
+                skill_name="lit-synthesizer",
+                script_name="lit_synthesizer.py",
+                args={"--query": "test"},
+            )
+            assert repro.exists()
+            assert (repro / "commands.sh").exists()
+
+    def test_content_is_portable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repro = Path(tmp) / "reproducibility"
+            write_portable_commands_sh(
+                repro_dir=repro,
+                skill_name="vcf-annotator",
+                script_name="vcf_annotator.py",
+                args={"--input": "variants.vcf", "--output": "./report"},
+            )
+            content = (repro / "commands.sh").read_text()
+            assert "REPO_ROOT" in content
+            assert "BASH_SOURCE" in content
+            assert "/home/" not in content
+
+    def test_overwrite_existing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repro = Path(tmp) / "reproducibility"
+            repro.mkdir()
+            (repro / "commands.sh").write_text("old content")
+            write_portable_commands_sh(
+                repro_dir=repro,
+                skill_name="lit-synthesizer",
+                script_name="lit_synthesizer.py",
+                args={"--query": "new"},
+            )
+            content = (repro / "commands.sh").read_text()
+            assert "old content" not in content
+            assert "new" in content
+
+
+# ── Integration: lit-synthesizer generates portable commands ──────────────────
+
+class TestLitSynthesizerPortableCommands:
+    """Test that lit_synthesizer.py generates portable commands.sh"""
+
+    def test_commands_sh_uses_repo_root(self):
+        sys.path.insert(0, str(Path(__file__).parent.parent.parent /
+                               "lit-synthesizer" / "skills" / "lit-synthesizer"))
+        try:
+            from lit_synthesizer import DEMO_PAPERS, build_citation_graph, generate_report
+            with tempfile.TemporaryDirectory() as tmp:
+                out = Path(tmp)
+                graph = build_citation_graph(DEMO_PAPERS)
+                generate_report("CRISPR", DEMO_PAPERS, graph, out)
+                content = (out / "reproducibility" / "commands.sh").read_text()
+                assert "REPO_ROOT" in content
+                assert "BASH_SOURCE" in content
+                assert str(out) not in content  # no absolute output path
+        except ImportError:
+            pytest.skip("lit_synthesizer not available in this test run")
+
+
+# ── Integration: vcf-annotator generates portable commands ───────────────────
+
+class TestVCFAnnotatorPortableCommands:
+    """Test that vcf_annotator.py generates portable commands.sh"""
+
+    def test_commands_sh_uses_repo_root(self):
+        sys.path.insert(0, str(Path(__file__).parent.parent.parent /
+                               "vcf-annotator" / "skills" / "vcf-annotator"))
+        try:
+            from vcf_annotator import DEMO_ANNOTATIONS, generate_report
+            with tempfile.TemporaryDirectory() as tmp:
+                out = Path(tmp)
+                generate_report(DEMO_ANNOTATIONS, out, "demo.vcf")
+                content = (out / "reproducibility" / "commands.sh").read_text()
+                assert "REPO_ROOT" in content
+                assert "BASH_SOURCE" in content
+                assert str(out) not in content  # no absolute output path
+        except ImportError:
+            pytest.skip("vcf_annotator not available in this test run")

--- a/skills/lit-synthesizer/lit_synthesizer.py
+++ b/skills/lit-synthesizer/lit_synthesizer.py
@@ -334,15 +334,34 @@ def generate_report(query: str, papers: list[dict], graph: dict, output_dir: Pat
                 "url":     p["url"],
             })
 
+
     # ── reproducibility bundle ──
     commands = f"""#!/usr/bin/env bash
-# ClawBio Lit Synthesizer — reproducibility bundle
+# ClawBio Lit Synthesizer — portable reproducibility bundle
 # Generated: {now}
 # Query: {query}
+#
+# How to replay:
+#   bash reproducibility/commands.sh
+# from anywhere inside the repository clone.
 
-python skills/lit-synthesizer/lit_synthesizer.py \\
+set -euo pipefail
+
+# ── Locate repo root ──────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
+while [[ ! -d "$REPO_ROOT/skills" && "$REPO_ROOT" != "/" ]]; do
+  REPO_ROOT="$(dirname "$REPO_ROOT")"
+done
+if [[ ! -d "$REPO_ROOT/skills" ]]; then
+  echo "ERROR: Could not locate repo root (no skills/ directory found)" >&2
+  exit 1
+fi
+
+# ── Replay command ────────────────────────────────────────────────────────────
+python "$REPO_ROOT/skills/lit-synthesizer/lit_synthesizer.py" \\
     --query "{query}" \\
-    --output "{output_dir}"
+    --output "./report"
 """
     (output_dir / "reproducibility" / "commands.sh").write_text(commands)
 

--- a/skills/vcf-annotator/vcf_annotator.py
+++ b/skills/vcf-annotator/vcf_annotator.py
@@ -453,13 +453,31 @@ def generate_report(
 
     # ── reproducibility bundle ──
     commands = f"""#!/usr/bin/env bash
-# ClawBio VCF Annotator — reproducibility bundle
+# ClawBio VCF Annotator — portable reproducibility bundle
 # Generated: {now}
 # Input: {input_label}
+#
+# How to replay:
+#   bash reproducibility/commands.sh
+# from anywhere inside the repository clone.
 
-python skills/vcf-annotator/vcf_annotator.py \\
+set -euo pipefail
+
+# ── Locate repo root ──────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR"
+while [[ ! -d "$REPO_ROOT/skills" && "$REPO_ROOT" != "/" ]]; do
+  REPO_ROOT="$(dirname "$REPO_ROOT")"
+done
+if [[ ! -d "$REPO_ROOT/skills" ]]; then
+  echo "ERROR: Could not locate repo root (no skills/ directory found)" >&2
+  exit 1
+fi
+
+# ── Replay command ────────────────────────────────────────────────────────────
+python "$REPO_ROOT/skills/vcf-annotator/vcf_annotator.py" \\
     --input "{input_label}" \\
-    --output "{output_dir}"
+    --output "./vcf_report"
 """
     (output_dir / "reproducibility" / "commands.sh").write_text(commands)
 


### PR DESCRIPTION
Fixes #143 — commands.sh files in reproducibility bundles were 
embedding machine-specific absolute paths and cwd-dependent script 
names, breaking replay on other machines.

Changes:
- Add clawbio/common/portable_commands.py — centralized utility that
  generates self-anchoring commands.sh using BASH_SOURCE to locate
  the repo root at replay time
- Fix skills/lit-synthesizer — commands.sh now uses $REPO_ROOT 
  instead of verbatim output_dir
- Fix skills/vcf-annotator — same fix
- 19 tests covering portability guarantees

The generated commands.sh now:
- Does not embed machine-specific absolute paths
- Does not assume the original working directory
- Anchors itself to the repo root via BASH_SOURCE
- Exits with a clear error if repo root cannot be found

Closes #143