### PR TITLE
fix: resolve --search CLI collision introduced by PR #76

### DIFF
--- a/clawbio.py
+++ b/clawbio.py
@@ -1173,7 +1173,7 @@ def main():
         default=None,
         help="Local CellTypist model name or path for scrna skill",
     )
-    run_parser.add_argument("--search", default=None, help="Live Bioconductor package search query for bioc skill")
+    run_parser.add_argument("--search", default=None, help="Search query (bioc / galaxy skills)")
     run_parser.add_argument("--recommend", default=None, help="Recommendation query for bioc skill")
     run_parser.add_argument("--workflow", default=None, help="Workflow query for bioc skill")
     run_parser.add_argument("--package-details", default=None, help="Bioconductor package name for bioc skill")
@@ -1187,7 +1187,7 @@ def main():
     run_parser.add_argument("--modality", default=None, help="Modality hint for bioc skill")
     run_parser.add_argument("--max-results", type=int, default=None, help="Maximum bioc search/recommendation results")
     # flow-bio skill flags
-    run_parser.add_argument("--search", default=None, help="Search query (galaxy/flow skills)")
+    run_parser.add_argument("--flow-search", dest="flow_search", default=None, help="Search query (flow skill)")
     run_parser.add_argument("--pipelines", action="store_true", help="List pipelines (flow skill)")
     run_parser.add_argument("--samples", action="store_true", help="List samples (flow skill)")
     run_parser.add_argument("--projects", action="store_true", help="List projects (flow skill)")
@@ -1409,8 +1409,8 @@ def main():
         if getattr(args, "max_results", None) is not None:
             extra.extend(["--max-results", str(args.max_results)])
         # flow-bio skill flags
-        if getattr(args, "search", None):
-            extra.extend(["--search", args.search])
+        if getattr(args, "flow_search", None):
+            extra.extend(["--search", args.flow_search])
         if getattr(args, "pipelines", False):
             extra.append("--pipelines")
         if getattr(args, "samples", False):


### PR DESCRIPTION
## Summary

`python clawbio.py` has been completely broken on `main` since PR #76 (flow-bio skill) merged on 2026-04-22. The flow skill registered a second `--search` on the shared `run_parser`, colliding with the existing `--search` used by the bioc skill. argparse raises `ArgumentError` before any subcommand can dispatch, so **every** invocation — including `python clawbio.py --help` — fails.

```
argparse.ArgumentError: argument --search: conflicting option string: --search
```

This PR renames the flow-skill flag to `--flow-search` (the exact mitigation the April 2026 PR-audit recommended in its review of PR #76). The subprocess contract is unchanged: `skills/flow-bio/flow_bio.py` still accepts `--search` internally; the wrapper just translates `--flow-search` → `--search` on dispatch.

### Changes
- `--search` at line 1176 remains the shared bioc/galaxy flag (both skills already have it in their `allowed_extra_flags`).
- Flow skill's flag at line 1190 renamed to `--flow-search` (`dest='flow_search'`).
- Forwarder at line 1412 reads `args.flow_search` and emits `--search` to the flow subprocess.
- `allowed_extra_flags` at line 595 left alone — it filters subprocess flags, not CLI flags.

### Scope
Intentionally minimal — only `--search` is actively colliding. The April audit also flagged `--name`, `--project`, `--organism`, `--data`, `--genome`, `--json` as future-collision risks on the shared `run_parser`. They don't collide today and are left for a follow-up PR so the discussion there isn't bundled into an urgent hotfix.

## Test plan

- [x] `python clawbio.py --help` — parses without `ArgumentError`.
- [x] `python clawbio.py run --help` — shows both `--search SEARCH` and `--flow-search FLOW_SEARCH`.
- [x] `python clawbio.py run pharmgx --input skills/pharmgx-reporter/demo_patient.txt --output /tmp/pharmgx_smoketest` — parser + dispatcher run cleanly (skill itself fails later only on env-missing `pandas`; unrelated).
- [ ] `python clawbio.py run flow --flow-search "RNA-seq"` in an env with flow creds — not tested here, but the forwarder change is a mechanical rename.
- [ ] `python clawbio.py run bioc --search "DESeq2"` — parser path unchanged.

## Context

- Introduced by: #76 (merged 2026-04-22 08:10 UTC, commit c3adec4)
- Audit finding: PR #76 review 2026-04-02 ("Generic argparse flag names added to the shared run_parser in clawbio.py … Consider prefixing (e.g. --flow-name, --flow-project)"). Listed under "Requested before merge". Not applied.