### PR TITLE
docs(README.md): mark labstep and struct-predictor as MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,9 @@ report/
 | [LLM Biobank Bench](skills/llm-biobank-bench/) | **MVP** | Benchmark LLMs on biobank knowledge retrieval and coverage scoring |
 | [VCF Annotator](skills/vcf-annotator/) | Planned | Legacy VCF annotation pipeline (see Variant Annotation for the active skill) |
 | [Lit Synthesizer](skills/lit-synthesizer/) | Planned | PubMed/bioRxiv search with LLM summarisation and citation graphs |
-| [Struct Predictor](skills/struct-predictor/) | Planned | AlphaFold/Boltz local structure prediction |
+| [Struct Predictor](skills/struct-predictor/) | **MVP** | AlphaFold/Boltz local structure prediction |
 | [Repro Enforcer](skills/repro-enforcer/) | Planned | Export any analysis as Conda env + Singularity + Nextflow pipeline |
-| [Labstep](skills/labstep/) | Planned | Labstep electronic lab notebook API integration |
+| [Labstep](skills/labstep/) | **MVP** | Labstep electronic lab notebook API integration |
 | [Seq Wrangler](skills/seq-wrangler/) | Planned | Sequence QC, alignment, and BAM processing (FastQC, BWA, SAMtools) |
 
 ### Contributing a Skill


### PR DESCRIPTION
## Problem

Issue #149 identified that `labstep` and `struct-predictor` were listed as "Planned" in the README skills table despite having been shipped in v0.5.0 (PR #84 and PR #102 respectively). Since the README is the first document read by contributors and LLM agents, stale skill statuses erode trust in the documentation and can cause contributors to duplicate work or misjudge the project's current scope.

## Changes

- `README.md` — `Planned` → `**MVP**` for the `labstep` and `struct-predictor` rows

Both skills verified present:
- `skills/labstep/labstep.py` ✓
- `skills/struct-predictor/struct_predictor.py` ✓

CHANGELOG v0.5.0 records their delivery: labstep (PR #84), struct-predictor (PR #102).

Closes #149