### PR TITLE
fix(skills): add fine-mapping core compat symlink

### DIFF
--- a/skills/fine-mapping/core
+++ b/skills/fine-mapping/core
@@ -1,0 +1,1 @@
+fine_mapping_core


### PR DESCRIPTION
## Summary

Resolves the 21 harness errors observed in `clawbio_bench v0.1.5` against `clawbio-finemapping`. Same class of bug as #215: the bench imports the skill via a legacy package name (`core`) but the skill restructured to `fine_mapping_core`. Adds a tracked directory symlink so the legacy import path resolves.

## Root cause

`clawbio_bench/drivers/finemapping_driver.py:520-535` does:

```python
sys.path.insert(0, skill_dir)
core_abf = __import__("core.abf", fromlist=["compute_abf"])
core_susie = __import__("core.susie", fromlist=["run_susie"])
core_credible = __import__("core.credible_sets", ...)
core_susie_inf = __import__("core.susie_inf", fromlist=["run_susie_inf"])
```

The skill provides those exact module files (`abf.py`, `susie.py`, `credible_sets.py`, `susie_inf.py`) but they live in `skills/fine-mapping/fine_mapping_core/`, not `core/`. Result: every test case fails with `Skill module import failed: No module named 'core'`, harness reports 21 infrastructure errors.

## Effect on benchmark

| | Before | After |
|---|---|---|
| `clawbio-finemapping` | 0 / 0 (21 infra errors) | **19 / 20 (95.0%)** |
| **Aggregate** | **149 / 162 (92.0%)** excl. fine-mapping | **168 / 182 (92.3%)** including |

The single remaining failure (`susie_inf_est_tausq_ignored`) is a real algorithm finding, not an infrastructure error, and tracks as a normal benchmark failure for the remediation backlog.

## Why a symlink

Same reasoning as #215. The bench harness invokes the skill directly without going through the ClawBio CLI, so we cannot fix this from `clawbio.py`. The bench reads from a git checkout, so the symlink must be tracked.

## Why this is temporary

The proper fix is in `biostochastics/clawbio_bench`: read the skill package name from a manifest (`SKILL.md` frontmatter or a sibling `.bench-config.toml`) rather than hardcoding `core`. Issue forthcoming. Once the bench is updated, both this symlink and the nutrigx one (#215) can be removed.

## Verification

- `clawbio-bench --smoke --harness finemapping --repo .` returns 19 / 20 passing.
- `clawbio-bench --smoke --repo .` aggregate returns 168 / 182 (92.3%).

## Test plan

- [ ] CI green
- [ ] Manual: `git clone https://github.com/ClawBio/ClawBio.git && cd ClawBio && clawbio-bench --smoke --harness finemapping --repo .` returns 19 / 20

🤖 Generated with [Claude Code](https://claude.com/claude-code)