### PR TITLE
fix(skills): add nutrigx_advisor compat symlink for bench harness

### DIFF
--- a/skills/nutrigx_advisor
+++ b/skills/nutrigx_advisor
@@ -1,0 +1,1 @@
+nutrigx-advisor


### PR DESCRIPTION
## Summary

Restores nutrigx-advisor end-to-end testability against `clawbio-bench` v0.1.5. After the AgentSkills naming rename in `e4ed975` (`skills/nutrigx_advisor` to `skills/nutrigx-advisor`), the bench harness was still pointing at the legacy underscore path and all 10 nutrigx test cases were failing with `exit_code: 2` ("script not found").

This adds a tracked directory symlink so the legacy path resolves until the bench is updated.

## Impact on the public benchmark scorecard

| Harness | Before | After |
|---------|--------|-------|
| nutrigx-advisor | 0 / 10 (0.0%) | 10 / 10 (100.0%) |
| **Aggregate** | **139 / 162 (85.8%)** | **149 / 162 (92.0%)** |

Compared to the original 2026-04-05 audit baseline of 80 / 140 (57.1%), the live scorecard is now +35 percentage points across 7 of 10 harnesses (the other 3 are new harnesses added in bench v0.1.5).

## Why a symlink and not a code fix

The bench harness invokes the skill script directly (`nutrigx_harness.py:511`) bypassing the ClawBio CLI:

```python
tool_path = repo_path / "skills" / "nutrigx_advisor" / "nutrigx_advisor.py"
```

So updating `clawbio.py`'s SKILLS dict does not help. The bench reads from a git checkout (untracked files are invisible), which is why the symlink has to be tracked.

## Why this is temporary

The proper fix is in `biostochastics/clawbio_bench`: either resolve skill folders dynamically (try hyphen, fall back to underscore) or read the script path from a per-skill manifest. I will open a follow-up issue / PR there. Once that lands, this symlink can be removed.

## Verified locally

- `python clawbio.py run nutrigx --demo` returns exit 0 and writes the full reproducibility bundle (`commands.sh`, `environment.yml`, `checksums.txt`, `provenance.json`, `nutrigx_report.md`, `result.json`).
- `clawbio-bench --smoke --harness nutrigx` reports 10 / 10 passing with `score_correct`, `snp_valid`, `threshold_consistent`, `repro_functional`.
- `clawbio-bench --smoke` aggregate run reports 149 / 162 (92.0%).

## Test plan

- [ ] CI green
- [ ] Manual: `git clone https://github.com/ClawBio/ClawBio.git && cd ClawBio && python clawbio.py run nutrigx --demo` returns exit 0
- [ ] Manual: `clawbio-bench --smoke --harness nutrigx --repo .` returns 10 / 10 passing

## Follow-up (separate PR)

- Open issue at biostochastics/clawbio_bench requesting dynamic skill folder resolution
- Audit `clawbio.py` for other broken `SKILLS_DIR / "name"` references (one other was found: `llm-biobank-bench` has no folder; out of scope here)
- Update `benchmarks.html` to reflect 149 / 162 (92.0%) once this PR is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)