### PR TITLE
fix: declare missing skill-level dependencies for affinity-proteomics and variant-annotation

### DIFF
--- a/skills/affinity-proteomics/requirements.txt
+++ b/skills/affinity-proteomics/requirements.txt
@@ -1,0 +1,2 @@
+statsmodels>=0.14
+scipy>=1.10

--- a/skills/variant-annotation/requirements.txt
+++ b/skills/variant-annotation/requirements.txt
@@ -1,0 +1,2 @@
+# Linux / macOS only — pysam requires htslib C extensions
+pysam>=0.22


### PR DESCRIPTION
## Problem

Issues #159 and #160 found that two skills had undeclared runtime dependencies. Both skills already handle the missing-dependency case correctly in code — imports are deferred and guarded — but without declared requirements, users following standard install instructions (`pip install -r requirements.txt`) would hit `ModuleNotFoundError` at runtime with no guidance on how to fix it.

## Changes

### `skills/affinity-proteomics/requirements.txt` *(new file)*

`differential_abundance()` imports `statsmodels` and `scipy` at call time (correctly deferred inside the function body). Neither was declared in any requirements file. Both are declared together since they are used together in the same function.

```
statsmodels>=0.14
scipy>=1.10
```

### `skills/variant-annotation/requirements.txt` *(new file)*

`pysam` is already guarded with `try/except ImportError` at module level, and `parse_vcf()` raises a clear `ImportError` with installation instructions when `pysam` is absent. The dependency was simply undeclared. The platform constraint (Linux/macOS only — htslib C extensions) is documented inline.

```
# Linux / macOS only — pysam requires htslib C extensions
pysam>=0.22
```

## Testing

No code was changed. Existing test behaviour is unchanged:

```bash
# affinity-proteomics: 13 passed, 6 skipped (somadata optional) with statsmodels installed
pytest skills/affinity-proteomics/tests/

# variant-annotation: passes with pysam installed; gracefully raises ImportError without it
pytest skills/variant-annotation/tests/
```

Closes #159
Closes #160