### PR TITLE
fix(data-extractor): defer anthropic import to LLM backend functions

### DIFF
--- a/skills/data-extractor/core/digitizer.py
+++ b/skills/data-extractor/core/digitizer.py
@@ -9,7 +9,6 @@ import json
 import logging
 import re
 
-import anthropic
 from PIL import Image
 
 from .models import Confidence, DataSeries, ExtractedData, Figure, PlotType
@@ -951,6 +950,7 @@ async def pre_analyze(figure: Figure) -> dict:
     Uses Claude tool calling for structured, reliable output.
     Returns a dict with plot_type, axis info, scale, legend entries, etc.
     """
+    import anthropic
     client = anthropic.AsyncAnthropic()
 
     response = await client.messages.create(
@@ -1005,6 +1005,7 @@ async def detect_panels(figure: Figure) -> list[dict]:
     far more reliable than asking Claude to estimate pixel coordinates or
     percentages, which it consistently gets wrong.
     """
+    import anthropic
     client = anthropic.AsyncAnthropic()
 
     # Use actual image dimensions (may differ from figure.width/height if resized)
@@ -1133,6 +1134,7 @@ async def _digitize_single(
     a context image so the model can reference the full figure's axes, legends,
     and labels even when the cropped panel is missing them.
     """
+    import anthropic
     client = anthropic.AsyncAnthropic()
 
     # Phase 2: Pre-analyze if not already done

--- a/skills/data-extractor/requirements.txt
+++ b/skills/data-extractor/requirements.txt
@@ -1,0 +1,1 @@
+anthropic>=0.40


### PR DESCRIPTION
## Problem

Issue #164 identified that `core/digitizer.py` imported `anthropic` unconditionally at module level. Since `anthropic` was absent from all requirements files, this blocked four pure-utility tests — CSV/JSON export, input validation, and prompt constants — from running at all in the base environment: Python raises `ModuleNotFoundError` when the module is first loaded, before any test function executes. These functions have no dependency on the Anthropic SDK; they were blocked purely because a module-level import conflated the LLM backend with the rest of the file.

`anthropic` is used exclusively in three async functions that instantiate `AsyncAnthropic`: `pre_analyze`, `detect_panels`, and `_digitize_single`. All other functions have no dependency on it.

## Changes

### `skills/data-extractor/core/digitizer.py`
- Remove `import anthropic` from module level
- Add `import anthropic` as the first line of `pre_analyze`, `detect_panels`, and `_digitize_single`
- Follows the deferred-import pattern established in `affinity-proteomics` (`statsmodels` inside `differential_abundance()`) and `proteomics-clock` (`seaborn` inside plotting functions)

### `skills/data-extractor/requirements.txt` *(new file)*
- Declares `anthropic>=0.40` as the skill's LLM backend dependency

## Testing

```bash
python -c "import sys; sys.path.insert(0, 'skills/data-extractor'); import core.digitizer; print('OK')"
# OK — module loads without anthropic

pytest skills/data-extractor/tests/test_extractor.py  # 9/9 pass
```

Closes #164