### PR TITLE
fix(wes-reports): defer reportlab imports to unblock module without PDF dependency

### DIFF
--- a/skills/wes-clinical-report-en/requirements.txt
+++ b/skills/wes-clinical-report-en/requirements.txt
@@ -1,0 +1,1 @@
+reportlab>=4.0

--- a/skills/wes-clinical-report-en/tests/test_wes_clinical_report_en.py
+++ b/skills/wes-clinical-report-en/tests/test_wes_clinical_report_en.py
@@ -114,6 +114,10 @@ def sample_md_path(tmp_path):
     return md_file
 
 
+def _require_reportlab():
+    pytest.importorskip("reportlab")
+
+
 # ── Markdown parser tests ───────────────────────────────────────────────
 
 class TestParseMarkdownReport:
@@ -250,6 +254,7 @@ class TestExtractMetrics:
 
 class TestBuildPdf:
     def test_generates_pdf_file(self, sample_md_path, tmp_path):
+        _require_reportlab()
         from wes_clinical_report_en import build_sample_pdf_en
         output = tmp_path / "Sample1_WES_Clinical_Report.pdf"
         result = build_sample_pdf_en(sample_md_path, output)
@@ -257,6 +262,7 @@ class TestBuildPdf:
         assert result.stat().st_size > 1000  # non-trivial PDF
 
     def test_pdf_is_valid(self, sample_md_path, tmp_path):
+        _require_reportlab()
         from wes_clinical_report_en import build_sample_pdf_en
         output = tmp_path / "Sample1_WES_Clinical_Report.pdf"
         build_sample_pdf_en(sample_md_path, output)
@@ -266,6 +272,7 @@ class TestBuildPdf:
         assert header == b"%PDF-"
 
     def test_pdf_contains_sample_id(self, sample_md_path, tmp_path):
+        _require_reportlab()
         from wes_clinical_report_en import build_sample_pdf_en
         output = tmp_path / "Sample1_WES_Clinical_Report.pdf"
         build_sample_pdf_en(sample_md_path, output)
@@ -277,6 +284,7 @@ class TestBuildPdf:
 
 class TestBuildInterpretation:
     def test_returns_flowables(self, sample_md_path):
+        _require_reportlab()
         from wes_clinical_report_en import (
             parse_markdown_report, build_interpretation_paragraph, build_styles
         )
@@ -286,6 +294,7 @@ class TestBuildInterpretation:
         assert len(elements) > 0
 
     def test_interpretation_in_english(self, sample_md_path):
+        _require_reportlab()
         from wes_clinical_report_en import (
             parse_markdown_report, build_interpretation_paragraph, build_styles
         )
@@ -306,12 +315,14 @@ class TestBuildInterpretation:
 
 class TestLimitationsSection:
     def test_returns_elements(self):
+        _require_reportlab()
         from wes_clinical_report_en import _build_limitations_section, build_styles
         styles = build_styles()
         elements = _build_limitations_section(styles)
         assert len(elements) > 5
 
     def test_limitations_in_english(self):
+        _require_reportlab()
         from wes_clinical_report_en import _build_limitations_section, build_styles
         from reportlab.platypus import Paragraph
         styles = build_styles()

--- a/skills/wes-clinical-report-en/wes_clinical_report_en.py
+++ b/skills/wes-clinical-report-en/wes_clinical_report_en.py
@@ -11,17 +11,40 @@ import re
 from pathlib import Path
 from datetime import datetime
 
-from reportlab.lib import colors
-from reportlab.lib.pagesizes import A4
-from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
-from reportlab.lib.units import mm
-from reportlab.lib.enums import TA_LEFT, TA_CENTER, TA_JUSTIFY
-from reportlab.platypus import (
-    Paragraph, Spacer, Table, TableStyle,
-    HRFlowable, NextPageTemplate, Image, Frame, PageTemplate,
-    BaseDocTemplate,
-)
-from reportlab.platypus.doctemplate import _doNothing
+try:
+    from reportlab.lib import colors
+    from reportlab.lib.pagesizes import A4
+    from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+    from reportlab.lib.units import mm
+    from reportlab.lib.enums import TA_LEFT, TA_CENTER, TA_JUSTIFY
+    from reportlab.platypus import (
+        Paragraph, Spacer, Table, TableStyle,
+        HRFlowable, NextPageTemplate, Image, Frame, PageTemplate,
+        BaseDocTemplate,
+    )
+    from reportlab.platypus.doctemplate import _doNothing
+    _REPORTLAB_AVAILABLE = True
+except ImportError:
+    colors = None
+    A4 = None
+    getSampleStyleSheet = None
+    ParagraphStyle = None
+    mm = None
+    TA_LEFT = None
+    TA_CENTER = None
+    TA_JUSTIFY = None
+    Paragraph = None
+    Spacer = None
+    Table = None
+    TableStyle = None
+    HRFlowable = None
+    NextPageTemplate = None
+    Image = None
+    Frame = None
+    PageTemplate = None
+    BaseDocTemplate = None
+    _doNothing = None
+    _REPORTLAB_AVAILABLE = False
 
 # ── Paths (defaults, overridable via CLI) ───────────────────────────────
 REPORT_DIR = Path("/Volumes/CPM-16Tb/NOVOGENE/ANALYSIS/REPORTS")
@@ -31,23 +54,38 @@ LOGO_RIGHT = str(REPORT_DIR / "logo_inbiomedic.jpg")
 ANCESTRY_DIR = Path("/Volumes/CPM-16Tb/NOVOGENE/ANALYSIS/ANCESTRY/OUTPUT")
 SAMPLES = [f"Sample{i}" for i in range(1, 8)]
 
-# ── Colour palette ──────────────────────────────────────────────────────
-NAVY       = colors.HexColor("#1B2A4A")
-DARK_BLUE  = colors.HexColor("#2C4A7C")
-MID_BLUE   = colors.HexColor("#4A90D9")
-LIGHT_BLUE = colors.HexColor("#D6E8F7")
-PALE_BLUE  = colors.HexColor("#EBF3FB")
-ACCENT_RED = colors.HexColor("#C0392B")
-ACCENT_AMBER = colors.HexColor("#E67E22")
-ACCENT_GREEN = colors.HexColor("#27AE60")
-WARM_GREY  = colors.HexColor("#7F8C8D")
-LIGHT_GREY = colors.HexColor("#F4F6F8")
-WHITE      = colors.white
-BLACK      = colors.black
-ROW_ALT    = colors.HexColor("#F8FAFC")
+if _REPORTLAB_AVAILABLE:
+    # ── Colour palette ──────────────────────────────────────────────────
+    NAVY       = colors.HexColor("#1B2A4A")
+    DARK_BLUE  = colors.HexColor("#2C4A7C")
+    MID_BLUE   = colors.HexColor("#4A90D9")
+    LIGHT_BLUE = colors.HexColor("#D6E8F7")
+    PALE_BLUE  = colors.HexColor("#EBF3FB")
+    ACCENT_RED = colors.HexColor("#C0392B")
+    ACCENT_AMBER = colors.HexColor("#E67E22")
+    ACCENT_GREEN = colors.HexColor("#27AE60")
+    WARM_GREY  = colors.HexColor("#7F8C8D")
+    LIGHT_GREY = colors.HexColor("#F4F6F8")
+    WHITE      = colors.white
+    BLACK      = colors.black
+    ROW_ALT    = colors.HexColor("#F8FAFC")
 
-PAGE_W, PAGE_H = A4
-MARGIN = 20 * mm
+    PAGE_W, PAGE_H = A4
+    MARGIN = 20 * mm
+else:
+    NAVY = DARK_BLUE = MID_BLUE = LIGHT_BLUE = PALE_BLUE = None
+    ACCENT_RED = ACCENT_AMBER = ACCENT_GREEN = None
+    WARM_GREY = LIGHT_GREY = WHITE = BLACK = ROW_ALT = None
+    PAGE_W = PAGE_H = MARGIN = None
+
+
+def _require_reportlab():
+    """Raise a helpful error when PDF generation is requested without reportlab."""
+    if not _REPORTLAB_AVAILABLE:
+        raise ImportError(
+            "reportlab is required for PDF generation. Install it with "
+            "`pip install -r skills/wes-clinical-report-en/requirements.txt`."
+        )
 
 
 # ── Markdown parser ─────────────────────────────────────────────────────
@@ -1032,6 +1070,7 @@ def render_section(section, styles):
 
 def build_sample_pdf_en(md_path, output_path):
     """Generate an English clinical PDF from a WES markdown report."""
+    _require_reportlab()
     report = parse_markdown_report(md_path)
     sample_id = report["sample_id"] or md_path.stem.split("_")[0]
     styles = build_styles()

--- a/skills/wes-clinical-report-es/requirements.txt
+++ b/skills/wes-clinical-report-es/requirements.txt
@@ -1,0 +1,1 @@
+reportlab>=4.0

--- a/skills/wes-clinical-report-es/tests/test_wes_clinical_report_es.py
+++ b/skills/wes-clinical-report-es/tests/test_wes_clinical_report_es.py
@@ -114,6 +114,10 @@ def sample_md_path(tmp_path):
     return md_file
 
 
+def _require_reportlab():
+    pytest.importorskip("reportlab")
+
+
 # ── Markdown parser tests ───────────────────────────────────────────────
 
 class TestParseMarkdownReport:
@@ -271,6 +275,7 @@ class TestExtractMetrics:
 
 class TestBuildPdf:
     def test_generates_pdf_file(self, sample_md_path, tmp_path):
+        _require_reportlab()
         from wes_clinical_report_es import build_sample_pdf_es
         output = tmp_path / "Sample1_Informe_Clinico_WES.pdf"
         result = build_sample_pdf_es(sample_md_path, output)
@@ -278,6 +283,7 @@ class TestBuildPdf:
         assert result.stat().st_size > 1000
 
     def test_pdf_is_valid(self, sample_md_path, tmp_path):
+        _require_reportlab()
         from wes_clinical_report_es import build_sample_pdf_es
         output = tmp_path / "Sample1_Informe_Clinico_WES.pdf"
         build_sample_pdf_es(sample_md_path, output)
@@ -286,6 +292,7 @@ class TestBuildPdf:
         assert header == b"%PDF-"
 
     def test_pdf_contains_sample_id(self, sample_md_path, tmp_path):
+        _require_reportlab()
         from wes_clinical_report_es import build_sample_pdf_es
         output = tmp_path / "Sample1_Informe_Clinico_WES.pdf"
         build_sample_pdf_es(sample_md_path, output)
@@ -297,6 +304,7 @@ class TestBuildPdf:
 
 class TestBuildInterpretation:
     def test_returns_flowables(self, sample_md_path):
+        _require_reportlab()
         from wes_clinical_report_es import (
             parse_markdown_report, build_interpretation_paragraph, build_styles
         )
@@ -306,6 +314,7 @@ class TestBuildInterpretation:
         assert len(elements) > 0
 
     def test_interpretation_in_spanish(self, sample_md_path):
+        _require_reportlab()
         from wes_clinical_report_es import (
             parse_markdown_report, build_interpretation_paragraph, build_styles
         )
@@ -323,12 +332,14 @@ class TestBuildInterpretation:
 
 class TestLimitationsSection:
     def test_returns_elements(self):
+        _require_reportlab()
         from wes_clinical_report_es import _build_limitations_section, build_styles
         styles = build_styles()
         elements = _build_limitations_section(styles)
         assert len(elements) > 5
 
     def test_limitations_in_spanish(self):
+        _require_reportlab()
         from wes_clinical_report_es import _build_limitations_section, build_styles
         from reportlab.platypus import Paragraph
         styles = build_styles()
@@ -342,6 +353,7 @@ class TestLimitationsSection:
 
 class TestRenderSection:
     def test_renders_section(self, sample_md_path):
+        _require_reportlab()
         from wes_clinical_report_es import (
             parse_markdown_report, render_section_es, build_styles
         )

--- a/skills/wes-clinical-report-es/wes_clinical_report_es.py
+++ b/skills/wes-clinical-report-es/wes_clinical_report_es.py
@@ -12,20 +12,54 @@ import textwrap
 from pathlib import Path
 from datetime import datetime
 
-from reportlab.lib import colors
-from reportlab.lib.pagesizes import A4
-from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
-from reportlab.lib.units import mm, cm
-from reportlab.lib.enums import TA_LEFT, TA_CENTER, TA_RIGHT, TA_JUSTIFY
-from reportlab.platypus import (
-    SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle,
-    PageBreak, HRFlowable, KeepTogether, Frame, PageTemplate,
-    BaseDocTemplate, NextPageTemplate, Image
-)
-from reportlab.platypus.doctemplate import _doNothing
-from reportlab.graphics.shapes import Drawing, Rect, String, Line
-from reportlab.pdfbase import pdfmetrics
-from reportlab.pdfbase.ttfonts import TTFont
+try:
+    from reportlab.lib import colors
+    from reportlab.lib.pagesizes import A4
+    from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+    from reportlab.lib.units import mm, cm
+    from reportlab.lib.enums import TA_LEFT, TA_CENTER, TA_RIGHT, TA_JUSTIFY
+    from reportlab.platypus import (
+        SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle,
+        PageBreak, HRFlowable, KeepTogether, Frame, PageTemplate,
+        BaseDocTemplate, NextPageTemplate, Image
+    )
+    from reportlab.platypus.doctemplate import _doNothing
+    from reportlab.graphics.shapes import Drawing, Rect, String, Line
+    from reportlab.pdfbase import pdfmetrics
+    from reportlab.pdfbase.ttfonts import TTFont
+    _REPORTLAB_AVAILABLE = True
+except ImportError:
+    colors = None
+    A4 = None
+    getSampleStyleSheet = None
+    ParagraphStyle = None
+    mm = None
+    cm = None
+    TA_LEFT = None
+    TA_CENTER = None
+    TA_RIGHT = None
+    TA_JUSTIFY = None
+    SimpleDocTemplate = None
+    Paragraph = None
+    Spacer = None
+    Table = None
+    TableStyle = None
+    PageBreak = None
+    HRFlowable = None
+    KeepTogether = None
+    Frame = None
+    PageTemplate = None
+    BaseDocTemplate = None
+    NextPageTemplate = None
+    Image = None
+    _doNothing = None
+    Drawing = None
+    Rect = None
+    String = None
+    Line = None
+    pdfmetrics = None
+    TTFont = None
+    _REPORTLAB_AVAILABLE = False
 
 # ── Paths ────────────────────────────────────────────────────────────────
 REPORT_DIR = Path("/Volumes/CPM-16Tb/NOVOGENE/ANALYSIS/REPORTS")
@@ -241,23 +275,38 @@ INTERP_ES = {
 }
 
 
-# ── Colour palette ───────────────────────────────────────────────────────
-NAVY       = colors.HexColor("#1B2A4A")
-DARK_BLUE  = colors.HexColor("#2C4A7C")
-MID_BLUE   = colors.HexColor("#4A90D9")
-LIGHT_BLUE = colors.HexColor("#D6E8F7")
-PALE_BLUE  = colors.HexColor("#EBF3FB")
-ACCENT_RED = colors.HexColor("#C0392B")
-ACCENT_AMBER = colors.HexColor("#E67E22")
-ACCENT_GREEN = colors.HexColor("#27AE60")
-WARM_GREY  = colors.HexColor("#7F8C8D")
-LIGHT_GREY = colors.HexColor("#F4F6F8")
-WHITE      = colors.white
-BLACK      = colors.black
-ROW_ALT    = colors.HexColor("#F8FAFC")
+if _REPORTLAB_AVAILABLE:
+    # ── Colour palette ───────────────────────────────────────────────────
+    NAVY       = colors.HexColor("#1B2A4A")
+    DARK_BLUE  = colors.HexColor("#2C4A7C")
+    MID_BLUE   = colors.HexColor("#4A90D9")
+    LIGHT_BLUE = colors.HexColor("#D6E8F7")
+    PALE_BLUE  = colors.HexColor("#EBF3FB")
+    ACCENT_RED = colors.HexColor("#C0392B")
+    ACCENT_AMBER = colors.HexColor("#E67E22")
+    ACCENT_GREEN = colors.HexColor("#27AE60")
+    WARM_GREY  = colors.HexColor("#7F8C8D")
+    LIGHT_GREY = colors.HexColor("#F4F6F8")
+    WHITE      = colors.white
+    BLACK      = colors.black
+    ROW_ALT    = colors.HexColor("#F8FAFC")
 
-PAGE_W, PAGE_H = A4
-MARGIN = 20 * mm
+    PAGE_W, PAGE_H = A4
+    MARGIN = 20 * mm
+else:
+    NAVY = DARK_BLUE = MID_BLUE = LIGHT_BLUE = PALE_BLUE = None
+    ACCENT_RED = ACCENT_AMBER = ACCENT_GREEN = None
+    WARM_GREY = LIGHT_GREY = WHITE = BLACK = ROW_ALT = None
+    PAGE_W = PAGE_H = MARGIN = None
+
+
+def _require_reportlab():
+    """Raise a helpful error when PDF generation is requested without reportlab."""
+    if not _REPORTLAB_AVAILABLE:
+        raise ImportError(
+            "reportlab is required for PDF generation. Install it with "
+            "`pip install -r skills/wes-clinical-report-es/requirements.txt`."
+        )
 
 
 # ── Translation helper ───────────────────────────────────────────────────
@@ -1355,6 +1404,7 @@ def _build_limitations_section(styles):
 # ── Build PDF (Spanish) ──────────────────────────────────────────────────
 
 def build_sample_pdf_es(md_path, output_path):
+    _require_reportlab()
     report = parse_markdown_report(md_path)
     sample_id = report["sample_id"] or md_path.stem.split("_")[0]
     styles = build_styles()


### PR DESCRIPTION
## Problem

Issues #162 and #163 identified that both `wes-clinical-report-en` and `wes-clinical-report-es` imported the full `reportlab` PDF rendering stack at module level, without `reportlab` declared in any requirements file. Because Python evaluates top-level imports at load time, this blocked the entire module — including pure-Python functions like markdown parsing, variant extraction, and CLI argument handling — from loading at all in the base environment. Tests were excluded from `pytest.ini` precisely because they errored on import before a single test function ran.

## Fix applied to both skills

- Wrapped all `reportlab` imports and their dependent colour/layout constants (`NAVY`, `PAGE_W`, `MARGIN`, etc.) in a `try/except ImportError` block, setting `_REPORTLAB_AVAILABLE = True/False`
- Added `_require_reportlab()` helper that raises a clear `ImportError` with install instructions
- Called `_require_reportlab()` as the first line of `build_sample_pdf_en` / `build_sample_pdf_es` — the sole PDF entry points — so the error surfaces immediately before any `reportlab` symbol is accessed
- Added `pytest.importorskip("reportlab")` to the 7 (EN) + 8 (ES) test methods that exercise the PDF rendering layer, so they skip cleanly instead of erroring when `reportlab` is absent
- Added `requirements.txt` declaring `reportlab>=4.0` to both skills

**Result:** `import wes_clinical_report_en` and `import wes_clinical_report_es` now succeed without `reportlab`. Pure parsing functions are fully accessible. PDF tests skip gracefully. 35 tests pass, 15 skip, 0 errors.

## Test plan

- [ ] `python -c "import wes_clinical_report_en; import wes_clinical_report_es"` exits 0 without `reportlab` installed
- [ ] `python -m pytest skills/wes-clinical-report-en/tests/ skills/wes-clinical-report-es/tests/ -q` → 35 passed, 15 skipped, 0 errors

Closes #162
Closes #163