### PR TITLE
feat(repro): add conda-lock lockfile to reproducibility bundle

### DIFF
--- a/clawbio/common/__init__.py
+++ b/clawbio/common/__init__.py
@@ -24,6 +24,7 @@ from clawbio.common.reproducibility import (
     write_checksums,
     write_environment_yml,
     write_commands_sh,
+    write_conda_lock,
 )
 
 __all__ = [
@@ -46,4 +47,5 @@ __all__ = [
     "write_checksums",
     "write_environment_yml",
     "write_commands_sh",
+    "write_conda_lock",
 ]

--- a/clawbio/common/reproducibility.py
+++ b/clawbio/common/reproducibility.py
@@ -6,6 +6,7 @@ Provides write_checksums and write_environment_yml, both writing into
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 from clawbio.common.checksums import sha256_file
@@ -116,3 +117,36 @@ def write_commands_sh(output_dir: Path | str, command: str) -> Path:
     path.write_text(content)
     path.chmod(path.stat().st_mode | 0o111)
     return path
+
+
+def write_conda_lock(output_dir: Path | str) -> Path:
+    """Write reproducibility/conda-lock.yml from an existing environment.yml.
+
+    Runs ``conda-lock lock`` in the reproducibility directory. conda-lock
+    defaults to multi-platform resolution and writes conda-lock.yml.
+
+    Args:
+        output_dir: Skill output directory containing reproducibility/environment.yml.
+
+    Raises:
+        FileNotFoundError: If reproducibility/environment.yml is missing.
+        subprocess.CalledProcessError: If conda-lock exits with a non-zero status.
+
+    Returns the path of the written conda-lock.yml file.
+    """
+    output_dir = Path(output_dir)
+    repro_dir = output_dir / "reproducibility"
+    if not (repro_dir / "environment.yml").exists():
+        raise FileNotFoundError(repro_dir / "environment.yml")
+
+    try:
+        subprocess.run(
+            ["conda-lock", "lock", "-f", "environment.yml"],
+            cwd=repro_dir,
+            check=True,
+        )
+    except FileNotFoundError:
+        raise FileNotFoundError(
+            "conda-lock is not installed. Install it with: pip install conda-lock"
+        )
+    return repro_dir / "conda-lock.yml"

--- a/clawbio/common/tests/test_reproducibility.py
+++ b/clawbio/common/tests/test_reproducibility.py
@@ -1,14 +1,18 @@
-"""Tests for clawbio.common.reproducibility — write_checksums and write_environment_yml."""
+"""Tests for clawbio.common.reproducibility."""
 
-import sys
+import subprocess
 from pathlib import Path
+from unittest.mock import patch, MagicMock
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
-
 from clawbio.common.checksums import sha256_file
-from clawbio.common.reproducibility import write_checksums, write_environment_yml, write_commands_sh
+from clawbio.common.reproducibility import (
+    write_checksums,
+    write_environment_yml,
+    write_commands_sh,
+    write_conda_lock,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -214,3 +218,68 @@ class TestWriteCommandsSh:
         write_commands_sh(tmp_path, "python skill.py")
         mode = (tmp_path / "reproducibility" / "commands.sh").stat().st_mode
         assert mode & stat.S_IXUSR, "owner execute bit not set"
+
+
+# ---------------------------------------------------------------------------
+# TestWriteCondaLock
+# ---------------------------------------------------------------------------
+
+
+class TestWriteCondaLock:
+    def test_calls_conda_lock_with_correct_args(self, tmp_path):
+        """write_conda_lock calls conda-lock with correct arguments."""
+        repro_dir = tmp_path / "reproducibility"
+        repro_dir.mkdir()
+        (repro_dir / "environment.yml").write_text("name: test\n")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            write_conda_lock(tmp_path)
+
+        mock_run.assert_called_once_with(
+            ["conda-lock", "lock", "-f", "environment.yml"],
+            cwd=repro_dir,
+            check=True,
+        )
+
+    def test_returns_lockfile_path(self, tmp_path):
+        """write_conda_lock returns the path to conda-lock.yml."""
+        repro_dir = tmp_path / "reproducibility"
+        repro_dir.mkdir()
+        (repro_dir / "environment.yml").write_text("name: test\n")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            result = write_conda_lock(tmp_path)
+
+        assert result == repro_dir / "conda-lock.yml"
+
+    def test_raises_if_environment_yml_missing(self, tmp_path):
+        """write_conda_lock raises FileNotFoundError if environment.yml is missing."""
+        repro_dir = tmp_path / "reproducibility"
+        repro_dir.mkdir()
+
+        with pytest.raises(FileNotFoundError):
+            write_conda_lock(tmp_path)
+
+    def test_raises_clear_error_if_conda_lock_not_installed(self, tmp_path):
+        """write_conda_lock raises FileNotFoundError with install instructions if conda-lock binary is missing."""
+        repro_dir = tmp_path / "reproducibility"
+        repro_dir.mkdir()
+        (repro_dir / "environment.yml").write_text("name: test\n")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError("conda-lock")
+            with pytest.raises(FileNotFoundError, match="pip install conda-lock"):
+                write_conda_lock(tmp_path)
+
+    def test_propagates_called_process_error(self, tmp_path):
+        """write_conda_lock propagates CalledProcessError from subprocess.run."""
+        repro_dir = tmp_path / "reproducibility"
+        repro_dir.mkdir()
+        (repro_dir / "environment.yml").write_text("name: test\n")
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(1, "conda-lock")
+            with pytest.raises(subprocess.CalledProcessError):
+                write_conda_lock(tmp_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+conda-lock>=2.0
 biopython>=1.82
 pandas>=2.0
 numpy>=1.24


### PR DESCRIPTION
## Summary

- Adds `write_conda_lock()` to `clawbio/common/reproducibility.py` so skills can write a pinned `conda-lock.yml` into their output reproducibility bundle alongside the existing `environment.yml`, `checksums.sha256`, and `commands.sh`
- Adds `conda-lock>=2.0` to `requirements.txt` — reproducibility is first-class, not opt-in
- Surfaces a clear install error if `conda-lock` binary is missing

## Skill affected

`clawbio/common` — reproducibility bundle helpers used by all skills

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology)
- [x] Tests included and passing (`pytest -v`)
- [x] Demo data included for reviewers to test
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

```
clawbio/common/tests/test_reproducibility.py::TestWriteCondaLock::test_calls_conda_lock_with_correct_args PASSED
clawbio/common/tests/test_reproducibility.py::TestWriteCondaLock::test_returns_lockfile_path PASSED
clawbio/common/tests/test_reproducibility.py::TestWriteCondaLock::test_raises_if_environment_yml_missing PASSED
clawbio/common/tests/test_reproducibility.py::TestWriteCondaLock::test_raises_clear_error_if_conda_lock_not_installed PASSED
clawbio/common/tests/test_reproducibility.py::TestWriteCondaLock::test_propagates_called_process_error PASSED
30 passed in 0.05s
```

Closes #168