### PR TITLE
fix: expose the documented clawbio package API

### DIFF
--- a/clawbio.py
+++ b/clawbio.py
@@ -13,6 +13,7 @@ Usage:
     python clawbio.py run full-profile --profile profiles/PT001.json --output ./results
 
 Importable:
+    # With the repository checkout on sys.path:
     from clawbio import run_skill, list_skills, upload_profile
     result = run_skill("pharmgx", demo=True)
 """

--- a/clawbio/__init__.py
+++ b/clawbio/__init__.py
@@ -1,3 +1,7 @@
 """ClawBio — Bioinformatics AI Agent shared library."""
 
+from .runner import list_skills, run_skill, upload_profile
+
 __version__ = "0.2.0"
+
+__all__ = ["__version__", "run_skill", "list_skills", "upload_profile"]

--- a/clawbio/runner.py
+++ b/clawbio/runner.py
@@ -1,0 +1,37 @@
+"""Package-level bridge to the root clawbio.py runner module."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+_ROOT_RUNNER_MODULE_NAME = "clawbio._root_runner"
+_ROOT_RUNNER_PATH = Path(__file__).resolve().parent.parent / "clawbio.py"
+
+
+def _load_root_runner() -> ModuleType:
+    """Load the root runner module once and return the cached module."""
+    cached = sys.modules.get(_ROOT_RUNNER_MODULE_NAME)
+    if cached is not None:
+        return cached
+
+    spec = importlib.util.spec_from_file_location(_ROOT_RUNNER_MODULE_NAME, _ROOT_RUNNER_PATH)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load ClawBio runner from {_ROOT_RUNNER_PATH}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[_ROOT_RUNNER_MODULE_NAME] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_ROOT_RUNNER = _load_root_runner()
+
+run_skill = _ROOT_RUNNER.run_skill
+list_skills = _ROOT_RUNNER.list_skills
+upload_profile = _ROOT_RUNNER.upload_profile
+
+__all__ = ["run_skill", "list_skills", "upload_profile"]

--- a/clawbio/tests/test_package_api.py
+++ b/clawbio/tests/test_package_api.py
@@ -1,0 +1,64 @@
+"""Tests for the public importable clawbio package API."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+def test_package_exports_documented_symbols():
+    from clawbio import __all__, list_skills, run_skill, upload_profile
+
+    assert "run_skill" in __all__
+    assert "list_skills" in __all__
+    assert "upload_profile" in __all__
+    assert callable(run_skill)
+    assert callable(list_skills)
+    assert callable(upload_profile)
+
+
+def test_package_exports_same_runner_implementation():
+    from clawbio import list_skills, run_skill, upload_profile
+    from clawbio import runner as package_runner
+
+    root_runner = package_runner._load_root_runner()
+
+    assert list_skills is root_runner.list_skills
+    assert run_skill is root_runner.run_skill
+    assert upload_profile is root_runner.upload_profile
+
+
+def test_list_skills_returns_registry_with_known_skill():
+    from clawbio import list_skills
+
+    skills = list_skills()
+
+    assert isinstance(skills, dict)
+    assert "pharmgx" in skills
+
+
+def test_run_skill_unknown_skill_returns_structured_failure():
+    from clawbio import run_skill
+
+    result = run_skill("definitely-not-a-real-skill")
+
+    assert result["success"] is False
+    assert result["skill"] == "definitely-not-a-real-skill"
+    assert "Unknown skill" in result["stderr"]
+
+
+def test_upload_profile_works_with_fixture(tmp_path, monkeypatch):
+    from clawbio import upload_profile
+    from clawbio import runner as package_runner
+
+    root_runner = package_runner._load_root_runner()
+    monkeypatch.setattr(root_runner, "PROFILES_DIR", tmp_path)
+
+    result = upload_profile(str(FIXTURES / "mock_23andme.txt"), patient_id="pkg-api")
+
+    assert result["success"] is True
+    assert result["patient_id"] == "pkg-api"
+    assert Path(result["profile_path"]).exists()
+    assert Path(result["profile_path"]).parent == tmp_path


### PR DESCRIPTION
## Summary
- expose `run_skill`, `list_skills`, and `upload_profile` from the `clawbio` package
- add a package-local bridge module that loads the root `clawbio.py` runner once without duplicating runner logic
- register package tests in `pytest.ini` and add regression coverage for the documented import API

## Problem
The repository documentation and the `clawbio.py` module docstring both advertise this import pattern:

```python
from clawbio import run_skill, list_skills, upload_profile
```

But in the current repo state, `clawbio/__init__.py` only exports `__version__`, so the documented import raises `ImportError`.

## Solution
This PR keeps `clawbio.py` as the source of truth and adds a thin package bridge in `clawbio/runner.py` that:
- loads the root runner under a stable internal module name
- reuses the same loaded module instance
- reexports `run_skill`, `list_skills`, and `upload_profile`

That makes the package API real without refactoring the CLI implementation or duplicating behavior.

## Verification
- `python -m pytest clawbio/tests/test_package_api.py -q`
- `python -m pytest clawbio/tests -q`
- `python -m pytest clawbio/tests/test_package_api.py clawbio/tests/test_profile.py skills/bigquery-public/tests/test_bigquery_public.py skills/illumina-bridge/tests/test_illumina_bridge.py -q`
- manual import smoke test: `from clawbio import run_skill, list_skills, upload_profile`
- manual API smoke test: `upload_profile(...)` with a fixture and `run_skill('pharmgx', demo=True, ...)` producing `report.md` and `result.json`

Fixes #156
