### PR TITLE
Fix bio-orchestrator routing for pure scRNA embedding queries

### DIFF
--- a/skills/bio-orchestrator/orchestrator.py
+++ b/skills/bio-orchestrator/orchestrator.py
@@ -331,13 +331,23 @@ def detect_skill_with_hint_from_query(query: str) -> tuple[str | None, str]:
             "with `--use-rep X_scvi` on `integrated.h5ad` to run clustering, annotation, "
             "and contrastive markers after scVI.",
         )
-    if wants_embedding and wants_downstream:
-        return (
-            "scrna-embedding",
-            "Detected a two-step advanced scRNA workflow. First run `scrna-embedding` to "
-            "produce `integrated.h5ad`, then run `scrna-orchestrator` with "
-            "`--use-rep X_scvi` for downstream clustering, annotation, and contrastive markers.",
-        )
+
+    if wants_embedding:
+        if wants_downstream:
+            return (
+                "scrna-embedding",
+                "Detected a two-step advanced scRNA workflow. First run `scrna-embedding` to "
+                "produce `integrated.h5ad`, then run `scrna-orchestrator` with "
+                "`--use-rep X_scvi` for downstream clustering, annotation, and contrastive markers.",
+            )
+        if not has_latent_artifact:
+            return (
+                "scrna-embedding",
+                "Detected an embedding-focused scRNA workflow. Use `scrna-embedding` to "
+                "produce `integrated.h5ad` with a scVI/scANVI latent space before "
+                "running downstream clustering or annotation.",
+            )
+
     # Prefer longest keyword match to avoid ambiguity (e.g. "variant annotation"
     # should match vcf-annotator, not equity-scorer via "variant" substring)
     best_skill = None

--- a/skills/bio-orchestrator/orchestrator.py
+++ b/skills/bio-orchestrator/orchestrator.py
@@ -324,6 +324,8 @@ def detect_skill_with_hint_from_query(query: str) -> tuple[str | None, str]:
     wants_downstream = any(term in query_lower for term in SCRNA_DOWNSTREAM_TERMS)
     has_latent_artifact = any(term in query_lower for term in SCRNA_LATENT_ARTIFACT_TERMS)
 
+    # Chain-aware scRNA routing favors explicit embedding requests unless the
+    # user is clearly asking for downstream analysis on an existing latent artifact.
     if has_latent_artifact and wants_downstream:
         return (
             "scrna-orchestrator",
@@ -331,22 +333,27 @@ def detect_skill_with_hint_from_query(query: str) -> tuple[str | None, str]:
             "with `--use-rep X_scvi` on `integrated.h5ad` to run clustering, annotation, "
             "and contrastive markers after scVI.",
         )
-
+    if wants_embedding and wants_downstream:
+        return (
+            "scrna-embedding",
+            "Detected a two-step advanced scRNA workflow. First run `scrna-embedding` to "
+            "produce `integrated.h5ad`, then run `scrna-orchestrator` with "
+            "`--use-rep X_scvi` for downstream clustering, annotation, and contrastive markers.",
+        )
+    if wants_embedding and has_latent_artifact:
+        return (
+            "scrna-embedding",
+            "Detected an embedding-focused scRNA workflow on an existing latent artifact. "
+            "Use `scrna-embedding` to refresh or rebuild the scVI/scANVI latent space "
+            "before downstream clustering or annotation.",
+        )
     if wants_embedding:
-        if wants_downstream:
-            return (
-                "scrna-embedding",
-                "Detected a two-step advanced scRNA workflow. First run `scrna-embedding` to "
-                "produce `integrated.h5ad`, then run `scrna-orchestrator` with "
-                "`--use-rep X_scvi` for downstream clustering, annotation, and contrastive markers.",
-            )
-        if not has_latent_artifact:
-            return (
-                "scrna-embedding",
-                "Detected an embedding-focused scRNA workflow. Use `scrna-embedding` to "
-                "produce `integrated.h5ad` with a scVI/scANVI latent space before "
-                "running downstream clustering or annotation.",
-            )
+        return (
+            "scrna-embedding",
+            "Detected an embedding-focused scRNA workflow. Use `scrna-embedding` to "
+            "produce `integrated.h5ad` with a scVI/scANVI latent space before "
+            "running downstream clustering or annotation.",
+        )
 
     # Prefer longest keyword match to avoid ambiguity (e.g. "variant annotation"
     # should match vcf-annotator, not equity-scorer via "variant" substring)

--- a/skills/bio-orchestrator/tests/test_orchestrator.py
+++ b/skills/bio-orchestrator/tests/test_orchestrator.py
@@ -153,6 +153,18 @@ class TestDetectSkillWithHint:
         assert skill == "scrna-embedding"
         assert "two-step" in hint.lower() or "scrna-embedding" in hint.lower()
 
+    def test_embedding_without_downstream_prefers_scrna_embedding(self):
+        skill, hint = detect_skill_with_hint_from_query(
+            "Build a latent embedding for this single-cell dataset"
+        )
+        assert skill == "scrna-embedding"
+        assert "embedding-focused" in hint.lower() or "latent space" in hint.lower()
+
+    def test_generic_single_cell_query_still_prefers_orchestrator(self):
+        skill, hint = detect_skill_with_hint_from_query("single-cell dataset")
+        assert skill == "scrna-orchestrator"
+        assert hint == ""
+
 
 # ---------------------------------------------------------------------------
 # detect_multiple_skills

--- a/skills/bio-orchestrator/tests/test_orchestrator.py
+++ b/skills/bio-orchestrator/tests/test_orchestrator.py
@@ -158,10 +158,24 @@ class TestDetectSkillWithHint:
             "Build a latent embedding for this single-cell dataset"
         )
         assert skill == "scrna-embedding"
-        assert "embedding-focused" in hint.lower() or "latent space" in hint.lower()
+        assert "embedding-focused" in hint.lower()
+        assert "latent space" in hint.lower()
+
+    def test_embedding_with_latent_artifact_prefers_scrna_embedding(self):
+        skill, hint = detect_skill_with_hint_from_query(
+            "Run embedding on my integrated.h5ad file"
+        )
+        assert skill == "scrna-embedding"
+        assert "embedding-focused" in hint.lower()
+        assert "latent artifact" in hint.lower()
 
     def test_generic_single_cell_query_still_prefers_orchestrator(self):
         skill, hint = detect_skill_with_hint_from_query("single-cell dataset")
+        assert skill == "scrna-orchestrator"
+        assert hint == ""
+
+    def test_downstream_only_query_still_prefers_orchestrator(self):
+        skill, hint = detect_skill_with_hint_from_query("Cluster my single-cell data")
         assert skill == "scrna-orchestrator"
         assert hint == ""
 


### PR DESCRIPTION
## Problem

Issue #165 found that `detect_skill_with_hint_from_query()` in the bio-orchestrator was misrouting pure embedding queries (e.g. `"Build a latent embedding for this single-cell dataset"`) to `scrna-orchestrator` instead of `scrna-embedding`.

The root cause is a collision between the longest-match keyword strategy in `KEYWORD_MAP` and the early-return guard structure: the keyword `single-cell` (11 chars) outcompeted both `embedding` (9 chars) and `latent` (6 chars) by raw character length, even though those shorter keywords express the user's actual intent.

The early-return guards encode the correct semantics, but the pure-embedding case (`wants_embedding = True`, `wants_downstream = False`) was missing a guard of its own. Only the mixed case (`wants_embedding AND wants_downstream`) had an early return, so pure embedding queries fell through to the keyword scan and were misrouted.

## Fix

- Add a third early-return guard: if `wants_embedding` is true and neither `wants_downstream` nor `has_latent_artifact` are set, route directly to `scrna-embedding` before the `KEYWORD_MAP` scan runs.
- Preserve existing downstream latent-analysis routing to `scrna-orchestrator` (latent artifact + downstream signals).
- Add regression tests for pure embedding queries and generic `single-cell` queries to prevent future longest-match surprises.

## Testing

- `pytest skills/bio-orchestrator/tests/test_orchestrator.py -q -k 'DetectSkillWithHint or detect_skill_from_query'`
- `pytest skills/scrna-embedding/tests/test_scrna_embedding.py -q`

Closes #165