### PR TITLE
feat(site): public benchmark leaderboard at /benchmarks.html

### DIFF
--- a/benchmarks.html
+++ b/benchmarks.html
@@ -1,0 +1,285 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Benchmark Leaderboard · ClawBio</title>
+  <meta name="description" content="Public scientific-correctness leaderboard for ClawBio bioinformatics skills. Independent third-party benchmark, full audit trail, every failure documented.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="ClawBio">
+  <meta property="og:title" content="ClawBio Benchmark Leaderboard">
+  <meta property="og:description" content="Public scientific-correctness leaderboard. Independent third-party benchmark, full audit trail, every failure documented.">
+  <meta property="og:image" content="https://raw.githubusercontent.com/ClawBio/ClawBio/main/img/clawbio-social-preview.png">
+  <meta property="og:url" content="https://clawbio.ai/benchmarks.html">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@manuelcorpas">
+  <meta name="twitter:title" content="ClawBio Benchmark Leaderboard">
+  <meta name="twitter:description" content="Public scientific-correctness leaderboard. Independent third-party benchmark, full audit trail.">
+  <meta name="twitter:image" content="https://raw.githubusercontent.com/ClawBio/ClawBio/main/img/clawbio-social-preview.png">
+  <link rel="icon" type="image/x-icon" href="/img/favicon.ico">
+  <link rel="icon" type="image/png" sizes="32x32" href="/img/favicon-32.png">
+  <link rel="apple-touch-icon" href="/img/clawbio-logo.jpeg">
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg: #0d1117;
+      --bg2: #161b22;
+      --bg3: #21262d;
+      --border: #30363d;
+      --text: #e6edf3;
+      --text-muted: #8b949e;
+      --accent: #3fb950;
+      --accent2: #58a6ff;
+      --warn: #d29922;
+      --danger: #f85149;
+    }
+    html { scroll-behavior: smooth; }
+    body { background: var(--bg); color: var(--text); font-family: 'Segoe UI', system-ui, -apple-system, sans-serif; line-height: 1.6; }
+    nav { position: sticky; top: 0; z-index: 100; background: rgba(13,17,23,0.92); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); padding: 0 2rem; display: flex; align-items: center; justify-content: space-between; height: 60px; }
+    .nav-logo { display: flex; align-items: center; gap: 0.6rem; font-weight: 700; font-size: 1.15rem; text-decoration: none; color: var(--text); }
+    .nav-links { display: flex; gap: 1.5rem; list-style: none; }
+    .nav-links a { color: var(--text-muted); text-decoration: none; font-size: 0.9rem; transition: color 0.2s; }
+    .nav-links a:hover { color: var(--text); }
+    .hero { text-align: center; padding: 5rem 2rem 3.5rem; background: radial-gradient(ellipse 80% 60% at 50% -10%, rgba(63,185,80,0.12) 0%, transparent 70%); }
+    .hero-badge { display: inline-block; background: rgba(63,185,80,0.15); border: 1px solid rgba(63,185,80,0.4); color: var(--accent); font-size: 0.8rem; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; padding: 0.3rem 0.9rem; border-radius: 999px; margin-bottom: 1.5rem; }
+    .hero h1 { font-size: clamp(2rem, 4.5vw, 3.2rem); font-weight: 800; line-height: 1.15; margin-bottom: 1.2rem; letter-spacing: -0.02em; }
+    .hero h1 em { font-style: normal; color: var(--accent); }
+    .hero p { font-size: clamp(1rem, 2vw, 1.2rem); color: var(--text-muted); max-width: 720px; margin: 0 auto 2rem; }
+    section { padding: 3.5rem 2rem; }
+    .section-inner { max-width: 1100px; margin: 0 auto; }
+    .section-label { font-size: 0.8rem; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent); margin-bottom: 0.75rem; }
+    .section-title { font-size: clamp(1.5rem, 2.6vw, 2rem); font-weight: 700; margin-bottom: 1rem; }
+    .section-sub { color: var(--text-muted); max-width: 720px; margin-bottom: 2.2rem; font-size: 1.02rem; }
+
+    .meta-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; margin-bottom: 2.5rem; }
+    .meta-card { background: var(--bg2); border: 1px solid var(--border); border-radius: 10px; padding: 1rem 1.2rem; }
+    .meta-label { font-size: 0.72rem; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-muted); margin-bottom: 0.35rem; }
+    .meta-value { font-size: 1.05rem; font-weight: 600; }
+    .meta-value a { color: var(--accent2); text-decoration: none; }
+    .meta-value a:hover { text-decoration: underline; }
+
+    .summary-bar { background: var(--bg2); border: 1px solid var(--border); border-radius: 12px; padding: 1.5rem 1.8rem; margin-bottom: 2rem; display: flex; gap: 2rem; align-items: center; flex-wrap: wrap; }
+    .summary-headline { font-size: 1.6rem; font-weight: 800; }
+    .summary-headline .pass { color: var(--accent); }
+    .summary-rest { color: var(--text-muted); font-size: 0.95rem; }
+
+    .table-wrap { overflow-x: auto; border: 1px solid var(--border); border-radius: 12px; }
+    table.leaderboard { width: 100%; border-collapse: collapse; background: var(--bg2); }
+    table.leaderboard thead th { text-align: left; padding: 0.9rem 1rem; font-size: 0.78rem; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-muted); background: var(--bg3); border-bottom: 1px solid var(--border); }
+    table.leaderboard tbody td { padding: 0.95rem 1rem; border-bottom: 1px solid var(--border); font-size: 0.94rem; vertical-align: middle; }
+    table.leaderboard tbody tr:last-child td { border-bottom: none; }
+    table.leaderboard tbody tr:hover { background: var(--bg3); }
+    table.leaderboard td a.skill-link { color: var(--text); font-weight: 600; text-decoration: none; }
+    table.leaderboard td a.skill-link:hover { color: var(--accent2); }
+    .rate-cell { font-variant-numeric: tabular-nums; font-weight: 700; font-size: 0.95rem; }
+    .rate-bar-wrap { display: block; height: 4px; background: var(--bg3); border-radius: 999px; margin-top: 0.4rem; overflow: hidden; }
+    .rate-bar { display: block; height: 100%; border-radius: 999px; }
+    .pill-status { display: inline-block; font-size: 0.7rem; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; padding: 0.18rem 0.55rem; border-radius: 999px; border: 1px solid; }
+    .status-clear { color: var(--accent); border-color: rgba(63,185,80,0.4); background: rgba(63,185,80,0.1); }
+    .status-watch { color: var(--accent2); border-color: rgba(88,166,255,0.4); background: rgba(88,166,255,0.1); }
+    .status-p1 { color: var(--warn); border-color: rgba(210,153,34,0.4); background: rgba(210,153,34,0.1); }
+    .status-p0 { color: var(--danger); border-color: rgba(248,81,73,0.4); background: rgba(248,81,73,0.1); }
+    .finding-tag { display: inline-block; background: var(--bg3); border: 1px solid var(--border); color: var(--text-muted); font-family: 'Fira Code', monospace; font-size: 0.78rem; padding: 0.1rem 0.45rem; border-radius: 4px; margin: 0.15rem 0.2rem 0.15rem 0; }
+
+    .principles-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
+    .principle-card { background: var(--bg2); border: 1px solid var(--border); border-radius: 10px; padding: 1.4rem 1.5rem; }
+    .principle-card h3 { font-size: 1rem; font-weight: 700; margin-bottom: 0.5rem; color: var(--accent); }
+    .principle-card p { color: var(--text-muted); font-size: 0.9rem; }
+
+    .cta-section { background: var(--bg2); border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); text-align: center; }
+    .btn { display: inline-flex; align-items: center; gap: 0.5rem; padding: 0.7rem 1.4rem; border-radius: 8px; font-weight: 600; font-size: 0.95rem; text-decoration: none; transition: all 0.2s; }
+    .btn-primary { background: var(--accent); color: #0d1117; }
+    .btn-primary:hover { background: #56d364; transform: translateY(-1px); }
+    .btn-secondary { background: var(--bg3); color: var(--text); border: 1px solid var(--border); }
+    .btn-secondary:hover { background: var(--bg2); border-color: var(--text-muted); transform: translateY(-1px); }
+    .cta-row { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; margin-top: 1.5rem; }
+
+    footer { padding: 2.5rem 2rem; text-align: center; color: var(--text-muted); font-size: 0.85rem; border-top: 1px solid var(--border); }
+    footer a { color: var(--accent2); text-decoration: none; }
+    footer a:hover { text-decoration: underline; }
+
+    @media (max-width: 700px) {
+      .nav-links { display: none; }
+      table.leaderboard thead th:nth-child(4), table.leaderboard tbody td:nth-child(4) { display: none; }
+    }
+  </style>
+</head>
+<body>
+  <nav>
+    <a class="nav-logo" href="/"><span>🦖</span> ClawBio</a>
+    <ul class="nav-links">
+      <li><a href="/#skills">Skills</a></li>
+      <li><a href="/benchmarks.html" style="color:var(--accent);font-weight:600;">Benchmarks</a></li>
+      <li><a href="/#marketplace" style="color:var(--accent);font-weight:600;">Marketplace</a></li>
+      <li><a href="https://docs.clawbio.ai" target="_blank" style="color:var(--accent2);font-weight:600;">Docs</a></li>
+      <li><a href="https://github.com/ClawBio/ClawBio" target="_blank">GitHub</a></li>
+    </ul>
+  </nav>
+
+  <section class="hero">
+    <div class="hero-badge">Public Scientific Correctness Leaderboard</div>
+    <h1>We benchmark our skills.<br><em>And we publish the failures.</em></h1>
+    <p>Every ClawBio skill is tested by an independent benchmark suite that checks scientific correctness, edge case behaviour, and reporting honesty. The full scorecard, the audit commit, and every open remediation task are public.</p>
+  </section>
+
+  <section>
+    <div class="section-inner">
+      <div class="meta-grid">
+        <div class="meta-card">
+          <div class="meta-label">Audit Date</div>
+          <div class="meta-value">2026-04-05</div>
+        </div>
+        <div class="meta-card">
+          <div class="meta-label">Auditor</div>
+          <div class="meta-value">Sergey Kornilov, Biostochastics, LLC</div>
+        </div>
+        <div class="meta-card">
+          <div class="meta-label">Benchmark Suite</div>
+          <div class="meta-value"><a href="https://github.com/biostochastics/clawbio_bench" target="_blank">clawbio_bench v0.1.0</a></div>
+        </div>
+        <div class="meta-card">
+          <div class="meta-label">Audit Commit</div>
+          <div class="meta-value"><a href="https://github.com/ClawBio/ClawBio/commit/1481fb4" target="_blank"><code>1481fb4</code></a></div>
+        </div>
+      </div>
+
+      <div class="summary-bar">
+        <div>
+          <div class="summary-headline"><span class="pass">80</span> / 140 tests passing <span style="color:var(--text-muted);font-weight:600;">(57.1%)</span></div>
+          <div class="summary-rest">7 skills audited across 3 dimensions: safety, correctness, honesty. 13 remediation tasks open across 3 priority tiers.</div>
+        </div>
+      </div>
+
+      <div class="table-wrap">
+        <table class="leaderboard">
+          <thead>
+            <tr>
+              <th>Skill</th>
+              <th>Pass / Total</th>
+              <th>Rate</th>
+              <th>Worst Findings</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><a class="skill-link" href="https://github.com/ClawBio/ClawBio/tree/main/skills/claw-metagenomics" target="_blank">claw-metagenomics</a></td>
+              <td>6 / 7</td>
+              <td><div class="rate-cell" style="color:var(--accent);">85.7%</div><span class="rate-bar-wrap"><span class="rate-bar" style="width:85.7%;background:var(--accent);"></span></span></td>
+              <td><span class="finding-tag">exit_suppressed</span></td>
+              <td><span class="pill-status status-clear">Clear</span></td>
+            </tr>
+            <tr>
+              <td><a class="skill-link" href="https://github.com/ClawBio/ClawBio/tree/main/skills/nutrigx_advisor" target="_blank">nutrigx-advisor</a></td>
+              <td>8 / 10</td>
+              <td><div class="rate-cell" style="color:var(--accent);">80.0%</div><span class="rate-bar-wrap"><span class="rate-bar" style="width:80%;background:var(--accent);"></span></span></td>
+              <td><span class="finding-tag">snp_invalid</span><span class="finding-tag">score_incorrect</span></td>
+              <td><span class="pill-status status-clear">Clear</span></td>
+            </tr>
+            <tr>
+              <td><a class="skill-link" href="https://github.com/ClawBio/ClawBio/tree/main/skills/clinical-variant-reporter" target="_blank">clinical-variant</a></td>
+              <td>4 / 5</td>
+              <td><div class="rate-cell" style="color:var(--accent);">80.0%</div><span class="rate-bar-wrap"><span class="rate-bar" style="width:80%;background:var(--accent);"></span></span></td>
+              <td><span class="finding-tag">report_structure_incomplete</span></td>
+              <td><span class="pill-status status-clear">Clear</span></td>
+            </tr>
+            <tr>
+              <td><a class="skill-link" href="https://github.com/ClawBio/ClawBio/tree/main/skills/bio-orchestrator" target="_blank">bio-orchestrator</a></td>
+              <td>41 / 54</td>
+              <td><div class="rate-cell" style="color:var(--accent);">75.9%</div><span class="rate-bar-wrap"><span class="rate-bar" style="width:75.9%;background:var(--accent);"></span></span></td>
+              <td><span class="finding-tag">stub_silent</span><span class="finding-tag">routed_wrong</span></td>
+              <td><span class="pill-status status-watch">Watch</span></td>
+            </tr>
+            <tr>
+              <td><a class="skill-link" href="https://github.com/ClawBio/ClawBio/tree/main/skills/pharmgx-reporter" target="_blank">pharmgx-reporter</a></td>
+              <td>14 / 33</td>
+              <td><div class="rate-cell" style="color:var(--warn);">42.4%</div><span class="rate-bar-wrap"><span class="rate-bar" style="width:42.4%;background:var(--warn);"></span></span></td>
+              <td><span class="finding-tag">correct_indeterminate</span><span class="finding-tag">disclosure_failure</span></td>
+              <td><span class="pill-status status-p1">P1</span></td>
+            </tr>
+            <tr>
+              <td><a class="skill-link" href="https://github.com/ClawBio/ClawBio/tree/main/skills/fine-mapping" target="_blank">fine-mapping</a></td>
+              <td>4 / 16</td>
+              <td><div class="rate-cell" style="color:var(--danger);">25.0%</div><span class="rate-bar-wrap"><span class="rate-bar" style="width:25%;background:var(--danger);"></span></span></td>
+              <td><span class="finding-tag">pathology_flagged</span></td>
+              <td><span class="pill-status status-p0">P0</span></td>
+            </tr>
+            <tr>
+              <td><a class="skill-link" href="https://github.com/ClawBio/ClawBio/tree/main/skills/equity-scorer" target="_blank">equity-scorer</a></td>
+              <td>3 / 15</td>
+              <td><div class="rate-cell" style="color:var(--danger);">20.0%</div><span class="rate-bar-wrap"><span class="rate-bar" style="width:20%;background:var(--danger);"></span></span></td>
+              <td><span class="finding-tag">fst_mislabeled</span><span class="finding-tag">heim_unbounded</span><span class="finding-tag">edge_crash</span></td>
+              <td><span class="pill-status status-p0">P0</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <p style="margin-top:1.5rem;color:var(--text-muted);font-size:0.9rem;">Status legend: <span class="pill-status status-clear">Clear</span> at or above 75%, <span class="pill-status status-watch">Watch</span> active remediation, <span class="pill-status status-p1">P1</span> medium priority fix, <span class="pill-status status-p0">P0</span> critical fix before next release. Full task breakdown in <a href="https://github.com/ClawBio/ClawBio/blob/main/REMEDIATION-PLAN.md" style="color:var(--accent2);">REMEDIATION-PLAN.md</a>.</p>
+    </div>
+  </section>
+
+  <section style="background:var(--bg2);border-top:1px solid var(--border);border-bottom:1px solid var(--border);">
+    <div class="section-inner">
+      <div class="section-label">Why this exists</div>
+      <h2 class="section-title">Most bio-skill repositories never publish a number.</h2>
+      <p class="section-sub">"57 skills, 1,401 tests" is a claim any project can make. Scientific correctness, edge case stability, and reporting honesty are different measurements, and they are the ones that decide whether a skill should run on a clinician's data.</p>
+
+      <div class="principles-grid">
+        <div class="principle-card">
+          <h3>Independent</h3>
+          <p>Benchmark is in a separate repository, written and run by a third party. ClawBio cannot quietly tune the rubric.</p>
+        </div>
+        <div class="principle-card">
+          <h3>Three dimensions</h3>
+          <p>Safety: does the skill reject unsafe input. Correctness: does it produce the right number. Honesty: does the report match what the code actually computed.</p>
+        </div>
+        <div class="principle-card">
+          <h3>Public failure surface</h3>
+          <p>Every failing test maps to a tagged finding (<code>fst_mislabeled</code>, <code>heim_unbounded</code>, <code>pathology_flagged</code>). Every finding maps to a remediation task with an assignee.</p>
+        </div>
+        <div class="principle-card">
+          <h3>Block on regression</h3>
+          <p>The pr-audit skill runs the bench on touched skills before merge. New regressions block the PR. Resolved findings get highlighted as progress.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="cta-section">
+    <div class="section-inner">
+      <h2 class="section-title">Submit your bio skill. We will benchmark it.</h2>
+      <p class="section-sub" style="margin-left:auto;margin-right:auto;">Skill authors get an independent third-party correctness audit, a public scoreboard slot, and a remediation task list they can work against. No private benchmarks, no marketing-grade pass rates.</p>
+      <div class="cta-row">
+        <a class="btn btn-primary" href="https://github.com/ClawBio/ClawBio/blob/main/CONTRIBUTING.md" target="_blank">Submit a Skill</a>
+        <a class="btn btn-secondary" href="https://github.com/biostochastics/clawbio_bench" target="_blank">Run the Bench Yourself</a>
+        <a class="btn btn-secondary" href="https://github.com/ClawBio/ClawBio/blob/main/REMEDIATION-PLAN.md" target="_blank">Full Remediation Plan</a>
+      </div>
+    </div>
+  </section>
+
+  <footer>
+    <p>Last benchmark run: 2026-04-05 against commit <a href="https://github.com/ClawBio/ClawBio/commit/1481fb4" target="_blank"><code>1481fb4</code></a>. Next run rebases on the v0.6.0 release.</p>
+    <p style="margin-top:0.5rem;">ClawBio is open source under the <a href="https://github.com/ClawBio/ClawBio/blob/main/LICENSE" target="_blank">MIT License</a>.</p>
+  </footer>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Dataset",
+    "name": "ClawBio Benchmark Leaderboard",
+    "description": "Public scientific-correctness leaderboard for ClawBio bioinformatics skills, audited by an independent third-party benchmark suite.",
+    "url": "https://clawbio.ai/benchmarks.html",
+    "creator": {
+      "@type": "Organization",
+      "name": "ClawBio",
+      "url": "https://clawbio.ai"
+    },
+    "license": "https://opensource.org/licenses/MIT",
+    "isAccessibleForFree": true,
+    "dateModified": "2026-04-05",
+    "keywords": "bioinformatics, benchmark, scientific-correctness, AI-agents, genomics, equity-scorer, fine-mapping, pharmgx, nutrigx"
+  }
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -111,6 +111,7 @@
       <li><a href="#why">Why ClawBio</a></li>
       <li><a href="#showcase">Showcase</a></li>
       <li><a href="#community">Community</a></li>
+      <li><a href="/benchmarks.html" style="color:var(--accent);font-weight:600;">Benchmarks</a></li>
       <li><a href="#marketplace" style="color:var(--accent);font-weight:600;">Marketplace</a></li>
       <li><a href="https://docs.clawbio.ai" target="_blank" style="color:var(--accent2);font-weight:600;">Docs</a></li>
       <li><a href="https://docs.clawbio.ai/research/" target="_blank">Research</a></li>


### PR DESCRIPTION
## Summary

- Adds `benchmarks.html` to clawbio.ai with the full clawbio_bench scorecard (80/140 tests passing, audit commit `1481fb4`, auditor Sergey Kornilov / Biostochastics LLC).
- Wires a `Benchmarks` link into the main nav on `index.html`.
- Page is self-contained, reuses the existing dark-mode design tokens from `index.html`, no new framework, no new dependencies.
- All numbers are sourced verbatim from `REMEDIATION-PLAN.md` so the public-facing claim and the in-repo backlog cannot drift.

## Why ship this

The repository already has the discipline (third-party bench, open remediation plan, every failure tagged) but it lives in a single Markdown file most visitors will never open. Putting the scorecard on the front door turns "trust me" into a citable trust signal. Skill authors who consider contributing can see what the audit looks like before they invest time. Visitors who land from social or search read "we benchmark and we publish" rather than "57 skills, 1,401 tests" which any repo can claim.

The page deliberately declares its staleness (last-run date, audit commit) rather than hiding it. The next bench run rebases on v0.6.0 and overwrites the values.

## What is in the PR

- `benchmarks.html` (new, ~280 lines): hero, audit metadata cards, summary bar, per-skill scorecard table with rate bars and status pills (Clear / Watch / P1 / P0), three-dimension explainer, CTA row. Includes a schema.org `Dataset` JSON-LD block so search picks up the resource.
- `index.html` (one line): adds the `Benchmarks` link in the nav between Skills and Marketplace.

## Test plan

- [ ] Render `clawbio.ai/benchmarks.html` and confirm dark theme matches `index.html`
- [ ] Confirm rate bars render at correct widths (20%, 25%, 42.4%, 75.9%, 80%, 80%, 85.7%)
- [ ] Click each skill name and confirm it lands on the right `skills/<name>` directory
- [ ] Click `REMEDIATION-PLAN.md` link and confirm the file is reachable
- [ ] Mobile viewport: nav collapses, table hides the Worst Findings column at small widths
- [ ] No em-dashes or en-dashes in the new HTML (verified locally: 0 matches)

## Follow-ups (not in this PR)

- CI job that re-runs `clawbio_bench` on each release tag and rewrites the table from a generated JSON
- Add the Benchmarks link to `marketplace.html` and the workshop slide decks
- Per-skill detail pages with the full failing-test breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)