### PR TITLE
docs: align Python minimum version to 3.10 across all docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ Follow the [ClawHub submission guide](https://clawhub.ai/docs/submit).
 
 ## Code Standards
 
-- Python 3.11+
+- Python 3.10+
 - Type hints encouraged
 - pathlib for all file paths
 - No hardcoded absolute paths

--- a/docs/tutorial-build-a-skill.ipynb
+++ b/docs/tutorial-build-a-skill.ipynb
@@ -129,7 +129,7 @@
     "    description: Analysis report\n",
     "\n",
     "dependencies:\n",
-    "  python: \">=3.11\"\n",
+    "  python: \">=3.10\"\n",
     "  packages:\n",
     "    - pandas>=2.0\n",
     "\n",

--- a/templates/SKILL-TEMPLATE.md
+++ b/templates/SKILL-TEMPLATE.md
@@ -34,7 +34,7 @@ metadata:
         - json
       description: Machine-readable results
   dependencies:
-    python: ">=3.11"
+    python: ">=3.10"
     packages:
       - pandas>=2.0
   demo_data:


### PR DESCRIPTION
## Problem

Issue #154 found that four project files stated two different Python minimums (3.10 and 3.11) with no clear canonical source. The conflict had real impact: contributors setting up Python 3.10 environments could hit unexpected CI failures if 3.11 were the true requirement, while new skill authors using the template would silently inherit the wrong version in their skills.

The authoritative source is the CI matrix (`ci.yml`): `["3.10", "3.11", "3.12"]` — 3.10 is the tested minimum.

## State before this fix

| File | Claimed minimum |
|------|----------------|
| `templates/SKILL-TEMPLATE.md` | `>=3.11` |
| `CONTRIBUTING.md` | `3.11+` |
| `README.md` | `3.10+` |
| `AGENTS.md` | `3.10+` |

## Files changed (3)

- `CONTRIBUTING.md` — `Python 3.11+` → `Python 3.10+`
- `templates/SKILL-TEMPLATE.md` — `">=3.11"` → `">=3.10"`
- `docs/tutorial-build-a-skill.ipynb` — embedded template example `">=3.11"` → `">=3.10"`

`README.md` and `AGENTS.md` already said 3.10+ and are unchanged.

## Test plan

- [ ] `grep -rn '">=3\.11"' CONTRIBUTING.md templates/ docs/tutorial-build-a-skill.ipynb` returns no matches
- [ ] All project-level docs consistently reference Python 3.10+

Closes #154