### PR TITLE
fix(conda): replace defaults channel with conda-forge + nodefaults

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,14 @@ skills/your-skill-name/
     └── expected_output.md
 ```
 
+If your skill requires a conda environment, add an `environment.yml` using `conda-forge` as the sole channel and `nodefaults` to prevent fallback to the Anaconda `defaults` channel (which has commercial licensing restrictions):
+
+```yaml
+channels:
+  - conda-forge
+  - nodefaults
+```
+
 ### 4. Test locally
 
 ```bash

--- a/skills/omics-target-evidence-mapper/environment.yml
+++ b/skills/omics-target-evidence-mapper/environment.yml
@@ -1,6 +1,7 @@
 name: omics-target-evidence-mapper
 channels:
   - conda-forge
+  - nodefaults
 dependencies:
   - python=3.11
   - pip

--- a/skills/target-validation-scorer/environment.yml
+++ b/skills/target-validation-scorer/environment.yml
@@ -1,6 +1,7 @@
 name: target-validation-scorer
 channels:
-  - defaults
+  - conda-forge
+  - nodefaults
 dependencies:
   - python=3.11
   - pandas>=2.0


### PR DESCRIPTION
## Problem

Issue #181 flagged that two skill `environment.yml` files used the Anaconda `defaults` channel, which carries commercial licensing restrictions (prohibited for organisations with more than 200 users). Additionally, without an explicit `nodefaults` entry, conda can silently fall back to `defaults` via the user's `.condarc` even when `defaults` is not listed — making the restriction non-portable across different user configurations.

## Changes

### `skills/target-validation-scorer/environment.yml`
- Replace `defaults` with `conda-forge`
- Add `nodefaults` to prevent implicit fallback

### `skills/omics-target-evidence-mapper/environment.yml`
- Already used `conda-forge`; add `nodefaults` for consistency and portability

### `CONTRIBUTING.md`
- Add a note under "Add supporting code" documenting the `conda-forge` + `nodefaults` convention for contributors creating new `environment.yml` files

## Verification

```bash
# No 'defaults' channel remains in any environment.yml
grep -rn "^\s*- defaults" --include="environment.yml" .
# → no output

# Both files parse as valid YAML with correct channel list
python3 -c "
import yaml
for f in ['skills/target-validation-scorer/environment.yml',
          'skills/omics-target-evidence-mapper/environment.yml']:
    doc = yaml.safe_load(open(f))
    assert doc['channels'] == ['conda-forge', 'nodefaults']
    print('OK:', f)
"
```

Closes #181