### PR TITLE
docs: make slash commands discoverable in agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,12 +147,24 @@ These are non-negotiable constraints:
 4. **Security filtering**: `clawbio.py` enforces per-skill `allowed_extra_flags` whitelists (INT-001). Do not bypass this.
 5. **Warn before overwriting**: Check for existing output before writing to a directory.
 
+## Slash Commands
+
+The `commands/` directory contains reusable slash-command workflows for common agent tasks. Check these before reinventing analysis, scaffolding, listing, or demo flows.
+
+| Command | Purpose |
+|---------|---------|
+| `/analyse` | Analyse a file or input with the appropriate ClawBio skill |
+| `/new-skill` | Scaffold a new skill from the official template |
+| `/list-skills` | List available skills from `skills/catalog.json` |
+| `/run-demo` | Run a skill demo with built-in sample data |
+
 ## Key Files Reference
 
 | File | Purpose |
 |------|---------|
 | `clawbio.py` | CLI runner, SKILLS dict, security filtering, profile management |
 | `skills/catalog.json` | Machine-readable skill index (auto-generated) |
+| `commands/` | Slash commands for analysis, skill scaffolding, skill listing, and demos |
 | `CLAUDE.md` | Claude-specific routing table and demo commands |
 | `CONTRIBUTING.md` | Human contributor guide and wanted skills list |
 | `requirements.txt` | Core Python dependencies |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,23 @@
 
 You are **ClawBio**, a bioinformatics AI agent. You answer biological and genomic questions by routing to specialised skills — never by guessing. Every answer must trace back to a SKILL.md methodology or a script output.
 
+## Key Files
+
+| File | Purpose |
+|---|---|
+| `CLAUDE.md` | Routing rules, CLI reference, demo data, and safety instructions for Claude Code |
+| `commands/` | Slash commands for analysis, skill scaffolding, skill listing, and demos |
+| `skills/catalog.json` | Machine-readable index of available skills and metadata |
+
+## Slash Commands
+
+Before improvising a common workflow, check `commands/` for reusable slash commands:
+
+- `/analyse` — Analyse a file or input with the appropriate ClawBio skill
+- `/new-skill` — Scaffold a new skill from the official template
+- `/list-skills` — List available skills from `skills/catalog.json`
+- `/run-demo` — Run a skill demo with built-in sample data
+
 ## Skill Routing Table
 
 When the user asks a question, match it to a skill and act:

--- a/README.md
+++ b/README.md
@@ -425,6 +425,17 @@ Inside [Claude Code](https://claude.ai/claude-code):
 
 All skills are then available as agent-routable commands. Alternatively, clone the repo and open it as your working directory in Claude Code; the `CLAUDE.md` at the repo root teaches Claude how to route requests to skills automatically.
 
+### Slash Commands
+
+The repository also ships reusable slash commands in [`commands/`](commands/) for Claude Code and compatible agents:
+
+| Command | Purpose |
+|---------|---------|
+| `/analyse` | Analyse a file or input with the appropriate ClawBio skill |
+| `/new-skill` | Scaffold a new skill from the official template |
+| `/list-skills` | List available skills from `skills/catalog.json` |
+| `/run-demo` | Run a skill demo with built-in sample data |
+
 ### Try all skills
 
 ```bash

--- a/llms.txt
+++ b/llms.txt
@@ -9,10 +9,20 @@
 - [README](README.md): Project overview, quick start, architecture, skill table
 - [CLAUDE.md](CLAUDE.md): Agent routing table, CLI reference, demo data, safety rules
 - [AGENTS.md](AGENTS.md): Universal guide for AI coding agents (setup, style, workflow)
+- [commands/](commands/): Slash commands for analysis, skill scaffolding, skill listing, and demos
 - [CONTRIBUTING.md](CONTRIBUTING.md): How to contribute a skill, naming conventions, code standards
 - [SECURITY-AUDIT.md](SECURITY-AUDIT.md): Security audit results and remediation log
 - [SOUL.md](SOUL.md): ClawBio persona and voice
 - [Reference Genome](docs/reference-genome.md): Corpas 30x WGS reference genome (CC0, GRCh37, SNPs + indels + SVs + CNVs)
+
+## Slash Commands
+
+The `commands/` directory contains reusable slash-command workflows for common agent tasks:
+
+- `/analyse`: Analyse a file or input with the appropriate ClawBio skill
+- `/new-skill`: Scaffold a new skill from the official template
+- `/list-skills`: List available skills from `skills/catalog.json`
+- `/run-demo`: Run a skill demo with built-in sample data
 
 ## Skills (MVP)
 


### PR DESCRIPTION
## Summary
- add slash-command discoverability to `AGENTS.md`, including a dedicated section and `commands/` in the key files table
- add `commands/` and the four reusable slash commands to `CLAUDE.md` and `llms.txt` so agents can discover them early
- add a `Slash Commands` subsection to the `README.md` Quick Start so Claude Code and compatible agents can find these workflows during onboarding

## Why
Issue #153 identified that the repo already ships useful slash commands in `commands/`, but none of the main agent context files pointed to them. That made the commands effectively undiscoverable to agents reading standard repository guidance.

Fixes #153.

## Validation
- `git diff --check`
- `rg -n "commands/|/analyse|/new-skill|/list-skills|/run-demo" AGENTS.md CLAUDE.md llms.txt README.md`
- manual audit against `commands/analyse.md`, `commands/new-skill.md`, `commands/list-skills.md`, and `commands/run-demo.md`
