### PR TITLE
refresh(site): feature benchmark leaderboard and update homepage metrics

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,17 +118,16 @@
       <li><a href="https://github.com/ClawBio/ClawBio" target="_blank">GitHub</a></li>
     </ul>
   </nav>
-  <a href="https://github.com/ClawBio/ClawBio/releases/tag/v0.5.0" target="_blank" style="display:block;background:linear-gradient(90deg,#238636,#1f6feb);color:#fff;text-align:center;padding:0.7rem 1rem;font-size:0.95rem;font-weight:600;text-decoration:none;">v0.5.0 Released: Validation &amp; Benchmark Infrastructure | AD ground truth, mock APIs, swappable fine-mapping, 1,401 tests | DOI: 10.5281/zenodo.19420648 &rarr;</a>
+  <a href="/benchmarks.html" style="display:block;background:linear-gradient(90deg,#238636,#1f6feb);color:#fff;text-align:center;padding:0.7rem 1rem;font-size:0.95rem;font-weight:600;text-decoration:none;">📊 NEW: Public Benchmark Leaderboard | 80/140 tests passing across 7 skills | Independent third-party audit | Every failure documented &rarr;</a>
   <section class="hero">
-    <div class="hero-badge">v0.5.0 · 773 stars · 154 forks · 57 skills · 1,401 tests · Claude Code plugin</div>
+    <div class="hero-badge">📊 Publicly benchmarked · 774 stars · 59 skills · 21 contributors · 1,401 tests</div>
     <h1>The first <em>bioinformatics-native</em><br>AI agent skill library</h1>
     <p>ClawBio is where biological AI gets its skills: a curated, reproducible, open repository any agent can call.</p>
     <div class="hero-ctas">
       <a class="btn btn-primary" href="https://github.com/ClawBio/ClawBio" target="_blank">⭐ View on GitHub</a>
-      <a class="btn btn-secondary" href="https://discord.gg/DHpmptyv" target="_blank">🎮 Join Discord</a>
-      <a class="btn btn-secondary" href="https://t.me/ClawBioContributors" target="_blank">💬 Join Telegram</a>
+      <a class="btn btn-primary" href="/benchmarks.html" style="background:var(--accent2);color:#0d1117;">📊 Leaderboard · 80/140</a>
       <a class="btn btn-secondary" href="https://github.com/ClawBio/ClawBio/blob/main/CONTRIBUTING.md" target="_blank">🧬 Submit a Skill</a>
-      <a class="btn btn-secondary" href="https://t.me/RoboTerri_bot" target="_blank">🤖 Try RoboTerri on Telegram</a>
+      <a class="btn btn-secondary" href="https://t.me/RoboTerri_bot" target="_blank">🤖 Try RoboTerri</a>
     </div>
     <div class="hero-pills">
       <span class="pill">bioinformatics</span><span class="pill">genomics</span><span class="pill">reproducibility</span><span class="pill">population-genetics</span><span class="pill">equity</span><span class="pill">ai-agents</span><span class="pill">local-first</span><span class="pill">openclaw</span>
@@ -193,8 +192,8 @@
         <div class="feature-card"><div class="feature-icon">🧩</div><div class="feature-title">Modular</div><div class="feature-desc">Each skill is a self-contained directory (SKILL.md + Python scripts) that plugs into the orchestrator — or runs standalone.</div></div>
         <div class="feature-card"><div class="feature-icon">⚖️</div><div class="feature-title">MIT Licensed</div><div class="feature-desc">Open-source, free, community-driven. Clone it, run it, build a skill, submit a PR.</div></div>
         <div class="feature-card"><div class="feature-icon">🌍</div><div class="feature-title">Equity-aware</div><div class="feature-desc">Built-in support for underrepresented populations. HEIM diversity metrics baked into the roadmap.</div></div>
-        <div class="feature-card"><div class="feature-icon">🎯</div><div class="feature-title">Benchmark Validated</div><div class="feature-desc">AD ground truth (34 genes, 3 evidence tiers), mock API server for offline CI, swappable fine-mapping (ABF vs SuSiE), benchmark scorer with precision/recall/F1. 74 benchmark tests. <a href="https://doi.org/10.5281/zenodo.19420648" style="color:var(--accent2);">DOI: 10.5281/zenodo.19420648</a></div></div>
-        <div class="feature-card"><div class="feature-icon">🦞</div><div class="feature-title">Built on OpenClaw</div><div class="feature-desc">Powered by OpenClaw (180k+ GitHub stars) — the agent platform that routes natural language to the right specialist skill.</div></div>
+        <div class="feature-card"><div class="feature-icon">🎯</div><div class="feature-title"><a href="/benchmarks.html" style="color:inherit;text-decoration:none;border-bottom:1px dotted var(--accent2);">Benchmark Validated</a></div><div class="feature-desc">Public scientific-correctness leaderboard: 80/140 tests passing, 7 skills audited, every failure tagged. AD ground truth (34 genes, 3 evidence tiers), mock API server for offline CI, swappable fine-mapping (ABF vs SuSiE), benchmark scorer with precision/recall/F1. <a href="/benchmarks.html" style="color:var(--accent2);">View leaderboard</a> · <a href="https://doi.org/10.5281/zenodo.19420648" style="color:var(--accent2);">DOI</a></div></div>
+        <div class="feature-card"><div class="feature-icon">🦞</div><div class="feature-title">Built on OpenClaw</div><div class="feature-desc">Powered by OpenClaw, the open agent platform that routes natural language to the right specialist skill. ClawBio is the bioinformatics catalogue any OpenClaw-compatible agent can call.</div></div>
         <div class="feature-card"><div class="feature-icon">🔌</div><div class="feature-title">Claude Code Plugin</div><div class="feature-desc">Install with two commands: <code style="background:var(--bg3);padding:0.1rem 0.4rem;border-radius:4px;font-size:0.85rem;">/plugin marketplace add ClawBio/ClawBio</code> then <code style="background:var(--bg3);padding:0.1rem 0.4rem;border-radius:4px;font-size:0.85rem;">/plugin install clawbio</code>. All skills instantly available.</div></div>
       </div>
     </div>
@@ -202,7 +201,7 @@
   <section id="skills" style="background:var(--bg2);border-top:1px solid var(--border);border-bottom:1px solid var(--border);">
     <div class="section-inner">
       <div class="section-label">Skills Library</div>
-      <div class="section-title">57 skills · 20 production-ready · 1,401 tests</div>
+      <div class="section-title">59 skills · 1,401 tests · 7 publicly benchmarked</div>
       <p class="section-sub">Each skill includes demo data so you can try it immediately without your own files.</p>
       <div class="skills-grid">
         <div class="skill-card"><div><div class="skill-name">💊 PharmGx Reporter</div><div class="skill-desc">Pharmacogenomic report from 23andMe/AncestryDNA: 12 genes, 31 SNPs, 51 drugs, CPIC guidelines.</div></div><span class="skill-badge badge-mvp">MVP</span></div>
@@ -218,7 +217,7 @@
         <div class="skill-card"><div><div class="skill-name">🏦 UKB Navigator</div><div class="skill-desc">Semantic search across UK Biobank's 12,000+ data fields and publications: find the right variables for your analysis.</div></div><span class="skill-badge badge-mvp">MVP</span></div>
         <div class="skill-card"><div><div class="skill-name">📷 Drug Photo</div><div class="skill-desc">Snap a photo of any medication packaging. ClawBio identifies the drug, queries your pharmacogenomic profile, and returns a personalised dosage card.</div></div><span class="skill-badge badge-mvp">MVP</span></div>
       </div>
-      <p style="color:var(--text-muted);margin-top:1.5rem;font-size:0.95rem;">+ 45 more skills on <a href="https://github.com/ClawBio/ClawBio" target="_blank" style="color:var(--accent);">GitHub</a></p>
+      <p style="color:var(--text-muted);margin-top:1.5rem;font-size:0.95rem;">+ 47 more skills on <a href="https://github.com/ClawBio/ClawBio" target="_blank" style="color:var(--accent);">GitHub</a> · <a href="/benchmarks.html" style="color:var(--accent2);">see which ones are publicly benchmarked &rarr;</a></p>
     </div>
   </section>
   <section id="showcase">
@@ -284,7 +283,7 @@
             </tr>
           </thead>
           <tbody>
-            <tr style="border-bottom:1px solid var(--border);background:rgba(63,185,80,0.05);"><td style="padding:0.6rem 1rem;"><a href="https://github.com/ClawBio/ClawBio" target="_blank" style="color:var(--accent);">ClawBio</a></td><td style="padding:0.6rem 1rem;text-align:center;color:var(--accent);">&#10003;</td><td style="padding:0.6rem 1rem;text-align:right;">773</td><td style="padding:0.6rem 1rem;text-align:right;">154</td><td style="padding:0.6rem 1rem;text-align:right;">57</td></tr>
+            <tr style="border-bottom:1px solid var(--border);background:rgba(63,185,80,0.05);"><td style="padding:0.6rem 1rem;"><a href="https://github.com/ClawBio/ClawBio" target="_blank" style="color:var(--accent);">ClawBio</a></td><td style="padding:0.6rem 1rem;text-align:center;color:var(--accent);">&#10003;</td><td style="padding:0.6rem 1rem;text-align:right;">774</td><td style="padding:0.6rem 1rem;text-align:right;">154</td><td style="padding:0.6rem 1rem;text-align:right;">59</td></tr>
             <tr style="border-bottom:1px solid var(--border);"><td style="padding:0.6rem 1rem;"><a href="https://github.com/FreedomIntelligence/OpenClaw-Medical-Skills" target="_blank" style="color:var(--accent2);">OpenClaw-Medical-Skills</a></td><td style="padding:0.6rem 1rem;text-align:center;color:var(--accent);">&#10003;</td><td style="padding:0.6rem 1rem;text-align:right;">1,037</td><td style="padding:0.6rem 1rem;text-align:right;">123</td><td style="padding:0.6rem 1rem;text-align:right;">869</td></tr>
             <tr style="border-bottom:1px solid var(--border);"><td style="padding:0.6rem 1rem;"><a href="https://github.com/GPTomics/bioSkills" target="_blank" style="color:var(--accent2);">bioSkills</a></td><td style="padding:0.6rem 1rem;text-align:center;color:var(--accent);">&#10003;</td><td style="padding:0.6rem 1rem;text-align:right;">331</td><td style="padding:0.6rem 1rem;text-align:right;">52</td><td style="padding:0.6rem 1rem;text-align:right;">425</td></tr>
             <tr style="border-bottom:1px solid var(--border);"><td style="padding:0.6rem 1rem;"><a href="https://github.com/wu-yc/LabClaw" target="_blank" style="color:var(--accent2);">LabClaw</a></td><td style="padding:0.6rem 1rem;text-align:center;color:var(--accent);">&#10003;</td><td style="padding:0.6rem 1rem;text-align:right;">317</td><td style="padding:0.6rem 1rem;text-align:right;">54</td><td style="padding:0.6rem 1rem;text-align:right;">211</td></tr>
@@ -302,17 +301,24 @@
       <div class="section-title">Latest from the community</div>
       <div style="display:grid;gap:0.75rem;max-width:700px;">
         <div style="background:var(--bg2);border:1px solid var(--border);border-radius:10px;padding:1rem 1.25rem;display:flex;align-items:center;gap:1rem;">
-          <span style="font-size:1.5rem;flex-shrink:0;">📦</span>
+          <span style="font-size:1.5rem;flex-shrink:0;">📊</span>
           <div>
-            <div style="font-weight:600;font-size:0.95rem;">Importable package API: ClawBio is now usable as a Python library via <code style="background:var(--bg3);padding:0.1rem 0.3rem;border-radius:3px;font-size:0.82rem;">from clawbio import run_skill, list_skills</code>, in addition to the CLI. Exposes a clean public API surface for programmatic use.</div>
-            <div style="color:var(--text-muted);font-size:0.85rem;margin-top:0.15rem;">PR #210 · 28 April 2026</div>
+            <div style="font-weight:600;font-size:0.95rem;">Public benchmark leaderboard: ClawBio now publishes scientific-correctness scores for every audited skill at <a href="/benchmarks.html" style="color:var(--accent2);">clawbio.ai/benchmarks</a>. Independent third-party audit by Biostochastics LLC, full remediation backlog tracked in the open.</div>
+            <div style="color:var(--text-muted);font-size:0.85rem;margin-top:0.15rem;">PR #213 · 3 May 2026</div>
           </div>
         </div>
         <div style="background:var(--bg2);border:1px solid var(--border);border-radius:10px;padding:1rem 1.25rem;display:flex;align-items:center;gap:1rem;">
-          <span style="font-size:1.5rem;flex-shrink:0;">🔧</span>
+          <span style="font-size:1.5rem;flex-shrink:0;">🔁</span>
           <div>
-            <div style="font-weight:600;font-size:0.95rem;">Core namespace fix: resolved a module-level name collision in the <code style="background:var(--bg3);padding:0.1rem 0.3rem;border-radius:3px;font-size:0.82rem;">clawbio</code> core package that prevented clean imports when multiple skills were loaded together.</div>
-            <div style="color:var(--text-muted);font-size:0.85rem;margin-top:0.15rem;">PR #209 · 28 April 2026</div>
+            <div style="font-weight:600;font-size:0.95rem;">Portable reproducibility bundles: every skill now writes a <code style="background:var(--bg3);padding:0.1rem 0.3rem;border-radius:3px;font-size:0.82rem;">commands.sh</code> with portable paths, anchor-relative replay, and non-deterministic output exclusions. Anyone can rerun an analysis without the agent and verify the result.</div>
+            <div style="color:var(--text-muted);font-size:0.85rem;margin-top:0.15rem;">PR #146 · 3 May 2026</div>
+          </div>
+        </div>
+        <div style="background:var(--bg2);border:1px solid var(--border);border-radius:10px;padding:1rem 1.25rem;display:flex;align-items:center;gap:1rem;">
+          <span style="font-size:1.5rem;flex-shrink:0;">📦</span>
+          <div>
+            <div style="font-weight:600;font-size:0.95rem;">Importable package API: ClawBio is now usable as a Python library via <code style="background:var(--bg3);padding:0.1rem 0.3rem;border-radius:3px;font-size:0.82rem;">from clawbio import run_skill, list_skills</code>, in addition to the CLI. Clean public API surface for programmatic use.</div>
+            <div style="color:var(--text-muted);font-size:0.85rem;margin-top:0.15rem;">PR #210 · 28 April 2026</div>
           </div>
         </div>
         <div style="background:var(--bg2);border:1px solid var(--border);border-radius:10px;padding:1rem 1.25rem;display:flex;align-items:center;gap:1rem;">


### PR DESCRIPTION
## Summary

Refreshes clawbio.ai to feature the benchmark leaderboard as the flagship trust signal, fixes stale numbers against live GitHub state, declutters the hero CTAs, and surfaces today's merges.

The homepage was selling "v0.5.0 released" (4 weeks old) and "57 skills, 1,401 tests" (a claim any repo can make). After this refresh the front door says "publicly benchmarked, 80/140 tests passing, every failure documented" which is what makes ClawBio defensible against generic bio-skills repos.

## Changes

- **Top banner**: replaced `v0.5.0 Released` strip with `NEW: Public Benchmark Leaderboard` pointer to `/benchmarks.html`. The v0.5.0 release page is still reachable from GitHub releases; the front-page banner slot belongs to the freshest news.
- **Hero badge**: now leads with the publicly-benchmarked claim. Numbers refreshed against live `gh api`: 773 to 774 stars, 57 to 59 skills, added 21 contributors. Dropped `Claude Code plugin` (mentioned elsewhere) and `154 forks` to keep it tight.
- **Hero CTAs**: dropped Discord and Telegram (they're still in Community section and footer). Added a Leaderboard primary button in accent-blue. Order is now GitHub, Leaderboard, Submit Skill, RoboTerri.
- **Benchmark Validated feature card**: title now links to `/benchmarks.html`, body leads with the public scorecard claim.
- **Built on OpenClaw feature card**: removed unverified `180k+ GitHub stars` claim (also removed from CLAWBIO-BRIEF.md in PR #203). Replaced with neutral platform description.
- **Skills section header**: `57 skills, 20 production-ready, 1,401 tests` becomes `59 skills, 1,401 tests, 7 publicly benchmarked` which is the stronger trust claim.
- **Skills section footer**: 45 to 47 more on GitHub, added link to leaderboard.
- **Marketplace table**: ClawBio row 773 to 774 stars, 57 to 59 skills.
- **Recent Updates**: prepended PR #213 (leaderboard) and PR #146 (portable repro bundles), kept #210 importable API and #110 ncbi-datasets, dropped older items to keep four cards.

## What did not change

- All anchor links (`#skills`, `#why`, `#showcase`, `#community`, `#marketplace`, `#updates`) preserved.
- All external links (Discord, Telegram, RoboTerri bot, GitHub, releases, CONTRIBUTING.md) preserved.
- Video showcase, skill marketplace cards, community-contribution grid, install code block, footer all unchanged.
- No new em-dashes or en-dashes introduced (verified by diff).

## Test plan

- [ ] Render `clawbio.ai` and confirm the new leaderboard banner is the top strip
- [ ] Click each CTA in the hero and confirm correct destination
- [ ] Confirm the Benchmark Validated feature card title is now a link
- [ ] Confirm marketplace table shows 774 stars and 59 skills for ClawBio
- [ ] Mobile viewport: hero CTAs wrap cleanly
- [ ] Confirm v0.5.0 release page is still reachable via GitHub releases (the URL did not change, only the homepage banner did)

## Follow-ups (not in this PR)

- Wire `clawbio_bench` into a release CI job that regenerates `benchmarks.html` from a JSON
- Add a "Latest benchmark run" badge to the README that reads from the same JSON
- Refresh the PharmGx demo video (currently v0.2.0 era) once a v0.6.0 demo exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)