### PR TITLE
feat(nfcore-scrnaseq-wrapper): add upstream scRNA FASTQ preprocessing skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,6 @@ data/
 skills/proteomics-de/output_diann_test/
 skills/proteomics-de/output_maxquant_test/
 .venv/
+.claude/
+.claire/
 brief.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to ClawBio are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### New Skills
+- **nfcore-scrnaseq-wrapper** (`skills/nfcore-scrnaseq-wrapper/`, `scrnaseq-pipeline`): Upstream single-cell RNA-seq preprocessing from FASTQ using nf-core/scrnaseq. Supports six presets (simpleaf/standard, STARsolo/star, kallisto, cellranger, cellrangerarc, cellrangermulti), strict preflight for Java/Nextflow/backend, samplesheet validation, `params.yaml`-driven execution, SHA-256 reproducibility bundle, and automatic handoff to `scrna-orchestrator` (via `--run-downstream`). Includes macOS/Apple Silicon Docker workaround. 282 tests.
+
 ## [v0.5.0] — 2026-04-04 — Validation & Benchmark Infrastructure
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ When the user asks a question, match it to a skill and act:
 | PubMed search, "summarise PubMed papers about X", "recent papers on gene/disease", research briefing, gene papers, disease papers | `skills/pubmed-summariser/` | Run `pubmed_summariser.py` |
 | Target evidence, omics evidence, translational evidence, target triage, gene evidence aggregation | `skills/omics-target-evidence-mapper/` | Run `omics_target_evidence_mapper.py` |
 | Target validation, GO/NO-GO, drug target scoring, target prioritisation, target assessment | `skills/target-validation-scorer/` | Run `target_validation_scorer.py` |
+| Upstream single-cell pipeline, run nf-core/scrnaseq, FASTQ to h5ad, 10x Chromium FASTQ preprocessing, generate h5ad from raw FASTQs, STARsolo from FASTQ, alevin-fry from FASTQ, run nextflow scrnaseq | `skills/nfcore-scrnaseq-wrapper/` | Run `nfcore_scrnaseq_wrapper.py` |
 | Single-cell RNA-seq, Scanpy, clustering, marker genes, doublet removal, h5ad | `skills/scrna-orchestrator/` | Run `scrna_orchestrator.py` |
 | scVI, scANVI, single-cell embedding, latent embedding, batch integration, integrated h5ad | `skills/scrna-embedding/` | Run `scrna_embedding.py` |
 | Differential expression visualisation, volcano plot styling, marker heatmap, DE report plots, contrast visualisation | `skills/diff-visualizer/` | Run `diff_visualizer.py` |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://github.com/ClawBio/ClawBio/actions/workflows/ci.yml"><img src="https://github.com/ClawBio/ClawBio/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="#quick-start"><img src="https://img.shields.io/badge/python-3.10+-blue?logo=python&logoColor=white" alt="Python 3.10+"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="MIT License"></a>
-  <a href="https://clawhub.ai"><img src="https://img.shields.io/badge/ClawHub-63_skills-orange" alt="ClawHub Skills"></a>
+  <a href="https://clawhub.ai"><img src="https://img.shields.io/badge/ClawHub-64_skills-orange" alt="ClawHub Skills"></a>
   <a href="https://doi.org/10.5281/zenodo.19420648"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.19420648.svg" alt="DOI"></a>
   <a href="https://github.com/ClawBio/ClawBio/issues"><img src="https://img.shields.io/github/issues/ClawBio/ClawBio" alt="Open Issues"></a>
   <a href="https://clawbio.github.io/ClawBio/slides/"><img src="https://img.shields.io/badge/slides-London_Bioinformatics_Meetup-purple" alt="Slides"></a>
@@ -47,7 +47,7 @@ Or install as a [Claude Code](https://claude.ai/claude-code) plugin: `/plugin ma
 
 ## What ClawBio Does Today
 
-**63 skills + 8,000 Galaxy tools + 1,756 tests + benchmark validation. Local-first. No cloud. No guessing.**
+**64 skills + 8,000 Galaxy tools + 1,756 tests + benchmark validation. Local-first. No cloud. No guessing.**
 
 > **v0.5.0 released** (4 Apr 2026): Validation and Benchmark Infrastructure. AD ground truth benchmark, mock API server for offline testing, swappable fine-mapping pipeline (SuSiE vs ABF), 74 benchmark tests, red/green TDD mandate. [Release notes](https://github.com/ClawBio/ClawBio/releases/tag/v0.5.0). DOI: [10.5281/zenodo.19420648](https://doi.org/10.5281/zenodo.19420648).
 
@@ -171,7 +171,7 @@ report/
 
 ## Featured Skills
 
-A curated cross-section of ClawBio's 63 skills. The full machine-readable catalog (with status flags, trigger keywords, demo commands, and chaining partners) lives in [`skills/catalog.json`](skills/catalog.json); browse the directory at [`skills/`](skills/) to see every skill folder.
+A curated cross-section of ClawBio's 64 skills. The full machine-readable catalog (with status flags, trigger keywords, demo commands, and chaining partners) lives in [`skills/catalog.json`](skills/catalog.json); browse the directory at [`skills/`](skills/) to see every skill folder.
 
 | Skill | Scale | Description |
 |-------|-------|-------------|
@@ -186,6 +186,7 @@ A curated cross-section of ClawBio's 63 skills. The full machine-readable catalo
 | [Galaxy Bridge](skills/galaxy-bridge/) | Research | Search, run, and chain 8,000+ Galaxy bioinformatics tools |
 | [Variant Annotation](skills/variant-annotation/) | Clinical | Annotate VCF variants with Ensembl VEP REST, ClinVar significance, gnomAD frequencies |
 | [Clinical Variant Reporter](skills/clinical-variant-reporter/) | Clinical | ACMG-guided clinical variant classification from VCF with GiAB validation |
+| [nf-core scRNA Wrapper](skills/nfcore-scrnaseq-wrapper/) | Single-cell | Upstream FASTQ → h5ad preprocessing via nf-core/scrnaseq (simpleaf, STARsolo, kallisto, CellRanger) with strict preflight and reproducibility bundle |
 | [scRNA Orchestrator](skills/scrna-orchestrator/) | Single-cell | Scanpy automation: QC, optional doublet detection, clustering, markers, annotation |
 | [Equity Scorer](skills/equity-scorer/) | Systemic | HEIM diversity metrics from VCF or ancestry CSV |
 | [DnaSP](skills/dnasp/) | Population *(community)* | Python reimplementation of DnaSP 6: 16 population-genetics analyses (Pi, Tajima's D, Fst, Ka/Ks, McDonald-Kreitman) |

--- a/clawbio.py
+++ b/clawbio.py
@@ -500,6 +500,80 @@ SKILLS = {
             "--min-samples",
         },
     },
+    "scrnaseq-pipeline": {
+        "script": SKILLS_DIR / "nfcore-scrnaseq-wrapper" / "nfcore_scrnaseq_wrapper.py",
+        "demo_args": ["--demo"],
+        "description": "Wrapper de preprocessing scRNA FASTQ-to-h5ad vía scrnaseq/Nextflow",
+        # Keep the ClawBio runner timeout above the wrapper's internal Nextflow
+        # timeout so the wrapper can terminate the process group cleanly first.
+        "default_timeout_seconds": 60 * 60 * 12 + 10 * 60,
+        "max_output_files_listed": 50,
+        "allowed_extra_flags": {
+            "--check",
+            "--profile",
+            "--pipeline-version",
+            "--preset",
+            "--protocol",
+            "--email",
+            "--multiqc-title",
+            "--expected-cells",
+            "--resume",
+            "--genome",
+            "--save-reference",
+            "--save-align-intermeds",
+            "--skip-cellbender",
+            "--skip-fastqc",
+            "--skip-emptydrops",
+            "--skip-multiqc",
+            "--skip-cellranger-renaming",
+            "--skip-cellrangermulti-vdjref",
+            "--run-downstream",
+            "--skip-downstream",
+            "--fasta",
+            "--gtf",
+            "--transcript-fasta",
+            "--txp2gene",
+            "--simpleaf-index",
+            "--simpleaf-umi-resolution",
+            "--kallisto-index",
+            "--kb-workflow",
+            "--kb-t1c",
+            "--kb-t2c",
+            "--star-index",
+            "--star-feature",
+            "--star-ignore-sjdbgtf",
+            "--seq-center",
+            "--cellranger-index",
+            "--cellranger-vdj-index",
+            "--cellrangerarc-config",
+            "--cellrangerarc-reference",
+            "--barcode-whitelist",
+            "--motifs",
+            "--gex-frna-probe-set",
+            "--gex-target-panel",
+            "--gex-cmo-set",
+            "--fb-reference",
+            "--vdj-inner-enrichment-primers",
+            "--gex-barcode-sample-assignment",
+            "--cellranger-multi-barcodes",
+        },
+        "allowed_extra_flags_without_values": {
+            "--check",
+            "--resume",
+            "--skip-cellbender",
+            "--skip-fastqc",
+            "--skip-emptydrops",
+            "--skip-multiqc",
+            "--skip-cellranger-renaming",
+            "--skip-cellrangermulti-vdjref",
+            "--run-downstream",
+            "--skip-downstream",
+            "--save-reference",
+            "--save-align-intermeds",
+            "--star-ignore-sjdbgtf",
+        },
+        "accepts_genotypes": False,
+    },
     "rdoutlier": {
         "script": SKILLS_DIR / "rare-disease-rnaseq" / "rare_disease_rnaseq.py",
         "demo_args": ["--demo"],
@@ -787,7 +861,18 @@ def run_skill(
         ts = datetime.now().strftime("%Y%m%d_%H%M%S")
         out_dir = DEFAULT_OUTPUT_ROOT / f"{skill_name}_{ts}"
     if out_dir:
-        out_dir.mkdir(parents=True, exist_ok=True)
+        output_error = _ensure_output_directory(out_dir)
+        if output_error:
+            return {
+                "skill": skill_name,
+                "success": False,
+                "exit_code": -1,
+                "output_dir": str(out_dir),
+                "files": [],
+                "stdout": "",
+                "stderr": json.dumps(output_error, indent=2),
+                "duration_seconds": 0,
+            }
 
     # Build command
     cmd = [PYTHON, str(script_path)]
@@ -875,9 +960,11 @@ def run_skill(
 
     # Collect output files
     if out_dir and out_dir.exists():
-        output_files = sorted(
-            [f.name for f in out_dir.rglob("*") if f.is_file()],
-        )
+        max_files = int(skill_info.get("max_output_files_listed", 200))
+        all_output_files = sorted(f.name for f in out_dir.rglob("*") if f.is_file())
+        output_files = all_output_files[:max_files]
+        if len(all_output_files) > max_files:
+            output_files.append(f"... {len(all_output_files) - max_files} more files")
     else:
         output_files = []
 
@@ -897,6 +984,30 @@ def run_skill(
         _store_result_in_profile(profile_path, skill_name, out_dir)
 
     return result
+
+
+def _ensure_output_directory(out_dir: Path) -> dict[str, object] | None:
+    if out_dir.exists() and not out_dir.is_dir():
+        return {
+            "ok": False,
+            "stage": "preflight",
+            "error_code": "OUTPUT_DIR_NOT_WRITABLE",
+            "message": "Output path exists but is not a directory.",
+            "fix": "Choose a directory path for --output, or remove/rename the existing file.",
+            "details": {"output": str(out_dir)},
+        }
+    try:
+        out_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return {
+            "ok": False,
+            "stage": "preflight",
+            "error_code": "OUTPUT_DIR_NOT_WRITABLE",
+            "message": "Output directory could not be created.",
+            "fix": "Choose a writable output location.",
+            "details": {"output": str(out_dir), "error": str(exc)},
+        }
+    return None
 
 
 # --------------------------------------------------------------------------- #
@@ -1050,6 +1161,261 @@ def main():
     run_parser.add_argument(
         "--timeout", type=int, default=300, help="Timeout in seconds (default: 300)"
     )
+    run_parser.add_argument("--drug", default=None, help="Drug name for single-drug lookup (drugphoto skill)")
+    run_parser.add_argument("--dose", default=None, help="Visible dose from packaging (e.g. '50mg')")
+    run_parser.add_argument("--trait", default=None, help="Trait search term for PRS skill")
+    run_parser.add_argument("--pgs-id", default=None, help="PGS Catalog score ID for PRS skill")
+    run_parser.add_argument("--gene", default=None, help="Gene symbol for ClinPGx skill")
+    run_parser.add_argument("--genes", default=None, help="Comma-separated gene symbols for ClinPGx")
+    run_parser.add_argument("--rsid", default=None, help="rsID for GWAS lookup skill (e.g. rs3798220)")
+    run_parser.add_argument("--skip", default=None, help="Comma-separated API names to skip (gwas-lookup skill)")
+    run_parser.add_argument("--query", default=None, help="Inline SQL query for bigquery skill")
+    run_parser.add_argument("--location", default=None, help="BigQuery location (e.g. US, EU)")
+    run_parser.add_argument("--max-rows", type=int, default=None, help="Maximum number of query rows for bigquery skill")
+    run_parser.add_argument(
+        "--max-bytes-billed",
+        type=int,
+        default=None,
+        help="Maximum billed bytes safeguard for bigquery skill",
+    )
+    run_parser.add_argument(
+        "--param",
+        action="append",
+        default=None,
+        help="Repeatable bigquery parameter in name=type:value format",
+    )
+    run_parser.add_argument("--dry-run", action="store_true", help="BigQuery dry-run (estimate bytes only)")
+    run_parser.add_argument("--list-datasets", default=None, help="List BigQuery datasets for a project")
+    run_parser.add_argument("--list-tables", default=None, help="List BigQuery tables for a dataset (project.dataset)")
+    run_parser.add_argument("--describe", default=None, help="Describe a BigQuery table schema (project.dataset.table)")
+    run_parser.add_argument("--preview", type=int, default=None, help="Preview wrapper row limit for bigquery skill")
+    run_parser.add_argument("--count-only", action="store_true", help="Return only row count for bigquery skill")
+    run_parser.add_argument("--paper", default=None, help="Paper reference/DOI/URL/path for bigquery provenance")
+    run_parser.add_argument("--note", action="append", default=None, help="Repeatable provenance note for bigquery skill")
+    run_parser.add_argument("--geo-id", default=None, help="GEO accession for methylation clock skill")
+    run_parser.add_argument("--clocks", default=None, help="Comma-separated clock names for methylation skill")
+    run_parser.add_argument("--metadata-cols", default=None, help="Comma-separated metadata columns for methylation skill")
+    run_parser.add_argument("--imputer-strategy", default=None, help="Imputer strategy for methylation skill")
+    run_parser.add_argument("--skip-epicv2-aggregation", action="store_true", help="Skip EPICv2 probe aggregation")
+    run_parser.add_argument("--verbose", action="store_true", help="Verbose output for skill backends")
+    run_parser.add_argument("--vcf", default=None, help="Explicit VCF override for illumina skill")
+    run_parser.add_argument("--qc", default=None, help="Explicit QC metrics override for illumina skill")
+    run_parser.add_argument("--sample-sheet", default=None, help="Explicit SampleSheet override for illumina skill")
+    run_parser.add_argument(
+        "--metadata-provider",
+        default=None,
+        help="Optional metadata provider for illumina skill (none or ica)",
+    )
+    run_parser.add_argument("--ica-project-id", default=None, help="ICA project ID for illumina skill")
+    run_parser.add_argument("--ica-run-id", default=None, help="ICA analysis/run ID for illumina skill")
+    run_parser.add_argument("--counts", default=None, help="Counts matrix for rnaseq/diffviz bulk workflows")
+    run_parser.add_argument("--metadata", default=None, help="Sample metadata for rnaseq/diffviz bulk workflows")
+    run_parser.add_argument("--formula", default=None, help="Design formula for rnaseq skill")
+    run_parser.add_argument("--contrast", default=None, help="Contrast for rnaseq skill: factor,numerator,denominator")
+    run_parser.add_argument("--backend", default=None, help="Backend for rnaseq skill (auto|pydeseq2|simple)")
+    run_parser.add_argument("--min-count", type=int, default=None, help="Minimum count threshold for rnaseq skill")
+    run_parser.add_argument("--min-samples", type=int, default=None, help="Minimum samples threshold for rnaseq skill")
+    run_parser.add_argument("--check", action="store_true", help="Preflight-only mode for scrnaseq-pipeline")
+    run_parser.add_argument("--pipeline-version", default=None, help="Pinned pipeline version/tag for scrnaseq-pipeline")
+    run_parser.add_argument("--preset", default=None, help="Curated preset for scrnaseq-pipeline")
+    run_parser.add_argument("--protocol", default=None, help="Protocol value for scrnaseq-pipeline")
+    run_parser.add_argument("--email", default=None, help="Email address for scrnaseq-pipeline completion notification")
+    run_parser.add_argument("--multiqc-title", default=None, help="Custom MultiQC title for scrnaseq-pipeline")
+    run_parser.add_argument("--expected-cells", type=int, default=None, help="expected_cells override for scrnaseq-pipeline")
+    run_parser.add_argument("--resume", action="store_true", help="Enable resume policy for scrnaseq-pipeline")
+    run_parser.add_argument("--save-reference", action="store_true", help="Save built reference indexes for scrnaseq-pipeline")
+    run_parser.add_argument("--save-align-intermeds", action="store_true", help="Save alignment intermediates for scrnaseq-pipeline")
+    run_parser.add_argument("--skip-cellbender", action="store_true", help="Disable cellbender for scrnaseq-pipeline")
+    run_parser.add_argument("--skip-fastqc", action="store_true", help="Skip FastQC for scrnaseq-pipeline")
+    run_parser.add_argument(
+        "--skip-emptydrops",
+        action="store_true",
+        help="Deprecated alias for --skip-cellbender in scrnaseq-pipeline",
+    )
+    run_parser.add_argument("--skip-multiqc", action="store_true", help="Skip MultiQC for scrnaseq-pipeline")
+    run_parser.add_argument("--skip-cellranger-renaming", action="store_true", help="Skip CellRanger sample renaming")
+    run_parser.add_argument("--skip-cellrangermulti-vdjref", action="store_true", help="Skip CellRanger Multi VDJ reference build")
+    run_parser.add_argument("--run-downstream", action="store_true", help="Opt in to scrna_orchestrator handoff after scrnaseq-pipeline")
+    run_parser.add_argument("--skip-downstream", action="store_true", help="Compatibility flag for scrnaseq-pipeline downstream handoff")
+    run_parser.add_argument("--fasta", default=None, help="Genome FASTA for scrnaseq-pipeline")
+    run_parser.add_argument("--gtf", default=None, help="Annotation GTF for scrnaseq-pipeline")
+    run_parser.add_argument("--transcript-fasta", default=None, help="Transcript FASTA for scrnaseq-pipeline")
+    run_parser.add_argument("--txp2gene", default=None, help="Transcript-to-gene map for scrnaseq-pipeline")
+    run_parser.add_argument("--simpleaf-index", default=None, help="Prebuilt simpleaf index for scrnaseq-pipeline")
+    run_parser.add_argument("--simpleaf-umi-resolution", default=None, help="simpleaf UMI resolution strategy")
+    run_parser.add_argument("--kallisto-index", default=None, help="Prebuilt kallisto index for scrnaseq-pipeline")
+    run_parser.add_argument("--kb-workflow", default=None, help="Kallisto workflow for scrnaseq-pipeline")
+    run_parser.add_argument("--kb-t1c", default=None, help="Kallisto cDNA transcripts-to-capture file")
+    run_parser.add_argument("--kb-t2c", default=None, help="Kallisto intron transcripts-to-capture file")
+    run_parser.add_argument("--star-index", default=None, help="Prebuilt STAR index for scrnaseq-pipeline")
+    run_parser.add_argument("--star-feature", default=None, help="STARsolo feature type for scrnaseq-pipeline")
+    run_parser.add_argument("--star-ignore-sjdbgtf", action="store_true", help="Disable STAR SJDB GTF usage")
+    run_parser.add_argument("--seq-center", default=None, help="Sequencing center for scrnaseq-pipeline")
+    run_parser.add_argument("--cellranger-index", default=None, help="Prebuilt cellranger index for scrnaseq-pipeline")
+    run_parser.add_argument("--cellranger-vdj-index", default=None, help="Prebuilt CellRanger VDJ reference index")
+    run_parser.add_argument("--cellrangerarc-config", default=None, help="CellRanger ARC config file")
+    run_parser.add_argument("--cellrangerarc-reference", default=None, help="CellRanger ARC reference name")
+    run_parser.add_argument("--barcode-whitelist", default=None, help="Barcode whitelist override for scrnaseq-pipeline")
+    run_parser.add_argument("--motifs", default=None, help="Motif file for CellRanger ARC")
+    run_parser.add_argument("--gex-frna-probe-set", default=None, help="CellRanger Multi fixed RNA probe set")
+    run_parser.add_argument("--gex-target-panel", default=None, help="CellRanger Multi target panel")
+    run_parser.add_argument("--gex-cmo-set", default=None, help="CellRanger Multi CMO set")
+    run_parser.add_argument("--fb-reference", default=None, help="Feature barcoding reference CSV")
+    run_parser.add_argument("--vdj-inner-enrichment-primers", default=None, help="VDJ inner enrichment primers file")
+    run_parser.add_argument("--gex-barcode-sample-assignment", default=None, help="GEX barcode sample assignment CSV")
+    run_parser.add_argument("--cellranger-multi-barcodes", default=None, help="CellRanger Multi barcodes samplesheet")
+    run_parser.add_argument("--mode", default=None, help="Mode for diffviz skill (auto|bulk|scrna)")
+    run_parser.add_argument("--adata", default=None, help="AnnData input for enhanced diffviz scRNA plots")
+    run_parser.add_argument("--top-genes", type=int, default=None, help="Top genes/markers to display in diffviz")
+    run_parser.add_argument("--label-top", type=int, default=None, help="Label top hits in diffviz plots")
+    run_parser.add_argument(
+        "--padj-threshold",
+        type=float,
+        default=None,
+        help="Adjusted p-value threshold for diffviz significance highlighting",
+    )
+    run_parser.add_argument(
+        "--lfc-threshold",
+        type=float,
+        default=None,
+        help="Absolute log fold-change threshold for diffviz significance highlighting",
+    )
+    run_parser.add_argument(
+        "--min-basemean",
+        type=float,
+        default=None,
+        help="Minimum baseMean retained in diffviz bulk display plots/tables",
+    )
+    run_parser.add_argument("--method", default=None, help="Embedding backend (scrna-embedding skill)")
+    run_parser.add_argument("--layer", default=None, help="Raw-count layer for `.h5ad` input (scrna-embedding skill)")
+    run_parser.add_argument("--batch-key", default=None, help="obs batch column for integration (scrna-embedding skill)")
+    run_parser.add_argument("--labels-key", default=None, help="obs label column for scANVI (scrna-embedding skill)")
+    run_parser.add_argument(
+        "--unlabeled-category",
+        default=None,
+        help="Category value representing unlabeled cells for scANVI (scrna-embedding skill)",
+    )
+    run_parser.add_argument("--min-genes", type=int, default=None, help="Minimum genes per cell (scrna/scrna-embedding skill)")
+    run_parser.add_argument("--min-cells", type=int, default=None, help="Minimum cells per gene (scrna/scrna-embedding skill)")
+    run_parser.add_argument(
+        "--max-mt-pct",
+        type=float,
+        default=None,
+        help="Maximum mitochondrial percentage (scrna/scrna-embedding skill)",
+    )
+    run_parser.add_argument(
+        "--n-top-hvg",
+        type=int,
+        default=None,
+        help="Number of highly variable genes to keep (scrna/scrna-embedding skill)",
+    )
+    run_parser.add_argument("--n-pcs", type=int, default=None, help="Number of PCA components (scrna skill)")
+    run_parser.add_argument("--latent-dim", type=int, default=None, help="Latent dimensionality (scrna-embedding skill)")
+    run_parser.add_argument("--max-epochs", type=int, default=None, help="Max training epochs (scrna-embedding skill)")
+    run_parser.add_argument(
+        "--n-neighbors",
+        type=int,
+        default=None,
+        help="Neighbors for graph construction (scrna/scrna-embedding skill)",
+    )
+    run_parser.add_argument(
+        "--use-rep",
+        default=None,
+        help="Graph representation key or mode such as `auto`, `none`, or `X_scvi` (scrna skill)",
+    )
+    run_parser.add_argument(
+        "--leiden-resolution",
+        type=float,
+        default=None,
+        help="Leiden resolution (scrna skill)",
+    )
+    run_parser.add_argument("--random-state", type=int, default=None, help="Random seed (scrna/scrna-embedding skill)")
+    run_parser.add_argument(
+        "--top-markers",
+        type=int,
+        default=None,
+        help="Top markers per cluster (scrna skill)",
+    )
+    run_parser.add_argument(
+        "--accelerator",
+        default=None,
+        help="Training accelerator (scrna-embedding skill)",
+    )
+    run_parser.add_argument(
+        "--contrast-groupby",
+        default=None,
+        help="obs column for contrastive marker analysis (scrna skill)",
+    )
+    run_parser.add_argument(
+        "--contrast-scope",
+        default=None,
+        help="Contrast scope: dataset, within-cluster, or both (scrna skill)",
+    )
+    run_parser.add_argument(
+        "--contrast-clusterby",
+        default=None,
+        help="Cluster/partition column for within-cluster contrasts (scrna skill)",
+    )
+    run_parser.add_argument(
+        "--contrast-top-genes",
+        type=int,
+        default=None,
+        help="Top contrastive marker genes in summary table (scrna skill)",
+    )
+    run_parser.add_argument(
+        "--doublet-method",
+        default=None,
+        help="Optional doublet detection method for scrna skill",
+    )
+    run_parser.add_argument(
+        "--annotate",
+        default=None,
+        help="Optional annotation backend for scrna skill",
+    )
+    run_parser.add_argument(
+        "--annotation-model",
+        default=None,
+        help="Local CellTypist model name or path for scrna skill",
+    )
+    run_parser.add_argument("--search", default=None, help="Search query (bioc / galaxy skills)")
+    run_parser.add_argument("--recommend", default=None, help="Recommendation query for bioc skill")
+    run_parser.add_argument("--workflow", default=None, help="Workflow query for bioc skill")
+    run_parser.add_argument("--package-details", default=None, help="Bioconductor package name for bioc skill")
+    run_parser.add_argument("--docs-search", default=None, help="Documentation search query for bioc skill")
+    run_parser.add_argument("--package-docs", default=None, help="Fetch package documentation for bioc skill")
+    run_parser.add_argument("--list-domains", action="store_true", help="List supported Bioconductor domains")
+    run_parser.add_argument("--setup", action="store_true", help="Inspect local Bioconductor setup")
+    run_parser.add_argument("--install", default=None, help="Comma-separated Bioconductor packages to install")
+    run_parser.add_argument("--format", dest="skill_format", default=None, help="Input format hint for bioc skill")
+    run_parser.add_argument("--container", default=None, help="Canonical object/container hint for bioc skill")
+    run_parser.add_argument("--modality", default=None, help="Modality hint for bioc skill")
+    run_parser.add_argument("--max-results", type=int, default=None, help="Maximum bioc search/recommendation results")
+    # flow-bio skill flags
+    run_parser.add_argument("--flow-search", dest="flow_search", default=None, help="Search query (flow skill)")
+    run_parser.add_argument("--pipelines", action="store_true", help="List pipelines (flow skill)")
+    run_parser.add_argument("--samples", action="store_true", help="List samples (flow skill)")
+    run_parser.add_argument("--projects", action="store_true", help="List projects (flow skill)")
+    run_parser.add_argument("--executions", action="store_true", help="List executions (flow skill)")
+    run_parser.add_argument("--organisms", action="store_true", help="List organisms (flow skill)")
+    run_parser.add_argument("--sample-types", action="store_true", help="List sample types (flow skill)")
+    run_parser.add_argument("--data", action="store_true", help="List data (flow skill)")
+    run_parser.add_argument("--metadata-attributes", action="store_true", help="List metadata attributes (flow skill)")
+    run_parser.add_argument("--search-samples", nargs="+", default=None, help="Search samples by metadata key=value pairs (flow skill)")
+    run_parser.add_argument("--upload-sample", action="store_true", help="Upload a sample (flow skill)")
+    run_parser.add_argument("--name", default=None, help="Sample name for upload (flow skill)")
+    run_parser.add_argument("--reads1", default=None, help="First reads file (flow skill)")
+    run_parser.add_argument("--reads2", default=None, help="Second reads file (flow skill)")
+    run_parser.add_argument("--organism", default=None, help="Organism name or ID (flow skill)")
+    run_parser.add_argument("--project", default=None, help="Project ID (flow skill)")
+    run_parser.add_argument("--run-pipeline", default=None, help="Pipeline version ID to run (flow skill)")
+    run_parser.add_argument("--run-samples", default=None, help="Comma-separated sample IDs for pipeline (flow skill)")
+    run_parser.add_argument("--run-data", default=None, help="Comma-separated data IDs for pipeline (flow skill)")
+    run_parser.add_argument("--run-params", default=None, help="Pipeline parameters as JSON string (flow skill)")
+    run_parser.add_argument("--genome", default=None, help="Genome ID for pipeline run (flow/scrnaseq skill)")
+    run_parser.add_argument("--pipeline-detail", default=None, dest="pipeline_detail", help="Get pipeline details by ID (flow skill)")
+    run_parser.add_argument("--sample-detail", default=None, dest="sample_detail", help="Get sample details by ID (flow skill)")
+    run_parser.add_argument("--execution-detail", default=None, dest="execution_detail", help="Get execution details by ID (flow skill)")
+    run_parser.add_argument("--json", action="store_true", help="Output raw JSON (flow skill)")
 
     args, extra = parser.parse_known_args()
 
@@ -1072,14 +1438,342 @@ def main():
             sys.exit(1)
 
     elif args.command == "run":
+        skill_backend_profile = None
+        if args.skill == "scrnaseq-pipeline" and getattr(args, "profile_path", None) in {"docker", "conda", "singularity", "apptainer"}:
+            skill_backend_profile = args.profile_path
+            args.profile_path = None
+
+        # Build extra_args from skill-specific flags
+        extra = []
+        if getattr(args, "check", False):
+            extra.append("--check")
+        if skill_backend_profile:
+            extra.extend(["--profile", skill_backend_profile])
+        if getattr(args, "pipeline_version", None):
+            extra.extend(["--pipeline-version", args.pipeline_version])
+        if getattr(args, "preset", None):
+            extra.extend(["--preset", args.preset])
+        if getattr(args, "protocol", None):
+            extra.extend(["--protocol", args.protocol])
+        if getattr(args, "email", None):
+            extra.extend(["--email", args.email])
+        if getattr(args, "multiqc_title", None):
+            extra.extend(["--multiqc-title", args.multiqc_title])
+        if getattr(args, "expected_cells", None) is not None:
+            extra.extend(["--expected-cells", str(args.expected_cells)])
+        if getattr(args, "resume", False):
+            extra.append("--resume")
+        if getattr(args, "save_reference", False):
+            extra.append("--save-reference")
+        if getattr(args, "save_align_intermeds", False):
+            extra.append("--save-align-intermeds")
+        if getattr(args, "skip_cellbender", False):
+            extra.append("--skip-cellbender")
+        if getattr(args, "skip_fastqc", False):
+            extra.append("--skip-fastqc")
+        if getattr(args, "skip_emptydrops", False):
+            extra.append("--skip-emptydrops")
+        if getattr(args, "skip_multiqc", False):
+            extra.append("--skip-multiqc")
+        if getattr(args, "skip_cellranger_renaming", False):
+            extra.append("--skip-cellranger-renaming")
+        if getattr(args, "skip_cellrangermulti_vdjref", False):
+            extra.append("--skip-cellrangermulti-vdjref")
+        if getattr(args, "run_downstream", False):
+            extra.append("--run-downstream")
+        if getattr(args, "skip_downstream", False):
+            extra.append("--skip-downstream")
+        if getattr(args, "fasta", None):
+            extra.extend(["--fasta", args.fasta])
+        if getattr(args, "gtf", None):
+            extra.extend(["--gtf", args.gtf])
+        if getattr(args, "transcript_fasta", None):
+            extra.extend(["--transcript-fasta", args.transcript_fasta])
+        if getattr(args, "txp2gene", None):
+            extra.extend(["--txp2gene", args.txp2gene])
+        if getattr(args, "simpleaf_index", None):
+            extra.extend(["--simpleaf-index", args.simpleaf_index])
+        if getattr(args, "simpleaf_umi_resolution", None):
+            extra.extend(["--simpleaf-umi-resolution", args.simpleaf_umi_resolution])
+        if getattr(args, "kallisto_index", None):
+            extra.extend(["--kallisto-index", args.kallisto_index])
+        if getattr(args, "kb_workflow", None):
+            extra.extend(["--kb-workflow", args.kb_workflow])
+        if getattr(args, "kb_t1c", None):
+            extra.extend(["--kb-t1c", args.kb_t1c])
+        if getattr(args, "kb_t2c", None):
+            extra.extend(["--kb-t2c", args.kb_t2c])
+        if getattr(args, "star_index", None):
+            extra.extend(["--star-index", args.star_index])
+        if getattr(args, "star_feature", None):
+            extra.extend(["--star-feature", args.star_feature])
+        if getattr(args, "star_ignore_sjdbgtf", False):
+            extra.append("--star-ignore-sjdbgtf")
+        if getattr(args, "seq_center", None):
+            extra.extend(["--seq-center", args.seq_center])
+        if getattr(args, "cellranger_index", None):
+            extra.extend(["--cellranger-index", args.cellranger_index])
+        if getattr(args, "cellranger_vdj_index", None):
+            extra.extend(["--cellranger-vdj-index", args.cellranger_vdj_index])
+        if getattr(args, "cellrangerarc_config", None):
+            extra.extend(["--cellrangerarc-config", args.cellrangerarc_config])
+        if getattr(args, "cellrangerarc_reference", None):
+            extra.extend(["--cellrangerarc-reference", args.cellrangerarc_reference])
+        if getattr(args, "barcode_whitelist", None):
+            extra.extend(["--barcode-whitelist", args.barcode_whitelist])
+        if getattr(args, "motifs", None):
+            extra.extend(["--motifs", args.motifs])
+        if getattr(args, "gex_frna_probe_set", None):
+            extra.extend(["--gex-frna-probe-set", args.gex_frna_probe_set])
+        if getattr(args, "gex_target_panel", None):
+            extra.extend(["--gex-target-panel", args.gex_target_panel])
+        if getattr(args, "gex_cmo_set", None):
+            extra.extend(["--gex-cmo-set", args.gex_cmo_set])
+        if getattr(args, "fb_reference", None):
+            extra.extend(["--fb-reference", args.fb_reference])
+        if getattr(args, "vdj_inner_enrichment_primers", None):
+            extra.extend(["--vdj-inner-enrichment-primers", args.vdj_inner_enrichment_primers])
+        if getattr(args, "gex_barcode_sample_assignment", None):
+            extra.extend(["--gex-barcode-sample-assignment", args.gex_barcode_sample_assignment])
+        if getattr(args, "cellranger_multi_barcodes", None):
+            extra.extend(["--cellranger-multi-barcodes", args.cellranger_multi_barcodes])
+        if getattr(args, "drug", None):
+            extra.extend(["--drug", args.drug])
+        if getattr(args, "dose", None):
+            extra.extend(["--dose", args.dose])
+        if getattr(args, "trait", None):
+            extra.extend(["--trait", args.trait])
+        if getattr(args, "pgs_id", None):
+            extra.extend(["--pgs-id", args.pgs_id])
+        if getattr(args, "gene", None):
+            extra.extend(["--gene", args.gene])
+        if getattr(args, "genes", None):
+            extra.extend(["--genes", args.genes])
+        if getattr(args, "rsid", None):
+            extra.extend(["--rsid", args.rsid])
+        if getattr(args, "skip", None):
+            extra.extend(["--skip", args.skip])
+        if getattr(args, "query", None):
+            extra.extend(["--query", args.query])
+        if getattr(args, "location", None):
+            extra.extend(["--location", args.location])
+        if getattr(args, "max_rows", None) is not None:
+            extra.extend(["--max-rows", str(args.max_rows)])
+        if getattr(args, "max_bytes_billed", None) is not None:
+            extra.extend(["--max-bytes-billed", str(args.max_bytes_billed)])
+        if getattr(args, "param", None):
+            for param in args.param:
+                extra.extend(["--param", param])
+        if getattr(args, "dry_run", False):
+            extra.append("--dry-run")
+        if getattr(args, "list_datasets", None):
+            extra.extend(["--list-datasets", args.list_datasets])
+        if getattr(args, "list_tables", None):
+            extra.extend(["--list-tables", args.list_tables])
+        if getattr(args, "describe", None):
+            extra.extend(["--describe", args.describe])
+        if getattr(args, "preview", None) is not None:
+            extra.extend(["--preview", str(args.preview)])
+        if getattr(args, "count_only", False):
+            extra.append("--count-only")
+        if getattr(args, "paper", None):
+            extra.extend(["--paper", args.paper])
+        if getattr(args, "note", None):
+            for note in args.note:
+                extra.extend(["--note", note])
+        if getattr(args, "geo_id", None):
+            extra.extend(["--geo-id", args.geo_id])
+        if getattr(args, "clocks", None):
+            extra.extend(["--clocks", args.clocks])
+        if getattr(args, "metadata_cols", None):
+            extra.extend(["--metadata-cols", args.metadata_cols])
+        if getattr(args, "imputer_strategy", None):
+            extra.extend(["--imputer-strategy", args.imputer_strategy])
+        if getattr(args, "skip_epicv2_aggregation", False):
+            extra.append("--skip-epicv2-aggregation")
+        if getattr(args, "verbose", False):
+            extra.append("--verbose")
+        if getattr(args, "vcf", None):
+            extra.extend(["--vcf", args.vcf])
+        if getattr(args, "qc", None):
+            extra.extend(["--qc", args.qc])
+        if getattr(args, "sample_sheet", None):
+            extra.extend(["--sample-sheet", args.sample_sheet])
+        if getattr(args, "metadata_provider", None):
+            extra.extend(["--metadata-provider", args.metadata_provider])
+        if getattr(args, "ica_project_id", None):
+            extra.extend(["--ica-project-id", args.ica_project_id])
+        if getattr(args, "ica_run_id", None):
+            extra.extend(["--ica-run-id", args.ica_run_id])
+        if getattr(args, "counts", None):
+            extra.extend(["--counts", args.counts])
+        if getattr(args, "metadata", None):
+            extra.extend(["--metadata", args.metadata])
+        if getattr(args, "formula", None):
+            extra.extend(["--formula", args.formula])
+        if getattr(args, "contrast", None):
+            extra.extend(["--contrast", args.contrast])
+        if getattr(args, "backend", None):
+            extra.extend(["--backend", args.backend])
+        if getattr(args, "min_count", None) is not None:
+            extra.extend(["--min-count", str(args.min_count)])
+        if getattr(args, "min_samples", None) is not None:
+            extra.extend(["--min-samples", str(args.min_samples)])
+        if getattr(args, "mode", None):
+            extra.extend(["--mode", args.mode])
+        if getattr(args, "adata", None):
+            extra.extend(["--adata", args.adata])
+        if getattr(args, "top_genes", None) is not None:
+            extra.extend(["--top-genes", str(args.top_genes)])
+        if getattr(args, "label_top", None) is not None:
+            extra.extend(["--label-top", str(args.label_top)])
+        if getattr(args, "padj_threshold", None) is not None:
+            extra.extend(["--padj-threshold", str(args.padj_threshold)])
+        if getattr(args, "lfc_threshold", None) is not None:
+            extra.extend(["--lfc-threshold", str(args.lfc_threshold)])
+        if getattr(args, "min_basemean", None) is not None:
+            extra.extend(["--min-basemean", str(args.min_basemean)])
+        if getattr(args, "method", None):
+            extra.extend(["--method", args.method])
+        if getattr(args, "layer", None):
+            extra.extend(["--layer", args.layer])
+        if getattr(args, "batch_key", None):
+            extra.extend(["--batch-key", args.batch_key])
+        if getattr(args, "labels_key", None):
+            extra.extend(["--labels-key", args.labels_key])
+        if getattr(args, "unlabeled_category", None):
+            extra.extend(["--unlabeled-category", args.unlabeled_category])
+        if getattr(args, "min_genes", None) is not None:
+            extra.extend(["--min-genes", str(args.min_genes)])
+        if getattr(args, "min_cells", None) is not None:
+            extra.extend(["--min-cells", str(args.min_cells)])
+        if getattr(args, "max_mt_pct", None) is not None:
+            extra.extend(["--max-mt-pct", str(args.max_mt_pct)])
+        if getattr(args, "n_top_hvg", None) is not None:
+            extra.extend(["--n-top-hvg", str(args.n_top_hvg)])
+        if getattr(args, "n_pcs", None) is not None:
+            extra.extend(["--n-pcs", str(args.n_pcs)])
+        if getattr(args, "latent_dim", None) is not None:
+            extra.extend(["--latent-dim", str(args.latent_dim)])
+        if getattr(args, "max_epochs", None) is not None:
+            extra.extend(["--max-epochs", str(args.max_epochs)])
+        if getattr(args, "n_neighbors", None) is not None:
+            extra.extend(["--n-neighbors", str(args.n_neighbors)])
+        if getattr(args, "use_rep", None):
+            extra.extend(["--use-rep", args.use_rep])
+        if getattr(args, "leiden_resolution", None) is not None:
+            extra.extend(["--leiden-resolution", str(args.leiden_resolution)])
+        if getattr(args, "random_state", None) is not None:
+            extra.extend(["--random-state", str(args.random_state)])
+        if getattr(args, "top_markers", None) is not None:
+            extra.extend(["--top-markers", str(args.top_markers)])
+        if getattr(args, "accelerator", None):
+            extra.extend(["--accelerator", args.accelerator])
+        if getattr(args, "contrast_groupby", None):
+            extra.extend(["--contrast-groupby", args.contrast_groupby])
+        if getattr(args, "contrast_scope", None):
+            extra.extend(["--contrast-scope", args.contrast_scope])
+        if getattr(args, "contrast_clusterby", None):
+            extra.extend(["--contrast-clusterby", args.contrast_clusterby])
+        if getattr(args, "contrast_top_genes", None) is not None:
+            extra.extend(["--contrast-top-genes", str(args.contrast_top_genes)])
+        if getattr(args, "doublet_method", None):
+            extra.extend(["--doublet-method", args.doublet_method])
+        if getattr(args, "annotate", None):
+            extra.extend(["--annotate", args.annotate])
+        if getattr(args, "annotation_model", None):
+            extra.extend(["--annotation-model", args.annotation_model])
+        if getattr(args, "search", None):
+            extra.extend(["--search", args.search])
+        if getattr(args, "recommend", None):
+            extra.extend(["--recommend", args.recommend])
+        if getattr(args, "workflow", None):
+            extra.extend(["--workflow", args.workflow])
+        if getattr(args, "package_details", None):
+            extra.extend(["--package-details", args.package_details])
+        if getattr(args, "docs_search", None):
+            extra.extend(["--docs-search", args.docs_search])
+        if getattr(args, "package_docs", None):
+            extra.extend(["--package-docs", args.package_docs])
+        if getattr(args, "list_domains", False):
+            extra.append("--list-domains")
+        if getattr(args, "setup", False):
+            extra.append("--setup")
+        if getattr(args, "install", None):
+            extra.extend(["--install", args.install])
+        if getattr(args, "skill_format", None):
+            extra.extend(["--format", args.skill_format])
+        if getattr(args, "container", None):
+            extra.extend(["--container", args.container])
+        if getattr(args, "modality", None):
+            extra.extend(["--modality", args.modality])
+        if getattr(args, "max_results", None) is not None:
+            extra.extend(["--max-results", str(args.max_results)])
+        # flow-bio skill flags
+        if getattr(args, "flow_search", None):
+            extra.extend(["--search", args.flow_search])
+        if getattr(args, "pipelines", False):
+            extra.append("--pipelines")
+        if getattr(args, "samples", False):
+            extra.append("--samples")
+        if getattr(args, "projects", False):
+            extra.append("--projects")
+        if getattr(args, "executions", False):
+            extra.append("--executions")
+        if getattr(args, "organisms", False):
+            extra.append("--organisms")
+        if getattr(args, "sample_types", False):
+            extra.append("--sample-types")
+        if getattr(args, "data", False):
+            extra.append("--data")
+        if getattr(args, "metadata_attributes", False):
+            extra.append("--metadata-attributes")
+        if getattr(args, "search_samples", None):
+            extra.append("--search-samples")
+            extra.extend(args.search_samples)
+        if getattr(args, "upload_sample", False):
+            extra.append("--upload-sample")
+        if getattr(args, "name", None):
+            extra.extend(["--name", args.name])
+        if getattr(args, "reads1", None):
+            extra.extend(["--reads1", args.reads1])
+        if getattr(args, "reads2", None):
+            extra.extend(["--reads2", args.reads2])
+        if getattr(args, "organism", None):
+            extra.extend(["--organism", args.organism])
+        if getattr(args, "project", None):
+            extra.extend(["--project", args.project])
+        if getattr(args, "run_pipeline", None):
+            extra.extend(["--run-pipeline", args.run_pipeline])
+        if getattr(args, "run_samples", None):
+            extra.extend(["--run-samples", args.run_samples])
+        if getattr(args, "run_data", None):
+            extra.extend(["--run-data", args.run_data])
+        if getattr(args, "run_params", None):
+            extra.extend(["--run-params", args.run_params])
+        if getattr(args, "genome", None):
+            extra.extend(["--genome", args.genome])
+        if getattr(args, "pipeline_detail", None):
+            extra.extend(["--pipeline", args.pipeline_detail])
+        if getattr(args, "sample_detail", None):
+            extra.extend(["--sample", args.sample_detail])
+        if getattr(args, "execution_detail", None):
+            extra.extend(["--execution", args.execution_detail])
+        if getattr(args, "json", False):
+            extra.append("--json")
+
+        run_timeout = args.timeout
+        if args.timeout == 300:
+            run_timeout = SKILLS.get(args.skill, {}).get("default_timeout_seconds", args.timeout)
+
         result = run_skill(
             skill_name=args.skill,
             input_path=args.input_path,
             output_dir=args.output_dir,
             demo=args.demo,
             extra_args=extra or None,
-            timeout=args.timeout,
-            profile_path=args.profile_path,
+            timeout=run_timeout,
+            profile_path=getattr(args, "profile_path", None),
         )
 
         # Summary mode: skill printed text to stdout — relay it directly

--- a/pytest.ini
+++ b/pytest.ini
@@ -31,6 +31,7 @@ testpaths =
     skills/labstep/tests
     skills/lit-synthesizer/tests
     skills/mendelian-randomisation/tests
+    skills/nfcore-scrnaseq-wrapper/tests
     skills/methylation-clock/tests
     skills/multiqc-reporter/tests
     skills/nutrigx-advisor/tests
@@ -56,3 +57,5 @@ testpaths =
     tests
 python_files = test_*.py
 python_functions = test_*
+markers =
+    integration: marks tests that require external tools or network access (deselect with '-m "not integration"')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 conda-lock>=2.0
+pyyaml>=6.0
 biopython>=1.82
 pandas>=2.0
 numpy>=1.24

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -207,6 +207,7 @@ FOLDER_TO_ALIAS = {
     "profile-report": "profile",
     "galaxy-bridge": "galaxy",
     "bioconductor-bridge": "bioc",
+    "nfcore-scrnaseq-wrapper": "scrnaseq-pipeline",
     "rnaseq-de": "rnaseq",
     "diff-visualizer": "diffviz",
     "llm-biobank-bench": "llm-bench",
@@ -218,7 +219,7 @@ EXCLUDED_FOLDERS = {"pr-audit", "wes-clinical-report-es"}
 # Skills that are MVP (have working Python + are in SKILLS dict or are bio-orchestrator)
 MVP_FOLDERS = {
     "pharmgx-reporter", "equity-scorer", "nutrigx_advisor", "claw-metagenomics",
-    "scrna-orchestrator", "scrna-embedding",
+    "nfcore-scrnaseq-wrapper", "scrna-orchestrator", "scrna-embedding",
     "genome-compare", "drug-photo", "gwas-prs", "clinpgx", "gwas-lookup",
     "bigquery-public",
     "profile-report", "bio-orchestrator", "claw-ancestry-pca", "claw-semantic-sim",
@@ -240,6 +241,7 @@ TRIGGER_KEYWORDS: dict[str, list[str]] = {
     "genome-compare": ["genome comparison", "IBS", "George Church", "Corpasome", "pairwise"],
     "equity-scorer": ["HEIM", "equity", "FST", "heterozygosity", "population representation"],
     "nutrigx_advisor": ["nutrition", "nutrigenomics", "diet genetics", "MTHFR", "caffeine", "lactose"],
+    "nfcore-scrnaseq-wrapper": ["scrnaseq", "nf-core scrnaseq", "single-cell preprocessing", "10x fastq", "generate h5ad from fastq"],
     "scrna-orchestrator": ["single-cell", "scrna", "h5ad", "mtx", "10x", "scanpy", "umap", "leiden"],
     "scrna-embedding": ["scvi", "scanvi", "latent", "embedding", "integration", "batch correction", "10x"],
     "rnaseq-de": ["differential expression", "bulk rna", "rna-seq", "count matrix", "deseq2", "pydeseq2"],
@@ -267,6 +269,7 @@ CHAINING: dict[str, list[str]] = {
     "genome-compare": ["claw-ancestry-pca", "profile-report"],
     "equity-scorer": ["claw-semantic-sim"],
     "nutrigx_advisor": ["profile-report", "pharmgx-reporter"],
+    "nfcore-scrnaseq-wrapper": ["scrna-orchestrator", "scrna-embedding", "bio-orchestrator"],
     "scrna-orchestrator": [],
     "scrna-embedding": ["scrna-orchestrator"],
     "rnaseq-de": ["diff-visualizer"],

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "generated_by": "scripts/generate_catalog.py",
-  "skill_count": 63,
+  "skill_count": 64,
   "galaxy_tool_count": 8182,
   "skills": [
     {
@@ -92,7 +92,7 @@
       "has_script": true,
       "has_tests": true,
       "has_demo": true,
-      "demo_command": "python skills/archaic-introgression/archaic_introgression.py --demo",
+      "demo_command": "python skills/archaic-introgression/pipeline.py --demo",
       "dependencies": [],
       "tags": [],
       "trigger_keywords": [],
@@ -385,7 +385,7 @@
       "has_script": true,
       "has_tests": true,
       "has_demo": true,
-      "demo_command": "python skills/clinical-trial-finder/opentargets.py --demo",
+      "demo_command": "python skills/clinical-trial-finder/euctr.py --demo",
       "dependencies": [
         "python>=3.11"
       ],
@@ -419,7 +419,7 @@
       "has_script": true,
       "has_tests": true,
       "has_demo": true,
-      "demo_command": "python skills/clinical-variant-reporter/clinical_variant_reporter.py --demo",
+      "demo_command": "python skills/clinical-variant-reporter/acmg_engine.py --demo",
       "dependencies": [],
       "tags": [
         "acmg",
@@ -960,7 +960,7 @@
       "has_script": true,
       "has_tests": true,
       "has_demo": true,
-      "demo_command": "python skills/illumina-bridge/illumina_providers.py --demo",
+      "demo_command": "python skills/illumina-bridge/illumina_bridge.py --demo",
       "dependencies": [],
       "tags": [
         "illumina",
@@ -1193,6 +1193,51 @@
       "chaining_partners": []
     },
     {
+      "name": "nfcore-scrnaseq-wrapper",
+      "cli_alias": "scrnaseq-pipeline",
+      "description": "Wrapper skill for running nf-core/scrnaseq-style single-cell RNA-seq preprocessing from FASTQ with strict preflight, reproducibility outputs, and downstream handoff to ClawBio scRNA skills.",
+      "version": "0.1.0",
+      "status": "mvp",
+      "has_script": true,
+      "has_tests": true,
+      "has_demo": true,
+      "demo_command": "python clawbio.py run scrnaseq-pipeline --demo",
+      "dependencies": [
+        "python>=3.11"
+      ],
+      "tags": [
+        "scrna",
+        "single-cell",
+        "nextflow",
+        "nf-core",
+        "fastq",
+        "10x",
+        "h5ad",
+        "preprocessing"
+      ],
+      "trigger_keywords": [
+        "scrnaseq",
+        "nf-core scrnaseq",
+        "run scrnaseq from fastq",
+        "preprocess 10x fastqs",
+        "generate h5ad from single-cell fastq",
+        "single-cell preprocessing",
+        "nextflow scrna pipeline",
+        "10x chromium fastq pipeline",
+        "starsolo upstream processing",
+        "alevin-fry fastq to counts",
+        "run nextflow scrnaseq",
+        "upstream single-cell pipeline",
+        "fastq to h5ad single cell",
+        "10x genomics fastq pipeline"
+      ],
+      "chaining_partners": [
+        "scrna-orchestrator",
+        "scrna-embedding",
+        "bio-orchestrator"
+      ]
+    },
+    {
       "name": "nutrigx-advisor",
       "cli_alias": null,
       "description": "Personalised nutrition report from consumer genetic data (23andMe, AncestryDNA, VCF) — interrogates nutritionally-relevant SNPs and generates actionable dietary guidance, all computed locally.",
@@ -1201,7 +1246,7 @@
       "has_script": true,
       "has_tests": true,
       "has_demo": true,
-      "demo_command": "python skills/nutrigx-advisor/parse_input.py --demo",
+      "demo_command": "python skills/nutrigx-advisor/score_variants.py --demo",
       "dependencies": [],
       "tags": [
         "nutrigenomics",
@@ -1454,7 +1499,7 @@
       "has_script": true,
       "has_tests": true,
       "has_demo": true,
-      "demo_command": "python skills/pubmed-summariser/pubmed_summariser.py --demo",
+      "demo_command": "python skills/pubmed-summariser/pubmed_api.py --demo",
       "dependencies": [],
       "tags": [],
       "trigger_keywords": [

--- a/skills/nfcore-scrnaseq-wrapper/README.md
+++ b/skills/nfcore-scrnaseq-wrapper/README.md
@@ -1,0 +1,37 @@
+# nfcore-scrnaseq-wrapper
+
+ClawBio wrapper for running the upstream `scrnaseq` Nextflow pipeline from FASTQ inputs with strict preflight, reproducibility artifacts, provenance, and explicit handoff to downstream ClawBio scRNA skills.
+
+## Scope
+
+- Upstream scRNA preprocessing from FASTQ via Nextflow.
+- Curated presets for `standard`/simpleaf, `star`, `kallisto`, `cellranger`, `cellrangerarc`, and `cellrangermulti`.
+- Validated samplesheet input with absolute normalized FASTQ paths.
+- Reproducibility bundle, provenance bundle, `report.md`, and `result.json`.
+- Canonical `.h5ad` detection for downstream `scrna` and `scrna-embedding`.
+
+## Out Of Scope
+
+- Clustering, marker detection, normalization, scVI/scANVI, or other downstream analysis.
+- Automatic chaining into downstream ClawBio skills.
+- Free-form Nextflow passthrough flags.
+- Running without preflight.
+
+## Quick Start
+
+```bash
+python clawbio.py run scrnaseq-pipeline --demo --output ./outputs/scrnaseq_demo
+```
+
+For real data:
+
+```bash
+python clawbio.py run scrnaseq-pipeline \
+  --input samplesheet.csv \
+  --output ./scrnaseq_run \
+  --preset star \
+  --protocol 10XV3 \
+  --genome GRCh38
+```
+
+Use `--check` to run preflight without launching Nextflow.

--- a/skills/nfcore-scrnaseq-wrapper/SKILL.md
+++ b/skills/nfcore-scrnaseq-wrapper/SKILL.md
@@ -1,0 +1,433 @@
+---
+name: nfcore-scrnaseq-wrapper
+description: Wrapper skill for running nf-core/scrnaseq-style single-cell RNA-seq preprocessing from FASTQ with strict preflight, reproducibility outputs, and downstream handoff to ClawBio scRNA skills.
+license: MIT
+metadata:
+  version: "0.1.0"
+  author: ClawBio
+  domain: transcriptomics
+  tags:
+    - scrna
+    - single-cell
+    - nextflow
+    - nf-core
+    - fastq
+    - 10x
+    - h5ad
+    - preprocessing
+  inputs:
+    - name: samplesheet
+      type: file
+      format:
+        - csv
+      description: Valid scrnaseq samplesheet with sample, fastq_1, fastq_2 columns
+      required: true
+  outputs:
+    - name: report
+      type: file
+      format:
+        - md
+      description: Wrapper run summary and downstream handoff recommendations
+    - name: result
+      type: file
+      format:
+        - json
+      description: Structured result payload with detected outputs and provenance
+  dependencies:
+    python: ">=3.11"
+    packages: []
+  demo_data:
+    - path: demo/README.md
+      description: Demo mode uses the upstream scrnaseq test profile rather than bundled sample data
+  endpoints:
+    cli: python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py --input {samplesheet} --output {output_dir}
+  openclaw:
+    requires:
+      bins:
+        - python3
+        - nextflow
+        - java
+      env: []
+      config: []
+    always: false
+    emoji: "🧫"
+    homepage: https://github.com/ClawBio/ClawBio
+    os:
+      - darwin
+      - linux
+    install: []
+    trigger_keywords:
+      - scrnaseq
+      - nf-core scrnaseq
+      - run scrnaseq from fastq
+      - preprocess 10x fastqs
+      - generate h5ad from single-cell fastq
+      - single-cell preprocessing
+      - nextflow scrna pipeline
+      - 10x chromium fastq pipeline
+      - starsolo upstream processing
+      - alevin-fry fastq to counts
+      - run nextflow scrnaseq
+      - upstream single-cell pipeline
+      - fastq to h5ad single cell
+      - 10x genomics fastq pipeline
+---
+
+# 🧫 nfcore-scrnaseq-wrapper
+
+You are **nfcore-scrnaseq-wrapper**, a specialised ClawBio agent for upstream single-cell RNA-seq preprocessing from FASTQ using the `scrnaseq` Nextflow pipeline.
+
+## Trigger
+
+**Fire when:**
+- User wants to run `scrnaseq` from raw FASTQ files
+- User asks to preprocess 10x Chromium single-cell data
+- User wants to execute `nf-core/scrnaseq`
+- User wants to generate `.h5ad` from raw single-cell FASTQs
+- User asks for primary scRNA preprocessing (FASTQ → h5ad)
+- User mentions `simpleaf`, `STARsolo`, or `kb-python` as the aligner for upstream processing
+
+**Do NOT fire when:**
+- User already has an `.h5ad` and wants clustering, UMAP, or markers → route to `scrna-orchestrator`
+- User asks for scVI, scANVI, batch correction, or dimensionality reduction → route to `scrna-embedding`
+- User asks about bulk RNA-seq, differential expression, or pseudo-bulk analysis → route to `rnaseq-de`
+- Input is an already-processed count matrix, not raw FASTQs
+
+## Scope
+
+One skill, one task: run upstream scRNA preprocessing from FASTQ using the `scrnaseq` Nextflow pipeline and produce canonical outputs for downstream ClawBio skills.
+
+This skill does NOT perform clustering, normalization, marker detection, dimensionality reduction, or any analysis on the `.h5ad` it produces.
+
+## Why This Exists
+
+Running upstream scRNA pipelines manually is error-prone.
+
+- **Without it**: Users hand-build samplesheets, guess reference combinations, miss backend issues, and struggle to find the right `.h5ad` for downstream analysis.
+- **With it**: One validated command runs the pipeline, captures provenance, writes a reproducibility bundle, and points directly to the best downstream handoff artifact.
+- **Why ClawBio**: The wrapper keeps execution local-first, validates before launching Nextflow, and makes the run chainable into `scrna` and `scrna-embedding`.
+
+## Core Capabilities
+
+1. **Strict Preflight**: Validate Java, Nextflow, backend, samplesheet, FASTQs, and references before execution.
+2. **Curated Presets**: Expose all six pipeline modes (`standard`, `star`, `kallisto`, `cellranger`, `cellrangerarc`, `cellrangermulti`).
+3. **Controlled Execution**: Always run with `-params-file`, fixed pipeline source, and explicit reproducibility artifacts.
+4. **Output Resolution**: Detect MultiQC, pipeline_info, `.h5ad`, `.rds`, and choose a canonical `preferred_h5ad` when possible.
+5. **Downstream Handoff**: Recommend the next command for `scrna-orchestrator` (auto via `--run-downstream`); `scrna-embedding` can follow as a second step.
+
+## Input Formats
+
+| Format | Extension | Required Fields | Example |
+|--------|-----------|-----------------|---------|
+| Samplesheet | `.csv` | `sample`, `fastq_1`, `fastq_2` | `samplesheet.csv` |
+| Samplesheet CSV | `.csv` | `sample`, `fastq_1`, `fastq_2`; optional `expected_cells` and preset-specific columns | `--input samplesheet.csv` |
+| Demo mode | n/a | none | `python clawbio.py run scrnaseq-pipeline --demo` |
+
+## Workflow
+
+When the user asks for scRNA preprocessing from FASTQ:
+
+1. **Validate**: Check the selected preset, samplesheet structure, FASTQ accessibility, references, Java, Nextflow, and backend.
+2. **Normalize**: Write a validated samplesheet copy into the reproducibility bundle.
+3. **Configure**: Build one effective `params.yaml` and a fixed Nextflow command.
+4. **Execute**: Run the upstream `scrnaseq` pipeline using the local checkout when available.
+5. **Parse**: Detect MultiQC, pipeline_info, `.h5ad`, `.rds`, and CellBender-derived outputs.
+6. **Generate**: Write `report.md`, `result.json`, provenance JSON files, and reproducibility files.
+7. **Hand off**: Recommend the next ClawBio command using the preferred `.h5ad` when available.
+
+## Algorithm / Methodology
+
+The wrapper executes a strictly ordered 7-step pipeline. Each step is gated: a failure at any step raises a structured `SkillError` with an `error_code` and a `fix` hint, and no subsequent step runs.
+
+1. **Pipeline source resolution** (`pipeline_source.py`): Determine whether to use a local sibling `scrnaseq/` checkout (pinned commit, audit-safe) or fall back to the remote pipeline tag. Local checkouts always take priority.
+
+2. **Samplesheet validation** (`samplesheet_builder.py`): Parse the user-supplied CSV, resolve all FASTQ paths against the CSV's parent directory (not CWD), normalize whitespace in sample names to underscores, verify readability and FASTQ extensions, reject FASTQ basenames with whitespace, preserve upstream/preset-specific columns, reject exact duplicate FASTQ rows, enforce consistent `expected_cells` and `seq_center` for repeated sample rows, reject `expected_cells < 1`, and write a normalized copy with absolute POSIX FASTQ paths to `reproducibility/samplesheet.valid.csv`.
+
+3. **Preflight** (`preflight.py`): Verify Java (≥17), Nextflow (≥25.04.0), and the selected backend (`docker`, `conda`, `singularity`, or `apptainer`). For Docker, run `docker info` and gate on its exit code. Compare version tuples after zero-padding to 3 elements (avoids `(25, 4) < (25, 4, 0)` false negatives). All subprocess calls have a 30-second timeout.
+
+4. **Params construction** (`params_builder.py`): Translate the preset + CLI flags into a `params.yaml` that Nextflow consumes via `-params-file`. All paths use `.as_posix()` for forward-slash consistency across platforms.
+
+5. **Command build + execution** (`command_builder.py`, `executor.py`): Construct the `nextflow run` command with `-params-file` and `-work-dir <output>/upstream/work`, then launch it via `subprocess.Popen` with stdout and stderr piped directly to log files on disk — never buffered in RAM. On `TimeoutExpired`, the process is killed and `EXECUTION_FAILED` is raised.
+
+6. **Output parsing** (`outputs_parser.py`): Scan the output tree for MultiQC HTML, `pipeline_info/`, `.h5ad` (combined matrix preferred over per-sample), `.rds`, and CellBender-derived files. Set `handoff_available = True` only when a `preferred_h5ad` is confirmed on disk.
+
+7. **Provenance + reporting** (`provenance.py`, `reporting.py`): Write JSON provenance bundles, a SHA-256 checksum manifest, `environment.yml`, a reproducibility shell script, `report.md`, and `result.json`. SHA-256 is computed only on `is_file()` paths — never on directories such as `star_index/`.
+
+## Presets
+
+| Preset | Aligner | Use case |
+|--------|---------|---------|
+| `standard` | simpleaf (alevin-fry) | Default for 10x GEX; fast, memory-efficient |
+| `star` | STARsolo | Best FASTQ QC metrics; supports RNA velocity (`--star-feature "Gene Velocyto"`) |
+| `kallisto` | kb-python / BUStools | Pseudo-alignment; fastest; lamanno/nac RNA velocity via `--kb-workflow` |
+| `cellranger` | CellRanger | CellRanger v2/v3 compatibility; requires CellRanger binary in PATH |
+| `cellrangerarc` | CellRanger ARC | Multiome (GEX + ATAC); accepts prebuilt `--cellranger-index` or reference-build inputs |
+| `cellrangermulti` | CellRanger Multi | GEX + VDJ + feature barcoding in one run; `--cellranger-multi-barcodes` is required for CMO/multiplexed assignments and FFPE probe-set demultiplexing |
+
+Each preset requires at least one reference option (in priority order): `--genome <iGenomes_name>` OR a pre-built index (`--star-index`, `--simpleaf-index`, etc.) OR `--fasta` + `--gtf`.
+
+## CLI Reference
+
+```bash
+# Standard usage
+python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py \
+  --input samplesheet.csv --output ./scrnaseq_wrapper_run
+
+# Preflight check only (no Nextflow execution)
+python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py \
+  --input samplesheet.csv --output ./scrnaseq_wrapper_run --check
+
+# Demo mode (uses nf-core test profile; forces star preset; Docker must be running)
+python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py \
+  --demo --output ./scrnaseq_wrapper_demo
+
+# Via ClawBio runner
+python clawbio.py run scrnaseq-pipeline --input samplesheet.csv --output ./scrnaseq_wrapper_run
+python clawbio.py run scrnaseq-pipeline --demo --output ./scrnaseq_wrapper_demo
+
+# STARsolo with iGenomes reference
+python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py \
+  --input samplesheet.csv --output ./run --preset star --genome GRCh38
+
+# STARsolo RNA velocity
+python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py \
+  --input samplesheet.csv --output ./run --preset star \
+  --star-feature "Gene Velocyto" --star-ignore-sjdbgtf \
+  --fasta /refs/hg38.fa --gtf /refs/hg38.gtf
+
+# Kallisto RNA velocity (NAC workflow)
+python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py \
+  --input samplesheet.csv --output ./run --preset kallisto \
+  --kb-workflow nac --fasta /refs/hg38.fa --gtf /refs/hg38.gtf
+
+# CellRanger ARC (Multiome)
+python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py \
+  --input samplesheet.csv --output ./run --preset cellrangerarc \
+  --genome GRCh38 \
+  --cellrangerarc-reference GRCh38-2020-A-2.0.0 \
+  --cellrangerarc-config /refs/arc_config.json \
+  --motifs /refs/motifs.pfm
+
+# CellRanger Multi (multiplexed)
+python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py \
+  --input samplesheet.csv --output ./run --preset cellrangermulti \
+  --cellranger-index /refs/refdata-gex-GRCh38 \
+  --gex-cmo-set /refs/cmo_set.csv \
+  --fb-reference /refs/feature_barcodes.csv
+```
+
+### Key flags
+
+| Flag | Type | Description |
+|------|------|-------------|
+| `--preset` | string | Aligner preset (default: `standard`) |
+| `--profile` | string | Execution backend: `docker`, `conda`, `singularity`, `apptainer` (default: `docker`) |
+| `--pipeline-version` | string | Remote `nf-core/scrnaseq` tag or commit used when no local sibling checkout is found (default: `4.1.0`) |
+| `--genome` | string | iGenomes shortcut (`GRCh38`, `mm10`, etc.) — mutually exclusive with `--fasta`/`--gtf` |
+| `--fasta` | path | Genome FASTA (resolved to absolute POSIX path) |
+| `--gtf` | path | GTF annotation |
+| `--barcode-whitelist` | path | Custom barcode whitelist file (per-aligner format) — overrides aligner defaults |
+| `--star-feature` | enum | STARsolo feature type: `Gene`, `GeneFull`, `Gene Velocyto` |
+| `--star-ignore-sjdbgtf` | flag | Do not use GTF for SJDB (use with RNA velocity) |
+| `--kb-workflow` | enum | Kallisto workflow: `standard`, `lamanno`, `nac` |
+| `--kb-t1c` | path | cDNA t2c file for RNA velocity (lamanno/nac) |
+| `--kb-t2c` | path | Intron t2c file for RNA velocity (lamanno/nac) |
+| `--simpleaf-umi-resolution` | enum | UMI strategy: `cr-like`, `cr-like-em`, `parsimony`, `parsimony-em`, `parsimony-gene`, `parsimony-gene-em` |
+| `--skip-fastqc` | flag | Skip FastQC (when QC was done externally) |
+| `--skip-multiqc` | flag | Skip MultiQC report generation |
+| `--skip-cellbender` | flag | Disable CellBender ambient RNA removal. Upstream never runs CellBender for `cellrangerarc`, regardless of this flag |
+| `--skip-emptydrops` | flag | Deprecated compatibility alias for `--skip-cellbender`; replay commands use `--skip-cellbender` |
+| `--skip-cellranger-renaming` | flag | Skip automatic sample renaming in CellRanger |
+| `--skip-cellrangermulti-vdjref` | flag | Skip mkvdjref in cellrangermulti only when there is no VDJ data or a prebuilt `--cellranger-vdj-index` is supplied |
+| `--save-reference` | flag | Save the built reference index for future reuse |
+| `--save-align-intermeds` | flag | Save alignment intermediate BAM files |
+| `--email` | string | Email for pipeline completion notification |
+| `--multiqc-title` | string | Custom title for the MultiQC report |
+| `--seq-center` | string | Sequencing center name for BAM read group tag |
+| `--expected-cells` | int | Override expected cells count (≥1) |
+| `--protocol` | string | Chemistry/protocol. Required and non-`auto` for `standard`, `star`, and `kallisto`; `standard`/Simpleaf rejects `smartseq`; `cellranger` accepts only `auto` or `10XV1`-`10XV4`; ARC accepts only `auto` |
+| `--resume` | flag | Nextflow resume (checksum-verified against prior run) |
+| `--run-downstream` | flag | Opt in to `scrna_orchestrator` handoff after pipeline completion |
+| `--skip-downstream` | flag | Compatibility flag; downstream handoff is skipped unless `--run-downstream` is set |
+| `--gex-frna-probe-set` | path | Probe set CSV for fixed RNA profiling on FFPE samples (`cellrangermulti`) |
+| `--gex-target-panel` | path | Target panel CSV for targeted gene expression (`cellrangermulti`) |
+| `--gex-barcode-sample-assignment` | path | Barcode-to-sample assignment CSV for OCM multiplexing (`cellrangermulti`) |
+| `--vdj-inner-enrichment-primers` | path | Text file with V(D)J cDNA enrichment primer sequences (`cellrangermulti`) |
+
+## Example Queries
+
+The following are concrete user phrases that should route to this skill:
+
+- *"I have 10x Chromium FASTQs from three donors. How do I get an h5ad I can cluster?"*
+- *"Run nf-core/scrnaseq on my samplesheet and give me a reproducibility bundle."*
+- *"I want to preprocess single-cell data from FASTQ using STARsolo. Can you set it up?"*
+- *"Generate a combined_filtered_matrix.h5ad from these FASTQ files using alevin-fry."*
+- *"We have paired-end FASTQ files from a 10x Genomics Chromium v3 experiment. Run the upstream scRNA pipeline."*
+- *"Demo mode — show me what the scrnaseq wrapper produces without any input files."*
+
+## Demo
+
+```bash
+python clawbio.py run scrnaseq-pipeline --demo --output ./outputs/scrnaseq_demo
+```
+
+Expected output:
+- wrapper-level `report.md`
+- wrapper-level `result.json`
+- `logs/`
+- `provenance/`
+- `reproducibility/`
+- upstream `results/` tree under `upstream/`
+
+## Output Structure
+
+```text
+output_directory/
+├── report.md
+├── result.json
+├── logs/
+│   ├── stdout.txt
+│   └── stderr.txt
+├── upstream/
+│   └── results/
+├── reproducibility/
+│   ├── samplesheet.valid.csv
+│   ├── commands.sh
+│   ├── params.yaml
+│   ├── environment.yml
+│   ├── checksums.sha256
+│   └── manifest.json
+└── provenance/
+    ├── upstream.json
+    ├── skill.json
+    ├── invocation.json
+    ├── inputs.json
+    ├── outputs.json
+    ├── runtime.json
+    └── preflight.json
+```
+
+## Dependencies
+
+**Required**:
+- `nextflow`
+- `java` 17+
+- one supported backend (`docker`, `conda`, `singularity`, or `apptainer`)
+
+**Optional**:
+- local sibling checkout of `scrnaseq` for pinned local execution
+
+## Safety
+
+- **Local-first**: User FASTQs and outputs remain local.
+- **Strict preflight**: Do not launch Nextflow if validation fails.
+- **Controlled surface**: No arbitrary passthrough flags in v1.
+- **Disclaimer**: Every report includes the ClawBio disclaimer.
+- **No hallucinated outputs**: Report only artifacts that were actually detected on disk.
+
+## Example Output
+
+After a successful run, `result.json` contains:
+
+```json
+{
+  "skill": "scrnaseq-pipeline",
+  "version": "0.1.0",
+  "summary": {
+    "preset": "star",
+    "aligner_effective": "star",
+    "pipeline_source_kind": "local_checkout",
+    "pipeline_version_or_commit": "abc1234abcde",
+    "profile": "docker",
+    "resume_used": false,
+    "preferred_h5ad": "output/upstream/results/star/mtx_conversions/combined_filtered_matrix.h5ad",
+    "handoff_available": true,
+    "samples_detected": 2,
+    "cellbender_used": false,
+    "output_artifacts": {
+      "preferred_h5ad": "output/upstream/results/star/mtx_conversions/combined_filtered_matrix.h5ad",
+      "multiqc_report": "output/upstream/results/multiqc/star/multiqc_report.html",
+      "pipeline_info_dir": "output/upstream/results/pipeline_info",
+      "h5ad_candidates": [
+        "output/upstream/results/star/mtx_conversions/combined_filtered_matrix.h5ad"
+      ],
+      "rds_candidates": []
+    }
+  }
+}
+```
+
+And `report.md` closes with:
+```
+## Next Steps
+
+- `python clawbio.py run scrna --input output/upstream/.../combined_filtered_matrix.h5ad --output <dir>`
+- `python clawbio.py run scrna-embedding --input output/upstream/.../combined_filtered_matrix.h5ad --output <dir>`
+```
+
+## Gotchas
+
+- **Preflight runs before any Nextflow call.** If Java, Nextflow, or Docker are missing, the pipeline never starts and you get a structured JSON error with `error_code` and a `fix` hint. Do not try to skip preflight.
+- **`--resume` enforces strict compatibility.** The wrapper checks that the stored manifest matches the current preset, profile, and pipeline source. If any differ, it raises `INVALID_RESUME_STATE` rather than silently continuing with incompatible state.
+- **`--demo` runs the pipeline's real `test` profile, not bundled sample data.** It exercises the full Nextflow code path with the upstream test fixtures. Docker must be running. Output reflects what `nf-core/scrnaseq -profile test,docker` produces.
+- **`preferred_h5ad` may be empty.** If no combined matrix is found and there are multiple per-sample files, `handoff_available` is `false`. Always check `result.json` before chaining to `scrna-orchestrator` or manually invoking `scrna-embedding`.
+- **No arbitrary Nextflow passthrough.** You cannot add `-c`, `--outdir`, or custom Nextflow flags. All pipeline configuration flows through the preset system and `params.yaml`. Attempting to inject flags directly is blocked by the wrapper's CLI contract.
+- **`--genome` conflicts with any explicit reference flag.** Providing `--genome` alongside any of `--fasta`, `--gtf`, `--star-index`, `--simpleaf-index`, `--kallisto-index`, `--cellranger-index`, `--transcript-fasta`, or `--txp2gene` raises `CONFLICTING_REFERENCES` in preflight. Use either `--genome <shortcut>` or explicit reference/index flags — never both.
+- **Protocol compatibility is enforced before Nextflow starts.** `standard`/Simpleaf, `star`, and `kallisto` cannot rely on upstream `protocol=auto`, so provide an explicit protocol such as `10XV3`, `dropseq`, or a supported custom chemistry string. `standard`/Simpleaf rejects `smartseq`; use `star` or `kallisto` for Smart-seq data. `cellranger` accepts only `auto` or `10XV1`-`10XV4`; `cellrangerarc` accepts only `auto`.
+- **`--skip-emptydrops` is deprecated upstream.** The wrapper still accepts it for old commands, but normalizes it to the canonical `skip_cellbender` parameter in `params.yaml` and replay scripts.
+- **CellBender follows upstream behavior.** CellBender runs by default when supported and is disabled by `--skip-cellbender` (or deprecated `--skip-emptydrops`). The upstream workflow never runs CellBender for `cellrangerarc`, even when `skip_cellbender=false`.
+- **Schema-incompatible paths fail early.** The wrapper writes `params.input` as a relative bundle path and rejects FASTA paths that do not match the nf-core/scrnaseq 4.1.0 schema (`.fa`, `.fna`, `.fasta`, and gzip variants, with no whitespace).
+- **RNA velocity requires two coordinated flags.** For STARsolo, pass `--star-feature "Gene Velocyto"` AND `--star-ignore-sjdbgtf` together — the former selects the feature type, the latter suppresses GTF-based SJDB construction (required for velocity matrices). For Kallisto, use `--kb-workflow lamanno` or `nac` with `--kb-t1c` and `--kb-t2c`.
+- **`cellrangerarc` follows the upstream ARC rules.** It accepts a prebuilt `--cellranger-index`, or builds from `--genome` / `--fasta` + `--gtf`. `--motifs` is optional. If you provide a custom `--cellrangerarc-config`, you must also provide `--cellrangerarc-reference` (and vice versa), otherwise preflight fails with `INVALID_PRESET_CONFIGURATION`.
+- **`cellrangermulti` validates requirements from the samplesheet.** The main samplesheet must include `feature_type`. If `feature_type=ab`, preflight requires `--fb-reference`; if `feature_type=cmo`, preflight requires `--cellranger-multi-barcodes`; if `feature_type=vdj` and `--skip-cellrangermulti-vdjref` is set, preflight requires `--cellranger-vdj-index`. CMO, FFPE probe-set demultiplexing, and OCM assignment are treated as mutually exclusive multiplexing strategies.
+- **`--save-align-intermeds` defaults to false in `params.yaml`.** This overrides heavy upstream defaults unless the user explicitly requests alignment intermediates.
+- **`--check` writes `check_result.json` to the output directory.** This file is ignored by subsequent full runs. Running `--check` and a full run to the same `--output` directory is safe — `check_result.json` will be overwritten by `result.json` on success.
+- **`--demo` always forces `--preset star` and `--skip-cellbender`.** The nf-core test profile ships STAR-compatible data only. If you request another preset with `--demo`, the wrapper warns and overrides it.
+- **Local checkout must be a sibling directory.** The wrapper looks for `../scrnaseq` relative to the ClawBio repo root — both repos must share the same parent folder. If `scrnaseq/` is anywhere else, the wrapper silently falls back to downloading the remote pipeline from GitHub (slower, not pinned to a commit). To use the local path, ensure `ClawBio/` and `scrnaseq/` are siblings.
+
+## Agent Boundary
+
+The agent dispatches and explains; this skill executes.
+
+**The agent is responsible for:**
+- Interpreting the user's preprocessing intent and choosing the right preset
+- Verifying that `handoff_available` is true in `result.json` before routing to `scrna-orchestrator` (automatic) or `scrna-embedding` (manual follow-up)
+
+**This skill is responsible for:**
+- Validating the environment and inputs before any execution
+- Running the Nextflow pipeline with controlled, reproducible parameters
+- Writing all provenance, checksums, and reproducibility artifacts
+- Reporting the detected `preferred_h5ad` for downstream handoff
+
+## Integration with Bio Orchestrator
+
+**Trigger conditions**:
+- user wants to run `scrnaseq` from FASTQs
+- user asks for upstream scRNA preprocessing
+- user wants `.h5ad` generation from raw single-cell FASTQs
+
+**Do NOT route here when**:
+- the user already has `.h5ad` and wants clustering, markers, or UMAP
+- the user wants scVI/scANVI or batch correction downstream
+
+**Chaining partners**:
+- `scrna-orchestrator`: downstream clustering and markers from `preferred_h5ad`
+- `scrna-embedding`: downstream scVI/scANVI from `preferred_h5ad`
+
+## Maintenance
+
+**Review cadence**: Review this skill whenever `nf-core/scrnaseq` releases a new major version (currently tracked at `nf-co.re/scrnaseq/changelog`). Check that `NEXTFLOW_MIN_VERSION` in `schemas.py` and the `SUPPORTED_PRESETS` map in `schemas.py` remain correct.
+
+**Staleness signals**:
+- `preflight.py` raises `NEXTFLOW_VERSION_TOO_OLD` on a version that the current nf-core release explicitly supports — update `NEXTFLOW_MIN_VERSION` in `schemas.py`.
+- New aligners appear in the upstream `scrnaseq` pipeline but are not in `SUPPORTED_PRESETS` — add them to `schemas.py` and update this SKILL.md and the test suite.
+- The VirtioFS macOS workaround (`stageInMode = "copy"`) is only necessary while Apple Silicon runs Docker via QEMU. If Apple releases a native arm64 Docker runtime that eliminates VirtioFS deadlocks, remove `_write_macos_docker_config` and its tests.
+- The local sibling checkout path (`../scrnaseq`) is a convention for this thesis environment. Downstream deployments should configure `CLAWBIO_SCRNASEQ_PATH` or equivalent.
+
+**Deprecation criteria**: Deprecate this skill if nf-core/scrnaseq releases a Python SDK that exposes equivalent preflight, params, and provenance APIs — at that point the wrapper adds less value than it costs in maintenance.
+
+## Citations
+
+- [nf-core/scrnaseq](https://nf-co.re/scrnaseq)
+- [Nextflow](https://www.nextflow.io/)
+- [Alevin-fry / Simpleaf](https://simpleaf.readthedocs.io/)

--- a/skills/nfcore-scrnaseq-wrapper/SKILL.md
+++ b/skills/nfcore-scrnaseq-wrapper/SKILL.md
@@ -1,81 +1,59 @@
 ---
 name: nfcore-scrnaseq-wrapper
-description: Wrapper skill for running nf-core/scrnaseq-style single-cell RNA-seq preprocessing from FASTQ with strict preflight, reproducibility outputs, and downstream handoff to ClawBio scRNA skills.
+version: "0.1.0"
+author: ClawBio
+description: Wrapper skill for running nf-core/scrnaseq upstream single-cell RNA-seq preprocessing from FASTQ with strict preflight, reproducibility outputs, and downstream handoff to ClawBio scRNA skills.
+inputs:
+  - name: samplesheet
+    type: file
+    format: [csv]
+    description: "nf-core/scrnaseq samplesheet CSV with required columns: sample, fastq_1, fastq_2"
+    required: true
+outputs:
+  - name: report
+    type: file
+    format: [md]
+    description: Wrapper run summary and downstream handoff recommendations
+  - name: result
+    type: file
+    format: [json]
+    description: Structured result payload with detected outputs and provenance
+trigger_keywords:
+  - scrnaseq
+  - nf-core scrnaseq
+  - run scrnaseq from fastq
+  - preprocess 10x fastqs
+  - generate h5ad from single-cell fastq
+  - single-cell preprocessing
+  - nextflow scrna pipeline
+  - 10x chromium fastq pipeline
+  - starsolo upstream processing
+  - alevin-fry fastq to counts
+  - run nextflow scrnaseq
+  - upstream single-cell pipeline
+  - fastq to h5ad single cell
+  - 10x genomics fastq pipeline
 license: MIT
 metadata:
-  version: "0.1.0"
-  author: ClawBio
   domain: transcriptomics
-  tags:
-    - scrna
-    - single-cell
-    - nextflow
-    - nf-core
-    - fastq
-    - 10x
-    - h5ad
-    - preprocessing
-  inputs:
-    - name: samplesheet
-      type: file
-      format:
-        - csv
-      description: Valid scrnaseq samplesheet with sample, fastq_1, fastq_2 columns
-      required: true
-  outputs:
-    - name: report
-      type: file
-      format:
-        - md
-      description: Wrapper run summary and downstream handoff recommendations
-    - name: result
-      type: file
-      format:
-        - json
-      description: Structured result payload with detected outputs and provenance
+  tags: [scrna, single-cell, nextflow, nf-core, fastq, 10x, h5ad, preprocessing]
   dependencies:
     python: ">=3.11"
     packages: []
-  demo_data:
-    - path: demo/README.md
-      description: Demo mode uses the upstream scrnaseq test profile rather than bundled sample data
   endpoints:
     cli: python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py --input {samplesheet} --output {output_dir}
   openclaw:
     requires:
-      bins:
-        - python3
-        - nextflow
-        - java
-      env: []
-      config: []
+      bins: [python3, nextflow, java]
     always: false
     emoji: "🧫"
     homepage: https://github.com/ClawBio/ClawBio
-    os:
-      - darwin
-      - linux
-    install: []
-    trigger_keywords:
-      - scrnaseq
-      - nf-core scrnaseq
-      - run scrnaseq from fastq
-      - preprocess 10x fastqs
-      - generate h5ad from single-cell fastq
-      - single-cell preprocessing
-      - nextflow scrna pipeline
-      - 10x chromium fastq pipeline
-      - starsolo upstream processing
-      - alevin-fry fastq to counts
-      - run nextflow scrnaseq
-      - upstream single-cell pipeline
-      - fastq to h5ad single cell
-      - 10x genomics fastq pipeline
+    os: [darwin, linux]
 ---
 
-# 🧫 nfcore-scrnaseq-wrapper
+# nfcore-scrnaseq-wrapper
 
-You are **nfcore-scrnaseq-wrapper**, a specialised ClawBio agent for upstream single-cell RNA-seq preprocessing from FASTQ using the `scrnaseq` Nextflow pipeline.
+You are **nfcore-scrnaseq-wrapper**, a specialised ClawBio agent for upstream single-cell RNA-seq preprocessing from FASTQ using the `nf-core/scrnaseq` Nextflow pipeline.
 
 ## Trigger
 
@@ -85,7 +63,7 @@ You are **nfcore-scrnaseq-wrapper**, a specialised ClawBio agent for upstream si
 - User wants to execute `nf-core/scrnaseq`
 - User wants to generate `.h5ad` from raw single-cell FASTQs
 - User asks for primary scRNA preprocessing (FASTQ → h5ad)
-- User mentions `simpleaf`, `STARsolo`, or `kb-python` as the aligner for upstream processing
+- User mentions `simpleaf`, `STARsolo`, `alevin-fry`, or `kb-python` for upstream processing
 
 **Do NOT fire when:**
 - User already has an `.h5ad` and wants clustering, UMAP, or markers → route to `scrna-orchestrator`
@@ -95,15 +73,13 @@ You are **nfcore-scrnaseq-wrapper**, a specialised ClawBio agent for upstream si
 
 ## Scope
 
-One skill, one task: run upstream scRNA preprocessing from FASTQ using the `scrnaseq` Nextflow pipeline and produce canonical outputs for downstream ClawBio skills.
+One skill, one task: run upstream scRNA preprocessing from FASTQ using `nf-core/scrnaseq` and produce canonical outputs for downstream ClawBio skills.
 
 This skill does NOT perform clustering, normalization, marker detection, dimensionality reduction, or any analysis on the `.h5ad` it produces.
 
 ## Why This Exists
 
-Running upstream scRNA pipelines manually is error-prone.
-
-- **Without it**: Users hand-build samplesheets, guess reference combinations, miss backend issues, and struggle to find the right `.h5ad` for downstream analysis.
+- **Without it**: Users hand-build samplesheets, guess reference combinations, miss backend issues, and struggle to locate the correct `.h5ad` for downstream analysis.
 - **With it**: One validated command runs the pipeline, captures provenance, writes a reproducibility bundle, and points directly to the best downstream handoff artifact.
 - **Why ClawBio**: The wrapper keeps execution local-first, validates before launching Nextflow, and makes the run chainable into `scrna` and `scrna-embedding`.
 
@@ -111,47 +87,44 @@ Running upstream scRNA pipelines manually is error-prone.
 
 1. **Strict Preflight**: Validate Java, Nextflow, backend, samplesheet, FASTQs, and references before execution.
 2. **Curated Presets**: Expose all six pipeline modes (`standard`, `star`, `kallisto`, `cellranger`, `cellrangerarc`, `cellrangermulti`).
-3. **Controlled Execution**: Always run with `-params-file`, fixed pipeline source, and explicit reproducibility artifacts.
-4. **Output Resolution**: Detect MultiQC, pipeline_info, `.h5ad`, `.rds`, and choose a canonical `preferred_h5ad` when possible.
-5. **Downstream Handoff**: Recommend the next command for `scrna-orchestrator` (auto via `--run-downstream`); `scrna-embedding` can follow as a second step.
+3. **Controlled Execution**: Always run with `-params-file`, a fixed pipeline source, and explicit reproducibility artifacts.
+4. **Output Resolution**: Detect MultiQC, pipeline_info, `.h5ad`, `.rds`, and select a canonical `preferred_h5ad` when possible.
+5. **Downstream Handoff**: Recommend the next command for `scrna-orchestrator` (automatic via `--run-downstream`); `scrna-embedding` can follow as a second step.
 
 ## Input Formats
 
-| Format | Extension | Required Fields | Example |
-|--------|-----------|-----------------|---------|
-| Samplesheet | `.csv` | `sample`, `fastq_1`, `fastq_2` | `samplesheet.csv` |
-| Samplesheet CSV | `.csv` | `sample`, `fastq_1`, `fastq_2`; optional `expected_cells` and preset-specific columns | `--input samplesheet.csv` |
-| Demo mode | n/a | none | `python clawbio.py run scrnaseq-pipeline --demo` |
+| Format | Extension | Required columns | Optional columns |
+|--------|-----------|------------------|------------------|
+| Samplesheet | `.csv` | `sample`, `fastq_1`, `fastq_2` | `expected_cells`, `seq_center`, `sample_type`, `fastq_barcode`, `feature_type` |
+| Demo mode | n/a | none — test profile provides its own data | — |
 
 ## Workflow
 
-When the user asks for scRNA preprocessing from FASTQ:
-
 1. **Validate**: Check the selected preset, samplesheet structure, FASTQ accessibility, references, Java, Nextflow, and backend.
-2. **Normalize**: Write a validated samplesheet copy into the reproducibility bundle.
+2. **Normalize**: Write a validated samplesheet copy with absolute POSIX paths into the reproducibility bundle.
 3. **Configure**: Build one effective `params.yaml` and a fixed Nextflow command.
-4. **Execute**: Run the upstream `scrnaseq` pipeline using the local checkout when available.
+4. **Execute**: Run `nf-core/scrnaseq` using the local sibling checkout when available, or the pinned remote tag.
 5. **Parse**: Detect MultiQC, pipeline_info, `.h5ad`, `.rds`, and CellBender-derived outputs.
-6. **Generate**: Write `report.md`, `result.json`, provenance JSON files, and reproducibility files.
-7. **Hand off**: Recommend the next ClawBio command using the preferred `.h5ad` when available.
+6. **Generate**: Write `report.md`, `result.json`, provenance JSON files, and reproducibility artifacts.
+7. **Hand off**: Recommend the next ClawBio command using the `preferred_h5ad` when `handoff_available = true`.
 
 ## Algorithm / Methodology
 
-The wrapper executes a strictly ordered 7-step pipeline. Each step is gated: a failure at any step raises a structured `SkillError` with an `error_code` and a `fix` hint, and no subsequent step runs.
+The wrapper executes a strictly ordered 7-step pipeline. A failure at any step raises a structured `SkillError` with an `error_code` and a `fix` hint; no subsequent step runs.
 
-1. **Pipeline source resolution** (`pipeline_source.py`): Determine whether to use a local sibling `scrnaseq/` checkout (pinned commit, audit-safe) or fall back to the remote pipeline tag. Local checkouts always take priority.
+1. **Pipeline source resolution** (`pipeline_source.py`): Prefer a local sibling `scrnaseq/` checkout (pinned commit, audit-safe). Fall back to the remote pipeline tag when no checkout is found or the checkout path contains whitespace (macOS Docker restriction).
 
-2. **Samplesheet validation** (`samplesheet_builder.py`): Parse the user-supplied CSV, resolve all FASTQ paths against the CSV's parent directory (not CWD), normalize whitespace in sample names to underscores, verify readability and FASTQ extensions, reject FASTQ basenames with whitespace, preserve upstream/preset-specific columns, reject exact duplicate FASTQ rows, enforce consistent `expected_cells` and `seq_center` for repeated sample rows, reject `expected_cells < 1`, and write a normalized copy with absolute POSIX FASTQ paths to `reproducibility/samplesheet.valid.csv`.
+2. **Samplesheet validation** (`samplesheet_builder.py`): Parse the CSV, resolve FASTQ paths relative to the CSV parent directory, normalize sample-name whitespace to underscores, verify readability and FASTQ extensions, reject FASTQ basenames with whitespace, enforce consistent `expected_cells` (≥1) and `seq_center` for repeated sample rows, reject exact duplicate FASTQ rows, and write a normalized copy with absolute POSIX paths to `reproducibility/samplesheet.valid.csv`.
 
-3. **Preflight** (`preflight.py`): Verify Java (≥17), Nextflow (≥25.04.0), and the selected backend (`docker`, `conda`, `singularity`, or `apptainer`). For Docker, run `docker info` and gate on its exit code. Compare version tuples after zero-padding to 3 elements (avoids `(25, 4) < (25, 4, 0)` false negatives). All subprocess calls have a 30-second timeout.
+3. **Preflight** (`preflight.py`): Verify Java (≥17) and Nextflow (≥25.04.0). Compare version tuples after zero-padding to 3 elements (avoids false negatives such as `(24, 4) < (24, 4, 0)`). For `docker`, run `docker info` and gate on exit code. For `conda`/`mamba`, locate the binary. For `singularity`/`apptainer`, accept either binary interchangeably. For `wave` and `gpu`, no binary check is needed (Nextflow-native features). All subprocess calls have a 30-second timeout.
 
-4. **Params construction** (`params_builder.py`): Translate the preset + CLI flags into a `params.yaml` that Nextflow consumes via `-params-file`. All paths use `.as_posix()` for forward-slash consistency across platforms.
+4. **Params construction** (`params_builder.py`): Translate the preset + CLI flags into a `params.yaml` consumed by Nextflow via `-params-file`. All file paths use `.as_posix()` for forward-slash consistency across platforms. `igenomes_ignore` is automatically set to `true` whenever any explicit reference path is provided (suppresses nf-schema DNS validation of the default iGenomes S3 URL). Skip flags are only written when `true`, keeping `params.yaml` minimal.
 
-5. **Command build + execution** (`command_builder.py`, `executor.py`): Construct the `nextflow run` command with `-params-file` and `-work-dir <output>/upstream/work`, then launch it via `subprocess.Popen` with stdout and stderr piped directly to log files on disk — never buffered in RAM. On `TimeoutExpired`, the process is killed and `EXECUTION_FAILED` is raised.
+5. **Command build + execution** (`command_builder.py`, `executor.py`): Construct the `nextflow run` command with `-params-file` and `-work-dir <output>/upstream/work`, then launch via `subprocess.Popen` with stdout and stderr piped to log files on disk — never buffered in RAM. On `TimeoutExpired`, the process is killed and `EXECUTION_FAILED` is raised.
 
-6. **Output parsing** (`outputs_parser.py`): Scan the output tree for MultiQC HTML, `pipeline_info/`, `.h5ad` (combined matrix preferred over per-sample), `.rds`, and CellBender-derived files. Set `handoff_available = True` only when a `preferred_h5ad` is confirmed on disk.
+6. **Output parsing** (`outputs_parser.py`): Scan the upstream results tree for MultiQC HTML, `pipeline_info/`, `.h5ad` (combined matrix preferred over per-sample, filtered preferred over raw), `.rds`, and CellBender-derived files. `handoff_available` is set to `true` only when a `preferred_h5ad` is confirmed on disk.
 
-7. **Provenance + reporting** (`provenance.py`, `reporting.py`): Write JSON provenance bundles, a SHA-256 checksum manifest, `environment.yml`, a reproducibility shell script, `report.md`, and `result.json`. SHA-256 is computed only on `is_file()` paths — never on directories such as `star_index/`.
+7. **Provenance + reporting** (`provenance.py`, `reporting.py`): Write JSON provenance bundles, a SHA-256 checksum manifest (files only — never directories), `environment.yml`, a portable `commands.sh`, `report.md`, and `result.json`.
 
 ## Presets
 
@@ -162,32 +135,38 @@ The wrapper executes a strictly ordered 7-step pipeline. Each step is gated: a f
 | `kallisto` | kb-python / BUStools | Pseudo-alignment; fastest; lamanno/nac RNA velocity via `--kb-workflow` |
 | `cellranger` | CellRanger | CellRanger v2/v3 compatibility; requires CellRanger binary in PATH |
 | `cellrangerarc` | CellRanger ARC | Multiome (GEX + ATAC); accepts prebuilt `--cellranger-index` or reference-build inputs |
-| `cellrangermulti` | CellRanger Multi | GEX + VDJ + feature barcoding in one run; `--cellranger-multi-barcodes` is required for CMO/multiplexed assignments and FFPE probe-set demultiplexing |
+| `cellrangermulti` | CellRanger Multi | GEX + VDJ + feature barcoding; `--cellranger-multi-barcodes` required for CMO/FFPE multiplexing |
 
-Each preset requires at least one reference option (in priority order): `--genome <iGenomes_name>` OR a pre-built index (`--star-index`, `--simpleaf-index`, etc.) OR `--fasta` + `--gtf`.
+Each preset requires at least one reference option: `--genome <iGenomes_shortcut>` OR a pre-built index (`--star-index`, `--simpleaf-index`, etc.) OR `--fasta` + `--gtf`.
 
 ## CLI Reference
 
 ```bash
 # Standard usage
 python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py \
-  --input samplesheet.csv --output ./scrnaseq_wrapper_run
+  --input samplesheet.csv --output ./scrnaseq_run
 
 # Preflight check only (no Nextflow execution)
 python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py \
-  --input samplesheet.csv --output ./scrnaseq_wrapper_run --check
+  --input samplesheet.csv --output ./scrnaseq_run --check
 
-# Demo mode (uses nf-core test profile; forces star preset; Docker must be running)
+# Demo mode (runs the upstream nf-core test profile; forces star preset; Docker must be running)
 python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py \
-  --demo --output ./scrnaseq_wrapper_demo
+  --demo --output ./scrnaseq_demo
 
 # Via ClawBio runner
-python clawbio.py run scrnaseq-pipeline --input samplesheet.csv --output ./scrnaseq_wrapper_run
-python clawbio.py run scrnaseq-pipeline --demo --output ./scrnaseq_wrapper_demo
+python clawbio.py run scrnaseq-pipeline --input samplesheet.csv --output ./scrnaseq_run
+python clawbio.py run scrnaseq-pipeline --demo --output ./scrnaseq_demo
 
-# STARsolo with iGenomes reference
+# STARsolo with local FASTA+GTF (STAR index built by the pipeline)
 python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py \
-  --input samplesheet.csv --output ./run --preset star --genome GRCh38
+  --input samplesheet.csv --output ./run --preset star --protocol 10XV3 \
+  --fasta /refs/hg38.fa --gtf /refs/hg38.gtf
+
+# STARsolo with prebuilt STAR index
+python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py \
+  --input samplesheet.csv --output ./run --preset star --protocol 10XV3 \
+  --star-index /refs/star_index
 
 # STARsolo RNA velocity
 python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py \
@@ -195,140 +174,124 @@ python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py \
   --star-feature "Gene Velocyto" --star-ignore-sjdbgtf \
   --fasta /refs/hg38.fa --gtf /refs/hg38.gtf
 
+# Simpleaf (standard) with UMI resolution override
+python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py \
+  --input samplesheet.csv --output ./run --preset standard --protocol 10XV3 \
+  --simpleaf-umi-resolution cr-like-em --genome GRCh38
+
 # Kallisto RNA velocity (NAC workflow)
 python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py \
   --input samplesheet.csv --output ./run --preset kallisto \
   --kb-workflow nac --fasta /refs/hg38.fa --gtf /refs/hg38.gtf
 
-# CellRanger ARC (Multiome)
+# Air-gapped cluster: local iGenomes mirror
 python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py \
-  --input samplesheet.csv --output ./run --preset cellrangerarc \
-  --genome GRCh38 \
-  --cellrangerarc-reference GRCh38-2020-A-2.0.0 \
-  --cellrangerarc-config /refs/arc_config.json \
-  --motifs /refs/motifs.pfm
+  --input samplesheet.csv --output ./run --preset star --protocol 10XV3 \
+  --genome GRCh38 --igenomes-base /mnt/local_igenomes
 
-# CellRanger Multi (multiplexed)
+# CellRanger Multi (CMO multiplexing)
 python skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py \
   --input samplesheet.csv --output ./run --preset cellrangermulti \
   --cellranger-index /refs/refdata-gex-GRCh38 \
   --gex-cmo-set /refs/cmo_set.csv \
-  --fb-reference /refs/feature_barcodes.csv
+  --cellranger-multi-barcodes /refs/multi_barcodes.csv
 ```
 
 ### Key flags
 
-| Flag | Type | Description |
-|------|------|-------------|
-| `--preset` | string | Aligner preset (default: `standard`) |
-| `--profile` | string | Execution backend: `docker`, `conda`, `singularity`, `apptainer` (default: `docker`) |
-| `--pipeline-version` | string | Remote `nf-core/scrnaseq` tag or commit used when no local sibling checkout is found (default: `4.1.0`) |
-| `--genome` | string | iGenomes shortcut (`GRCh38`, `mm10`, etc.) — mutually exclusive with `--fasta`/`--gtf` |
-| `--fasta` | path | Genome FASTA (resolved to absolute POSIX path) |
-| `--gtf` | path | GTF annotation |
-| `--barcode-whitelist` | path | Custom barcode whitelist file (per-aligner format) — overrides aligner defaults |
-| `--star-feature` | enum | STARsolo feature type: `Gene`, `GeneFull`, `Gene Velocyto` |
-| `--star-ignore-sjdbgtf` | flag | Do not use GTF for SJDB (use with RNA velocity) |
-| `--kb-workflow` | enum | Kallisto workflow: `standard`, `lamanno`, `nac` |
-| `--kb-t1c` | path | cDNA t2c file for RNA velocity (lamanno/nac) |
-| `--kb-t2c` | path | Intron t2c file for RNA velocity (lamanno/nac) |
-| `--simpleaf-umi-resolution` | enum | UMI strategy: `cr-like`, `cr-like-em`, `parsimony`, `parsimony-em`, `parsimony-gene`, `parsimony-gene-em` |
-| `--skip-fastqc` | flag | Skip FastQC (when QC was done externally) |
-| `--skip-multiqc` | flag | Skip MultiQC report generation |
-| `--skip-cellbender` | flag | Disable CellBender ambient RNA removal. Upstream never runs CellBender for `cellrangerarc`, regardless of this flag |
-| `--skip-emptydrops` | flag | Deprecated compatibility alias for `--skip-cellbender`; replay commands use `--skip-cellbender` |
-| `--skip-cellranger-renaming` | flag | Skip automatic sample renaming in CellRanger |
-| `--skip-cellrangermulti-vdjref` | flag | Skip mkvdjref in cellrangermulti only when there is no VDJ data or a prebuilt `--cellranger-vdj-index` is supplied |
-| `--save-reference` | flag | Save the built reference index for future reuse |
-| `--save-align-intermeds` | flag | Save alignment intermediate BAM files |
-| `--email` | string | Email for pipeline completion notification |
-| `--multiqc-title` | string | Custom title for the MultiQC report |
-| `--seq-center` | string | Sequencing center name for BAM read group tag |
-| `--expected-cells` | int | Override expected cells count (≥1) |
-| `--protocol` | string | Chemistry/protocol. Required and non-`auto` for `standard`, `star`, and `kallisto`; `standard`/Simpleaf rejects `smartseq`; `cellranger` accepts only `auto` or `10XV1`-`10XV4`; ARC accepts only `auto` |
-| `--resume` | flag | Nextflow resume (checksum-verified against prior run) |
-| `--run-downstream` | flag | Opt in to `scrna_orchestrator` handoff after pipeline completion |
-| `--skip-downstream` | flag | Compatibility flag; downstream handoff is skipped unless `--run-downstream` is set |
-| `--gex-frna-probe-set` | path | Probe set CSV for fixed RNA profiling on FFPE samples (`cellrangermulti`) |
-| `--gex-target-panel` | path | Target panel CSV for targeted gene expression (`cellrangermulti`) |
-| `--gex-barcode-sample-assignment` | path | Barcode-to-sample assignment CSV for OCM multiplexing (`cellrangermulti`) |
-| `--vdj-inner-enrichment-primers` | path | Text file with V(D)J cDNA enrichment primer sequences (`cellrangermulti`) |
-
-## Example Queries
-
-The following are concrete user phrases that should route to this skill:
-
-- *"I have 10x Chromium FASTQs from three donors. How do I get an h5ad I can cluster?"*
-- *"Run nf-core/scrnaseq on my samplesheet and give me a reproducibility bundle."*
-- *"I want to preprocess single-cell data from FASTQ using STARsolo. Can you set it up?"*
-- *"Generate a combined_filtered_matrix.h5ad from these FASTQ files using alevin-fry."*
-- *"We have paired-end FASTQ files from a 10x Genomics Chromium v3 experiment. Run the upstream scRNA pipeline."*
-- *"Demo mode — show me what the scrnaseq wrapper produces without any input files."*
-
-## Demo
-
-```bash
-python clawbio.py run scrnaseq-pipeline --demo --output ./outputs/scrnaseq_demo
-```
-
-Expected output:
-- wrapper-level `report.md`
-- wrapper-level `result.json`
-- `logs/`
-- `provenance/`
-- `reproducibility/`
-- upstream `results/` tree under `upstream/`
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--preset` | string | `standard` | Aligner preset |
+| `--profile` | string | `docker` | Execution backend: `docker`, `conda`, `mamba`, `singularity`, `apptainer`, `podman`, `shifter`, `charliecloud`, `wave`, `gpu` |
+| `--pipeline-version` | string | `4.1.0` | Remote `nf-core/scrnaseq` tag or commit (used when no local sibling checkout is found) |
+| `--protocol` | string | `None` | Chemistry/protocol forwarded to the aligner. Required and non-`auto` for `standard`, `star`, and `kallisto`. `standard`/simpleaf additionally rejects `smartseq`. For `cellranger`, `cellrangerarc`, and `cellrangermulti` any value is accepted — `auto` is the typical upstream recommendation |
+| `--genome` | string | — | iGenomes shortcut (`GRCh38`, `mm10`, etc.) — mutually exclusive with `--fasta`/`--gtf` and all index flags |
+| `--igenomes-base` | string | — | Base URL or local path for iGenomes (default `s3://ngi-igenomes/igenomes/`). Use for local mirrors or air-gapped clusters |
+| `--fasta` | path | — | Genome FASTA (`.fa`, `.fna`, `.fasta`, `.gz` variants; no whitespace in path) |
+| `--gtf` | path | — | Gene annotation GTF |
+| `--star-index` | path | — | Prebuilt STAR genome index directory |
+| `--simpleaf-index` | path | — | Prebuilt simpleaf/alevin-fry index |
+| `--kallisto-index` | path | — | Prebuilt kallisto index |
+| `--cellranger-index` | path | — | Prebuilt CellRanger or CellRanger ARC reference |
+| `--transcript-fasta` | path | — | Transcriptome FASTA for simpleaf |
+| `--txp2gene` | path | — | Transcript-to-gene mapping for simpleaf |
+| `--barcode-whitelist` | path | — | Custom barcode whitelist (per-aligner format) |
+| `--star-feature` | enum | — | STARsolo feature type: `Gene`, `GeneFull`, `Gene Velocyto` |
+| `--star-ignore-sjdbgtf` | flag | — | Do not use GTF for SJDB construction (required for `Gene Velocyto`) |
+| `--seq-center` | string | — | Sequencing center name for BAM read group tag |
+| `--simpleaf-umi-resolution` | enum | — | UMI resolution strategy for alevin-fry: `cr-like`, `cr-like-em`, `parsimony`, `parsimony-em`, `parsimony-gene`, `parsimony-gene-em` |
+| `--kb-workflow` | enum | — | Kallisto workflow: `standard`, `lamanno`, `nac` |
+| `--kb-t1c` | path | — | cDNA transcripts-to-capture file for RNA velocity (lamanno/nac) |
+| `--kb-t2c` | path | — | Intron transcripts-to-capture file for RNA velocity (lamanno/nac) |
+| `--skip-cellbender` | flag | — | Disable the CellBender ambient RNA removal subworkflow |
+| `--skip-emptydrops` | flag | — | Skip emptyDrops cell calling (independent of `--skip-cellbender`) |
+| `--skip-fastqc` | flag | — | Skip FastQC quality control |
+| `--skip-multiqc` | flag | — | Skip MultiQC report generation |
+| `--skip-cellranger-renaming` | flag | — | Skip automatic sample renaming in CellRanger modules |
+| `--skip-cellrangermulti-vdjref` | flag | — | Skip mkvdjref in cellrangermulti (when VDJ data is absent or a prebuilt `--cellranger-vdj-index` is supplied) |
+| `--save-reference` | flag | — | Save the built reference index for future reuse |
+| `--save-align-intermeds` | flag | — | Save alignment intermediate BAM files (disabled by default) |
+| `--expected-cells` | int | — | Override expected cell count (≥1) for all samples |
+| `--email` | string | — | Email address for pipeline completion notification |
+| `--multiqc-title` | string | — | Custom title for the MultiQC report |
+| `--resume` | flag | — | Nextflow resume (checksum-verified against prior manifest) |
+| `--run-downstream` | flag | — | Opt in to `scrna_orchestrator` handoff after pipeline completion |
+| `--cellrangerarc-config` | path | — | Config JSON for CellRanger ARC index construction |
+| `--cellrangerarc-reference` | string | — | Reference genome name used inside the CellRanger ARC config |
+| `--motifs` | path | — | Motif file (e.g. JASPAR) for CellRanger ARC |
+| `--cellranger-vdj-index` | path | — | Prebuilt CellRanger VDJ reference |
+| `--gex-frna-probe-set` | path | — | Probe set CSV for FFPE fixed RNA profiling (`cellrangermulti`) |
+| `--gex-target-panel` | path | — | Target panel CSV for targeted GEX (`cellrangermulti`) |
+| `--gex-cmo-set` | path | — | CMO reference CSV for multiplexed samples (`cellrangermulti`) |
+| `--gex-barcode-sample-assignment` | path | — | Barcode-to-sample assignment CSV for OCM multiplexing (`cellrangermulti`) |
+| `--fb-reference` | path | — | Feature-barcode reference CSV for antibody capture (`cellrangermulti`) |
+| `--vdj-inner-enrichment-primers` | path | — | V(D)J cDNA enrichment primer sequences (`cellrangermulti`) |
+| `--cellranger-multi-barcodes` | path | — | Multiplexed sample samplesheet for CMO/FFPE demultiplexing (`cellrangermulti`) |
 
 ## Output Structure
 
 ```text
 output_directory/
-├── report.md
-├── result.json
+├── report.md                         # Wrapper run summary
+├── result.json                       # Structured result payload
 ├── logs/
-│   ├── stdout.txt
-│   └── stderr.txt
+│   ├── stdout.txt                    # Nextflow stdout
+│   └── stderr.txt                    # Nextflow stderr
 ├── upstream/
-│   └── results/
+│   └── results/                      # nf-core/scrnaseq output tree
+│       ├── fastqc/                   # Per-read FastQC reports
+│       ├── multiqc/                  # MultiQC HTML and data
+│       │   └── multiqc_report.html
+│       ├── pipeline_info/            # Execution report, timeline, trace, DAG
+│       └── <aligner>/                # Aligner-specific outputs
+│           ├── <sample>/             # Per-sample STAR/simpleaf/kallisto outputs
+│           └── mtx_conversions/      # AnnData (.h5ad), SCE (.rds), Seurat (.rds)
+│               ├── <sample>_filtered_matrix.h5ad
+│               ├── <sample>_raw_matrix.h5ad
+│               ├── combined_filtered_matrix.h5ad   ← preferred_h5ad (when present)
+│               └── combined_raw_matrix.h5ad
 ├── reproducibility/
-│   ├── samplesheet.valid.csv
-│   ├── commands.sh
-│   ├── params.yaml
-│   ├── environment.yml
-│   ├── checksums.sha256
-│   └── manifest.json
+│   ├── samplesheet.valid.csv         # Normalized samplesheet (absolute POSIX paths)
+│   ├── params.yaml                   # Effective Nextflow parameters
+│   ├── commands.sh                   # Portable replay script
+│   ├── environment.yml               # Conda environment spec (for reference)
+│   ├── checksums.sha256              # SHA-256 for samplesheet, params, refs, h5ad, MultiQC
+│   ├── manifest.json                 # Run metadata: preset, profile, versions, checksums
+│   ├── macos_docker.config           # macOS+Docker workarounds (VirtioFS, ARM64, STAR FIFOs)
+│   └── remap_paths.py                # Helper for replaying on a different machine
 └── provenance/
-    ├── upstream.json
-    ├── skill.json
-    ├── invocation.json
-    ├── inputs.json
-    ├── outputs.json
-    ├── runtime.json
-    └── preflight.json
+    ├── inputs.json                   # Samplesheet and reference paths + checksums
+    ├── invocation.json               # Timestamp, preset, profile, pipeline version
+    ├── preflight.json                # Java/Nextflow/backend info
+    ├── upstream.json                 # Pipeline source resolution details
+    ├── outputs.json                  # Detected artifacts
+    ├── runtime.json                  # Execution timing
+    └── skill.json                    # Skill name and version
 ```
-
-## Dependencies
-
-**Required**:
-- `nextflow`
-- `java` 17+
-- one supported backend (`docker`, `conda`, `singularity`, or `apptainer`)
-
-**Optional**:
-- local sibling checkout of `scrnaseq` for pinned local execution
-
-## Safety
-
-- **Local-first**: User FASTQs and outputs remain local.
-- **Strict preflight**: Do not launch Nextflow if validation fails.
-- **Controlled surface**: No arbitrary passthrough flags in v1.
-- **Disclaimer**: Every report includes the ClawBio disclaimer.
-- **No hallucinated outputs**: Report only artifacts that were actually detected on disk.
 
 ## Example Output
 
-After a successful run, `result.json` contains:
-
+`result.json` (abbreviated):
 ```json
 {
   "skill": "scrnaseq-pipeline",
@@ -336,98 +299,83 @@ After a successful run, `result.json` contains:
   "summary": {
     "preset": "star",
     "aligner_effective": "star",
-    "pipeline_source_kind": "local_checkout",
-    "pipeline_version_or_commit": "abc1234abcde",
+    "pipeline_source_kind": "remote_repo",
+    "pipeline_version_or_commit": "4.1.0",
     "profile": "docker",
-    "resume_used": false,
-    "preferred_h5ad": "output/upstream/results/star/mtx_conversions/combined_filtered_matrix.h5ad",
+    "preferred_h5ad": "<output>/upstream/results/star/mtx_conversions/combined_filtered_matrix.h5ad",
     "handoff_available": true,
     "samples_detected": 2,
-    "cellbender_used": false,
-    "output_artifacts": {
-      "preferred_h5ad": "output/upstream/results/star/mtx_conversions/combined_filtered_matrix.h5ad",
-      "multiqc_report": "output/upstream/results/multiqc/star/multiqc_report.html",
-      "pipeline_info_dir": "output/upstream/results/pipeline_info",
-      "h5ad_candidates": [
-        "output/upstream/results/star/mtx_conversions/combined_filtered_matrix.h5ad"
-      ],
-      "rds_candidates": []
-    }
+    "cellbender_used": false
   }
 }
 ```
 
-And `report.md` closes with:
+`report.md` closes with:
 ```
 ## Next Steps
-
-- `python clawbio.py run scrna --input output/upstream/.../combined_filtered_matrix.h5ad --output <dir>`
-- `python clawbio.py run scrna-embedding --input output/upstream/.../combined_filtered_matrix.h5ad --output <dir>`
+- python clawbio.py run scrna --input <preferred_h5ad> --output <dir>
+- python clawbio.py run scrna-embedding --input <preferred_h5ad> --output <dir>
 ```
 
 ## Gotchas
 
-- **Preflight runs before any Nextflow call.** If Java, Nextflow, or Docker are missing, the pipeline never starts and you get a structured JSON error with `error_code` and a `fix` hint. Do not try to skip preflight.
-- **`--resume` enforces strict compatibility.** The wrapper checks that the stored manifest matches the current preset, profile, and pipeline source. If any differ, it raises `INVALID_RESUME_STATE` rather than silently continuing with incompatible state.
-- **`--demo` runs the pipeline's real `test` profile, not bundled sample data.** It exercises the full Nextflow code path with the upstream test fixtures. Docker must be running. Output reflects what `nf-core/scrnaseq -profile test,docker` produces.
-- **`preferred_h5ad` may be empty.** If no combined matrix is found and there are multiple per-sample files, `handoff_available` is `false`. Always check `result.json` before chaining to `scrna-orchestrator` or manually invoking `scrna-embedding`.
-- **No arbitrary Nextflow passthrough.** You cannot add `-c`, `--outdir`, or custom Nextflow flags. All pipeline configuration flows through the preset system and `params.yaml`. Attempting to inject flags directly is blocked by the wrapper's CLI contract.
-- **`--genome` conflicts with any explicit reference flag.** Providing `--genome` alongside any of `--fasta`, `--gtf`, `--star-index`, `--simpleaf-index`, `--kallisto-index`, `--cellranger-index`, `--transcript-fasta`, or `--txp2gene` raises `CONFLICTING_REFERENCES` in preflight. Use either `--genome <shortcut>` or explicit reference/index flags — never both.
-- **Protocol compatibility is enforced before Nextflow starts.** `standard`/Simpleaf, `star`, and `kallisto` cannot rely on upstream `protocol=auto`, so provide an explicit protocol such as `10XV3`, `dropseq`, or a supported custom chemistry string. `standard`/Simpleaf rejects `smartseq`; use `star` or `kallisto` for Smart-seq data. `cellranger` accepts only `auto` or `10XV1`-`10XV4`; `cellrangerarc` accepts only `auto`.
-- **`--skip-emptydrops` is deprecated upstream.** The wrapper still accepts it for old commands, but normalizes it to the canonical `skip_cellbender` parameter in `params.yaml` and replay scripts.
-- **CellBender follows upstream behavior.** CellBender runs by default when supported and is disabled by `--skip-cellbender` (or deprecated `--skip-emptydrops`). The upstream workflow never runs CellBender for `cellrangerarc`, even when `skip_cellbender=false`.
-- **Schema-incompatible paths fail early.** The wrapper writes `params.input` as a relative bundle path and rejects FASTA paths that do not match the nf-core/scrnaseq 4.1.0 schema (`.fa`, `.fna`, `.fasta`, and gzip variants, with no whitespace).
-- **RNA velocity requires two coordinated flags.** For STARsolo, pass `--star-feature "Gene Velocyto"` AND `--star-ignore-sjdbgtf` together — the former selects the feature type, the latter suppresses GTF-based SJDB construction (required for velocity matrices). For Kallisto, use `--kb-workflow lamanno` or `nac` with `--kb-t1c` and `--kb-t2c`.
-- **`cellrangerarc` follows the upstream ARC rules.** It accepts a prebuilt `--cellranger-index`, or builds from `--genome` / `--fasta` + `--gtf`. `--motifs` is optional. If you provide a custom `--cellrangerarc-config`, you must also provide `--cellrangerarc-reference` (and vice versa), otherwise preflight fails with `INVALID_PRESET_CONFIGURATION`.
-- **`cellrangermulti` validates requirements from the samplesheet.** The main samplesheet must include `feature_type`. If `feature_type=ab`, preflight requires `--fb-reference`; if `feature_type=cmo`, preflight requires `--cellranger-multi-barcodes`; if `feature_type=vdj` and `--skip-cellrangermulti-vdjref` is set, preflight requires `--cellranger-vdj-index`. CMO, FFPE probe-set demultiplexing, and OCM assignment are treated as mutually exclusive multiplexing strategies.
-- **`--save-align-intermeds` defaults to false in `params.yaml`.** This overrides heavy upstream defaults unless the user explicitly requests alignment intermediates.
-- **`--check` writes `check_result.json` to the output directory.** This file is ignored by subsequent full runs. Running `--check` and a full run to the same `--output` directory is safe — `check_result.json` will be overwritten by `result.json` on success.
-- **`--demo` always forces `--preset star` and `--skip-cellbender`.** The nf-core test profile ships STAR-compatible data only. If you request another preset with `--demo`, the wrapper warns and overrides it.
-- **Local checkout must be a sibling directory.** The wrapper looks for `../scrnaseq` relative to the ClawBio repo root — both repos must share the same parent folder. If `scrnaseq/` is anywhere else, the wrapper silently falls back to downloading the remote pipeline from GitHub (slower, not pinned to a commit). To use the local path, ensure `ClawBio/` and `scrnaseq/` are siblings.
+- **Preflight runs before any Nextflow call.** If Java, Nextflow, or the backend are missing or too old, the pipeline never starts and you get a structured JSON error with `error_code` and a `fix` hint. Nextflow ≥25.04.0 is required.
+- **`--genome` conflicts with any explicit reference flag.** Providing `--genome` alongside `--fasta`, `--gtf`, or any index flag raises `CONFLICTING_REFERENCES` in preflight. Use either `--genome <shortcut>` or explicit flags — never both.
+- **`igenomes_ignore` is set automatically.** Whenever any explicit reference path (fasta, gtf, any index) is provided, the wrapper writes `igenomes_ignore: true` to suppress nf-schema DNS validation of the default iGenomes S3 URL. You do not need to set this manually. Use `--igenomes-base` only for local iGenomes mirrors.
+- **Protocol compatibility is enforced before Nextflow starts.** `standard`, `star`, and `kallisto` presets require an explicit non-`auto` protocol (e.g., `10XV3`, `dropseq`, or a supported custom chemistry string). `standard`/simpleaf additionally rejects `smartseq` — use `star` or `kallisto` for Smart-seq data. `cellranger`, `cellrangerarc`, and `cellrangermulti` accept any protocol value; `auto` is the typical upstream recommendation but is not enforced.
+- **`--skip-cellbender` and `--skip-emptydrops` are independent flags.** `--skip-cellbender` disables the CellBender ambient RNA removal subworkflow; `--skip-emptydrops` disables the emptyDrops cell calling step. Both are written as separate parameters in `params.yaml` and each replays as its own flag in `commands.sh`. Setting one does not imply the other.
+- **`--demo` forces preset=star and skip_cellbender=true.** The nf-core upstream `test` profile ships STAR-compatible data and explicitly disables CellBender (which does not work on small test datasets). If a different preset is requested with `--demo`, the wrapper warns and overrides it.
+- **`preferred_h5ad` may be absent.** If no combined matrix is produced and there are multiple per-sample files, `handoff_available` is `false`. Always check `result.json` before chaining to `scrna-orchestrator` or `scrna-embedding`.
+- **No arbitrary Nextflow passthrough.** All pipeline configuration flows through the preset system and `params.yaml`. Direct `-c`, `--outdir`, or custom Nextflow flags cannot be injected.
+- **`--resume` enforces strict compatibility.** The wrapper checks that the stored manifest matches the current preset, profile, and pipeline source. Mismatches raise `INVALID_RESUME_STATE`.
+- **RNA velocity requires two coordinated flags.** For STARsolo: `--star-feature "Gene Velocyto"` AND `--star-ignore-sjdbgtf` must be passed together. For Kallisto: `--kb-workflow lamanno` or `nac` with `--kb-t1c` and `--kb-t2c`.
+- **`cellrangerarc` config and reference are paired.** Providing `--cellrangerarc-config` without `--cellrangerarc-reference` (or vice versa) raises `INVALID_PRESET_CONFIGURATION`. `--motifs` is optional and independent.
+- **`cellrangermulti` validates against the samplesheet.** `feature_type=ab` requires `--fb-reference`; `feature_type=cmo` requires `--cellranger-multi-barcodes`; `feature_type=vdj` with `--skip-cellrangermulti-vdjref` requires `--cellranger-vdj-index`. CMO, FFPE probe-set, and OCM multiplexing modes are mutually exclusive.
+- **FASTA schema validation.** The FASTA path must match `^\S+\.fn?a(sta)?(\.gz)?$` (the nf-core/scrnaseq 4.1.0 schema). Paths with whitespace or non-standard extensions are rejected in preflight.
+- **Local checkout must be a sibling directory.** The wrapper looks for `../scrnaseq` relative to the ClawBio repo root. If the checkout path contains whitespace (common on macOS), the wrapper warns and falls back to the remote pipeline. Ensure `ClawBio/` and `scrnaseq/` share the same parent folder.
+- **macOS Docker workaround is applied automatically.** On macOS with Docker, `macos_docker.config` is written to the reproducibility bundle and passed to Nextflow. It sets `stageInMode = "copy"` (avoids VirtioFS EDEADLK), `--platform linux/amd64` (Rosetta emulation), and routes STAR `_STARtmp` to the container's `/tmp` (avoids VirtioFS FIFO limitation). Output directories under `/tmp` emit a WARNING — use a path under HOME.
+
+## Safety
+
+- **Local-first**: User FASTQs and outputs remain on the local filesystem.
+- **Strict preflight**: Nextflow is never invoked if validation fails.
+- **No hallucinated outputs**: Only artifacts confirmed on disk are reported.
+- **Disclaimer**: Every report includes the ClawBio medical disclaimer.
 
 ## Agent Boundary
 
 The agent dispatches and explains; this skill executes.
 
-**The agent is responsible for:**
-- Interpreting the user's preprocessing intent and choosing the right preset
-- Verifying that `handoff_available` is true in `result.json` before routing to `scrna-orchestrator` (automatic) or `scrna-embedding` (manual follow-up)
+**Agent**: Interpret the user's preprocessing intent, choose the preset, and verify that `handoff_available` is `true` in `result.json` before routing to downstream skills.
 
-**This skill is responsible for:**
-- Validating the environment and inputs before any execution
-- Running the Nextflow pipeline with controlled, reproducible parameters
-- Writing all provenance, checksums, and reproducibility artifacts
-- Reporting the detected `preferred_h5ad` for downstream handoff
+**Skill**: Validate environment and inputs, run the pipeline with controlled parameters, write all provenance and reproducibility artifacts, and report the detected `preferred_h5ad`.
 
-## Integration with Bio Orchestrator
+## Chaining Partners
 
-**Trigger conditions**:
-- user wants to run `scrnaseq` from FASTQs
-- user asks for upstream scRNA preprocessing
-- user wants `.h5ad` generation from raw single-cell FASTQs
-
-**Do NOT route here when**:
-- the user already has `.h5ad` and wants clustering, markers, or UMAP
-- the user wants scVI/scANVI or batch correction downstream
-
-**Chaining partners**:
-- `scrna-orchestrator`: downstream clustering and markers from `preferred_h5ad`
-- `scrna-embedding`: downstream scVI/scANVI from `preferred_h5ad`
+| Skill | When to chain |
+|-------|--------------|
+| `scrna-orchestrator` | After a successful run, pass `preferred_h5ad` for clustering, QC, and markers |
+| `scrna-embedding` | Pass `preferred_h5ad` for scVI/scANVI batch integration and latent embeddings |
+| `multiqc-reporter` | Re-aggregate QC across multiple wrapper runs |
 
 ## Maintenance
 
-**Review cadence**: Review this skill whenever `nf-core/scrnaseq` releases a new major version (currently tracked at `nf-co.re/scrnaseq/changelog`). Check that `NEXTFLOW_MIN_VERSION` in `schemas.py` and the `SUPPORTED_PRESETS` map in `schemas.py` remain correct.
+**Review cadence**: After each nf-core/scrnaseq major release. Check `NEXTFLOW_MIN_VERSION` (`schemas.py`), `SUPPORTED_PRESETS`, `SUPPORTED_PROFILES`, and this SKILL.md for accuracy.
 
 **Staleness signals**:
-- `preflight.py` raises `NEXTFLOW_VERSION_TOO_OLD` on a version that the current nf-core release explicitly supports — update `NEXTFLOW_MIN_VERSION` in `schemas.py`.
-- New aligners appear in the upstream `scrnaseq` pipeline but are not in `SUPPORTED_PRESETS` — add them to `schemas.py` and update this SKILL.md and the test suite.
-- The VirtioFS macOS workaround (`stageInMode = "copy"`) is only necessary while Apple Silicon runs Docker via QEMU. If Apple releases a native arm64 Docker runtime that eliminates VirtioFS deadlocks, remove `_write_macos_docker_config` and its tests.
-- The local sibling checkout path (`../scrnaseq`) is a convention for this thesis environment. Downstream deployments should configure `CLAWBIO_SCRNASEQ_PATH` or equivalent.
+- Preflight rejects a Nextflow version that the current pipeline supports → update `NEXTFLOW_MIN_VERSION` in `schemas.py` and `reproducibility/pinned_versions.json`.
+- New aligners appear upstream but are absent from `PRESET_ALIGNERS` → add to `schemas.py` and update tests.
+- The VirtioFS macOS workaround (`stageInMode = "copy"`) is only necessary while Apple Silicon runs Docker via QEMU. Remove `_write_macos_docker_config` when a native arm64 Docker runtime eliminates VirtioFS deadlocks.
 
-**Deprecation criteria**: Deprecate this skill if nf-core/scrnaseq releases a Python SDK that exposes equivalent preflight, params, and provenance APIs — at that point the wrapper adds less value than it costs in maintenance.
+**Deprecation criteria**: Deprecate if nf-core/scrnaseq releases a Python SDK with equivalent preflight, params, and provenance APIs.
 
 ## Citations
 
-- [nf-core/scrnaseq](https://nf-co.re/scrnaseq)
+- [nf-core/scrnaseq 4.1.0](https://nf-co.re/scrnaseq/4.1.0)
+- [nf-core/scrnaseq usage](https://nf-co.re/scrnaseq/4.1.0/docs/usage/)
+- [nf-core/scrnaseq parameters](https://nf-co.re/scrnaseq/4.1.0/parameters/)
+- [nf-core/scrnaseq output](https://nf-co.re/scrnaseq/4.1.0/docs/output/)
 - [Nextflow](https://www.nextflow.io/)
 - [Alevin-fry / Simpleaf](https://simpleaf.readthedocs.io/)
+- [STARsolo](https://github.com/alexdobin/STAR/blob/master/docs/STARsolo.md)
+- [kb-python / BUStools](https://www.kallistobus.tools/)

--- a/skills/nfcore-scrnaseq-wrapper/command_builder.py
+++ b/skills/nfcore-scrnaseq-wrapper/command_builder.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+def build_nextflow_command(
+    *,
+    pipeline_source: dict[str, str | bool],
+    profile: str,
+    params_path: Path,
+    resume: bool,
+    work_dir: Path | None = None,
+    extra_configs: list[Path] | None = None,
+) -> tuple[list[str], str]:
+    source_kind = str(pipeline_source["source_kind"])
+    source_ref = str(pipeline_source["source_ref"])
+    resolved_version = str(pipeline_source["resolved_version"])
+
+    command = ["nextflow", "run"]
+    if source_kind == "local_checkout":
+        # Convert to forward slashes: Nextflow (Java) accepts them on all platforms,
+        # and they avoid backslash ambiguity when the path is logged or copy-pasted.
+        command.append(Path(source_ref).as_posix())
+    else:
+        command.extend([source_ref, "-r", resolved_version])
+
+    # Use forward-slash paths for -params-file and -c so the command is portable
+    # across macOS, Linux, and Windows (native or via WSL2).
+    command.extend(["-profile", profile, "-params-file", params_path.as_posix()])
+    if work_dir is not None:
+        command.extend(["-work-dir", work_dir.as_posix()])
+    for cfg in extra_configs or []:
+        command.extend(["-c", cfg.as_posix()])
+    if resume:
+        command.append("-resume")
+
+    # command_str is the human-readable form stored in result.json / report.md.
+    # Use platform-appropriate quoting so it can be pasted directly into a terminal.
+    if sys.platform == "win32":
+        command_str = subprocess.list2cmdline(command)
+    else:
+        command_str = " ".join(shlex.quote(part) for part in command)
+
+    return command, command_str

--- a/skills/nfcore-scrnaseq-wrapper/demo/README.md
+++ b/skills/nfcore-scrnaseq-wrapper/demo/README.md
@@ -1,0 +1,7 @@
+This skill uses the upstream `scrnaseq` pipeline test profile for demo mode.
+
+Run:
+
+```bash
+python clawbio.py run scrnaseq-pipeline --demo --output ./outputs/scrnaseq_demo
+```

--- a/skills/nfcore-scrnaseq-wrapper/errors.py
+++ b/skills/nfcore-scrnaseq-wrapper/errors.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class SkillError(Exception):
+    stage: str
+    error_code: str
+    message: str
+    fix: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        super().__init__(self.message)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "stage": self.stage,
+            "error_code": self.error_code,
+            "message": self.message,
+            "fix": self.fix,
+            "details": self.details,
+        }
+
+
+class ErrorCode:
+    MISSING_INPUT = "MISSING_INPUT"
+    MISSING_FASTQ = "MISSING_FASTQ"
+    INVALID_FASTQ = "INVALID_FASTQ"
+    FASTQ_NOT_READABLE = "FASTQ_NOT_READABLE"
+    INVALID_SAMPLESHEET = "INVALID_SAMPLESHEET"
+    OUTPUT_DIR_NOT_EMPTY = "OUTPUT_DIR_NOT_EMPTY"
+    OUTPUT_DIR_NOT_WRITABLE = "OUTPUT_DIR_NOT_WRITABLE"
+    MISSING_REFERENCE = "MISSING_REFERENCE"
+    CONFLICTING_REFERENCES = "CONFLICTING_REFERENCES"
+    INVALID_PRESET_CONFIGURATION = "INVALID_PRESET_CONFIGURATION"
+    UNSUPPORTED_MODE = "UNSUPPORTED_MODE"
+    INVALID_PROFILE = "INVALID_PROFILE"
+    MISSING_DOCKER = "MISSING_DOCKER"
+    DOCKER_NOT_RUNNING = "DOCKER_NOT_RUNNING"
+    MISSING_CONDA = "MISSING_CONDA"
+    MISSING_SINGULARITY = "MISSING_SINGULARITY"
+    MISSING_PODMAN = "MISSING_PODMAN"
+    PODMAN_NOT_RUNNING = "PODMAN_NOT_RUNNING"
+    MISSING_HPC_RUNTIME = "MISSING_HPC_RUNTIME"
+    MISSING_JAVA = "MISSING_JAVA"
+    JAVA_VERSION_TOO_OLD = "JAVA_VERSION_TOO_OLD"
+    MISSING_NEXTFLOW = "MISSING_NEXTFLOW"
+    NEXTFLOW_VERSION_TOO_OLD = "NEXTFLOW_VERSION_TOO_OLD"
+    PIPELINE_SOURCE_INVALID = "PIPELINE_SOURCE_INVALID"
+    INVALID_RESUME_STATE = "INVALID_RESUME_STATE"
+    EXECUTION_FAILED = "EXECUTION_FAILED"
+    EXPECTED_OUTPUTS_NOT_FOUND = "EXPECTED_OUTPUTS_NOT_FOUND"
+    UNEXPECTED_ERROR = "UNEXPECTED_ERROR"

--- a/skills/nfcore-scrnaseq-wrapper/executor.py
+++ b/skills/nfcore-scrnaseq-wrapper/executor.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+_SKILL_DIR = Path(__file__).resolve().parent
+if str(_SKILL_DIR) not in sys.path:
+    sys.path.insert(0, str(_SKILL_DIR))
+
+from errors import ErrorCode, SkillError
+
+_PROCESS_TERMINATION_GRACE_SECONDS = 10
+
+
+def execute_nextflow(
+    command: list[str],
+    *,
+    cwd: Path,
+    output_dir: Path,
+    timeout_seconds: int,
+) -> dict[str, object]:
+    logs_dir = output_dir / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    stdout_path = logs_dir / "stdout.txt"
+    stderr_path = logs_dir / "stderr.txt"
+
+    popen_kwargs: dict = {}
+    if sys.platform != "win32":
+        popen_kwargs["start_new_session"] = True
+
+    with stdout_path.open("w", encoding="utf-8") as stdout_fh, \
+         stderr_path.open("w", encoding="utf-8") as stderr_fh:
+        try:
+            proc = subprocess.Popen(
+                command,
+                cwd=str(cwd),
+                stdout=stdout_fh,
+                stderr=stderr_fh,
+                **popen_kwargs,
+            )
+        except OSError as exc:
+            for path in (stdout_path, stderr_path):
+                path.unlink(missing_ok=True)
+            raise SkillError(
+                stage="preflight",
+                error_code=ErrorCode.EXECUTION_FAILED,
+                message=f"Could not launch Nextflow: {exc}",
+                fix="Ensure nextflow is installed and available on PATH.",
+                details={"command": command[0] if command else "", "error": str(exc)},
+            ) from exc
+
+        try:
+            exit_code = proc.wait(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired:
+            _terminate_process_tree(proc)
+            raise SkillError(
+                stage="execution",
+                error_code=ErrorCode.EXECUTION_FAILED,
+                message="Nextflow execution timed out.",
+                fix="Increase resources, inspect the pipeline, or retry with a smaller dataset.",
+                details={"timeout_seconds": timeout_seconds},
+            )
+
+    if exit_code != 0:
+        raise SkillError(
+            stage="execution",
+            error_code=ErrorCode.EXECUTION_FAILED,
+            message="Nextflow execution failed.",
+            fix="Inspect logs/stdout.txt and logs/stderr.txt, then correct the failing input or environment.",
+            details={
+                "exit_code": exit_code,
+                "stdout": str(stdout_path),
+                "stderr": str(stderr_path),
+            },
+        )
+
+    return {
+        "exit_code": exit_code,
+        "stdout_path": str(stdout_path),
+        "stderr_path": str(stderr_path),
+    }
+
+
+def _terminate_process_tree(proc: subprocess.Popen) -> None:
+    if sys.platform != "win32":
+        try:
+            pgid = os.getpgid(proc.pid)
+            os.killpg(pgid, signal.SIGTERM)
+            proc.wait(timeout=_PROCESS_TERMINATION_GRACE_SECONDS)
+            return
+        except (OSError, ProcessLookupError, subprocess.TimeoutExpired):
+            pass
+        try:
+            pgid = os.getpgid(proc.pid)
+            os.killpg(pgid, signal.SIGKILL)
+            proc.wait()
+            return
+        except (OSError, ProcessLookupError):
+            pass
+    proc.kill()
+    proc.wait()

--- a/skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py
+++ b/skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py
@@ -1,0 +1,603 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+
+_SKILL_DIR = Path(__file__).resolve().parent
+if str(_SKILL_DIR) not in sys.path:
+    sys.path.insert(0, str(_SKILL_DIR))
+_PROJECT_ROOT = _SKILL_DIR.parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from command_builder import build_nextflow_command
+from errors import ErrorCode, SkillError
+from executor import execute_nextflow
+from outputs_parser import parse_outputs
+from params_builder import build_effective_params, serialize_params_yaml, write_params_yaml
+from pipeline_source import resolve_pipeline_source
+from preflight import check_output_dir_available, run_preflight
+from provenance import write_provenance_bundle
+from reporting import write_check_result, write_report, write_repro_commands, write_result
+from samplesheet_builder import validate_and_normalize_samplesheet
+from schemas import (
+    DEFAULT_PIPELINE_VERSION,
+    DEFAULT_PRESET,
+    DEFAULT_PROFILE,
+    DEFAULT_TIMEOUT_SECONDS,
+    SKILL_NAME,
+    PRESET_ALIGNERS,
+    SUPPORTED_PRESETS,
+    SUPPORTED_PROFILES,
+)
+
+_DOWNSTREAM_HANDOFF_TIMEOUT_SECONDS = 60 * 60
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the scrnaseq pipeline through a ClawBio wrapper.")
+    parser.add_argument("--input", help="Path to a valid samplesheet.csv")
+    parser.add_argument("--output", required=True, help="Output directory for the wrapper results")
+    parser.add_argument("--demo", action="store_true", help="Run the pipeline demo with the upstream test profile")
+    parser.add_argument("--check", action="store_true", help="Run preflight only and exit")
+    parser.add_argument("--profile", default=DEFAULT_PROFILE, choices=sorted(SUPPORTED_PROFILES), help="Execution backend profile")
+    parser.add_argument("--pipeline-version", default=DEFAULT_PIPELINE_VERSION, help="Remote pipeline tag/commit fallback")
+    parser.add_argument("--preset", default=DEFAULT_PRESET, choices=sorted(SUPPORTED_PRESETS), help="Curated pipeline preset (standard = simpleaf/alevin-fry, star = STARsolo, kallisto = kb-python, cellranger/cellrangerarc/cellrangermulti = CellRanger variants)")
+    parser.add_argument("--protocol", default=None, help="Protocol forwarded to the aligner (e.g. 10XV3, auto, dropseq, or any custom string). Use 'auto' only for cellranger/cellrangerarc/cellrangermulti. For standard/star/kallisto an explicit non-auto value is required.")
+    parser.add_argument("--email", default=None, help="Email address for pipeline completion notification")
+    parser.add_argument("--multiqc-title", default=None, help="Custom title for the MultiQC report")
+    parser.add_argument("--expected-cells", type=int, default=None, help="Optional override for expected_cells")
+    parser.add_argument("--resume", action="store_true", help="Attempt a compatible Nextflow resume")
+    # Skip flags
+    parser.add_argument("--skip-cellbender", action="store_true", help="Disable the cellbender subworkflow")
+    parser.add_argument("--skip-fastqc", action="store_true", help="Skip the FastQC quality control step")
+    parser.add_argument(
+        "--skip-emptydrops",
+        action="store_true",
+        help="Deprecated alias for --skip-cellbender; kept for old commands.",
+    )
+    parser.add_argument("--skip-multiqc", action="store_true", help="Skip MultiQC report generation")
+    parser.add_argument("--skip-cellranger-renaming", action="store_true", help="Skip automatic sample renaming in CellRanger modules")
+    parser.add_argument("--skip-cellrangermulti-vdjref", action="store_true", help="Skip mkvdjref step in cellrangermulti (when no VDJ data)")
+    # Reference genome
+    parser.add_argument("--genome", default=None, help="iGenomes reference shortcut (e.g. GRCh38, mm10). Mutually exclusive with --fasta/--gtf.")
+    parser.add_argument("--save-reference", action="store_true", help="Save the built reference index for future reuse")
+    parser.add_argument("--save-align-intermeds", action="store_true", help="Save alignment intermediate files (BAMs)")
+    parser.add_argument("--fasta", default=None)
+    parser.add_argument("--gtf", default=None)
+    parser.add_argument("--transcript-fasta", default=None)
+    parser.add_argument("--txp2gene", default=None)
+    parser.add_argument("--simpleaf-index", default=None)
+    parser.add_argument("--kallisto-index", default=None)
+    parser.add_argument("--star-index", default=None)
+    parser.add_argument("--cellranger-index", default=None)
+    parser.add_argument("--barcode-whitelist", default=None)
+    # STARsolo extras
+    parser.add_argument("--star-feature", default=None, choices=["Gene", "GeneFull", "Gene Velocyto"], help="STARsolo feature type. 'Gene Velocyto' generates RNA velocity matrices.")
+    parser.add_argument("--star-ignore-sjdbgtf", action="store_true", help="Do not use GTF for SJDB construction (use with --star-feature 'Gene Velocyto')")
+    parser.add_argument("--seq-center", default=None, help="Sequencing center name for BAM read group tag")
+    # Simpleaf extras
+    parser.add_argument("--simpleaf-umi-resolution", default=None, choices=["cr-like", "cr-like-em", "parsimony", "parsimony-em", "parsimony-gene", "parsimony-gene-em"], help="UMI resolution strategy for alevin-fry")
+    # Kallisto/BUS extras
+    parser.add_argument("--kb-workflow", default=None, choices=["standard", "lamanno", "nac"], help="Kallisto workflow type")
+    parser.add_argument("--kb-t1c", default=None, help="cDNA transcripts-to-capture file for RNA velocity (lamanno/nac workflows)")
+    parser.add_argument("--kb-t2c", default=None, help="Intron transcripts-to-capture file for RNA velocity (lamanno/nac workflows)")
+    # CellRanger ARC
+    parser.add_argument("--motifs", default=None, help="Motif file (e.g. JASPAR) for CellRanger ARC index construction")
+    parser.add_argument("--cellrangerarc-config", default=None, help="Config file for CellRanger ARC index construction")
+    parser.add_argument("--cellrangerarc-reference", default=None, help="Reference genome name used inside the CellRanger ARC config file")
+    # CellRanger Multi
+    parser.add_argument("--cellranger-vdj-index", default=None, help="Pre-built CellRanger VDJ reference index")
+    parser.add_argument("--gex-frna-probe-set", default=None, help="Probe set CSV for fixed RNA profiling (FFPE samples)")
+    parser.add_argument("--gex-target-panel", default=None, help="Target panel CSV for targeted gene expression")
+    parser.add_argument("--gex-cmo-set", default=None, help="Cell Multiplexing Oligo (CMO) reference CSV for multiplexed samples")
+    parser.add_argument("--fb-reference", default=None, help="Feature barcoding reference CSV (e.g. antibody capture)")
+    parser.add_argument("--vdj-inner-enrichment-primers", default=None, help="Text file with V(D)J cDNA enrichment primer sequences")
+    parser.add_argument("--gex-barcode-sample-assignment", default=None, help="Barcode-to-sample assignment CSV to override CellRanger defaults")
+    parser.add_argument("--cellranger-multi-barcodes", default=None, help="Additional samplesheet CSV with multiplexed sample information for cellrangermulti")
+    parser.add_argument("--run-downstream", action="store_true", help="Opt in to running scrna_orchestrator after a canonical h5ad is detected")
+    parser.add_argument("--skip-downstream", action="store_true", help="Compatibility flag; downstream handoff is skipped unless --run-downstream is set")
+    return parser
+
+
+def _write_demo_samplesheet(samplesheet_path: Path) -> None:
+    samplesheet_path.parent.mkdir(parents=True, exist_ok=True)
+    samplesheet_path.write_text("sample,fastq_1,fastq_2,expected_cells,seq_center\n", encoding="utf-8")
+
+
+def _write_macos_docker_config(output_dir: Path) -> Path:
+    """Write a Nextflow config with macOS + Apple Silicon Docker workarounds.
+
+    Three issues on macOS with Docker (Colima / Docker Desktop):
+
+    1. EDEADLK (errno 35): QEMU-emulated amd64 containers cannot exec files from
+       VirtioFS bind-mounted paths. stageInMode="copy" forces Nextflow to copy
+       inputs to the host work dir before launching each container, giving the
+       guest kernel a clean page-cache state.
+
+    2. ARM64 host / amd64 images: nf-core containers ship only linux/amd64 images.
+       docker.runOptions = "--platform linux/amd64" tells Docker to pull and run
+       the amd64 image under Rosetta / QEMU emulation on Apple Silicon.
+
+    3. STAR FIFO (named-pipe) limitation: STAR creates named pipes under its work
+       dir for streaming reads. VirtioFS does not support FIFOs, so STAR fails with
+       "could not create FIFO file". --outTmpDir /tmp/star_tmp routes _STARtmp to
+       the container's own /tmp (Linux tmpfs) where FIFOs are supported. The full
+       ext.args from conf/modules.config is reproduced here so no flags are lost.
+       Do NOT use a self-referencing closure (task.ext.args ?: "") — that causes a
+       StackOverflowError.
+
+    4. Time limit: macOS Docker (VirtioFS) adds significant I/O overhead. The nf-core
+       test profile caps all tasks at 1 h, which is too short for STAR genome generation
+       and alignment under emulation. resourceLimits.time is raised to 4 h here so the
+       test profile limit is overridden (later configs take precedence in Nextflow).
+
+    IMPORTANT — work directory must be under HOME:
+    Colima (QEMU or VZ backend) only mounts the macOS HOME directory into the VM.
+    /tmp and /private/tmp are NOT mounted; they map to the VM's own filesystem.
+    Use --output under your home directory to avoid ".command.run: No such file"
+    errors. Preflight emits a WARNING when --output is under /tmp.
+    """
+    config_path = output_dir / "reproducibility" / "macos_docker.config"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        '// macOS + Docker workaround for VirtioFS EDEADLK (errno 35), ARM64 hosts,\n'
+        '// STAR FIFOs, and the nf-core test profile 1 h time cap.\n'
+        'process {\n'
+        '    stageInMode = "copy"\n'
+        '    // VirtioFS I/O overhead makes STAR genome generation and alignment\n'
+        '    // exceed the test profile\'s 1 h cap. Raise the ceiling to 4 h.\n'
+        '    resourceLimits = [\n'
+        '        cpus: 4,\n'
+        '        memory: \'15.GB\',\n'
+        '        time: \'4.h\'\n'
+        '    ]\n'
+        '    // STAR creates FIFOs in _STARtmp; VirtioFS does not support FIFOs.\n'
+        '    // --outTmpDir /tmp/star_tmp routes _STARtmp to the container\'s /tmp\n'
+        '    // (Linux tmpfs), which does support FIFOs.\n'
+        '    // All other flags mirror nf-core/scrnaseq conf/modules.config verbatim\n'
+        '    // so this override does not silently drop --readFilesCommand zcat.\n'
+        '    // Note: do NOT use a closure that references task.ext.args — that\n'
+        '    // causes a StackOverflowError. Instead we reproduce the flags here.\n'
+        '    withName: \'.*STAR_ALIGN.*\' {\n'
+        '        ext.args = { "--readFilesCommand zcat --runDirPerm All_RWX --outWigType bedGraph --twopassMode Basic --outSAMtype BAM SortedByCoordinate --limitBAMsortRAM ${task.memory.toBytes()} --outTmpDir /tmp/star_tmp" }\n'
+        '    }\n'
+        '}\n'
+        'docker {\n'
+        '    runOptions = "--platform linux/amd64"\n'
+        '}\n',
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def _write_error_result_if_safe(output_dir: Path, payload: dict[str, object]) -> None:
+    """Persist structured errors unless doing so would overwrite a rejected output dir."""
+    error_code = payload.get("error_code")
+    if error_code in {"OUTPUT_DIR_NOT_EMPTY", "OUTPUT_DIR_NOT_WRITABLE"}:
+        return
+    if error_code == "INVALID_RESUME_STATE" and (output_dir / "result.json").exists():
+        return
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "result.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    except OSError:
+        # stderr still receives the structured payload; avoid masking the root error.
+        return
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    output_dir = Path(args.output).expanduser().resolve()
+
+    try:
+        return _run_wrapper(args, output_dir)
+    except SkillError as exc:
+        return _handle_skill_error(output_dir, exc)
+    except Exception as exc:
+        return _handle_unexpected_error(output_dir, exc)
+
+
+def _run_wrapper(args: argparse.Namespace, output_dir: Path) -> int:
+    if args.resume:
+        with tempfile.TemporaryDirectory(prefix="clawbio-scrnaseq-resume-") as staging_dir:
+            return _run_wrapper_with_staging(args, output_dir, staging_dir=Path(staging_dir))
+    return _run_wrapper_with_staging(args, output_dir, staging_dir=None)
+
+
+def _run_wrapper_with_staging(args: argparse.Namespace, output_dir: Path, *, staging_dir: Path | None) -> int:
+    check_output_dir_available(output_dir, resume=args.resume)
+    pipeline_source = resolve_pipeline_source(requested_version=args.pipeline_version)
+    normalized_samplesheet, staged_samplesheet, samplesheet_summary = _prepare_samplesheet(
+        args,
+        output_dir,
+        staging_dir=staging_dir,
+    )
+    preflight_result = run_preflight(args, pipeline_source=pipeline_source, samplesheet_summary=samplesheet_summary)
+    if args.check:
+        return _write_check_mode_result(output_dir, preflight_result=preflight_result, pipeline_source=pipeline_source)
+    return _run_execution_mode(
+        args,
+        output_dir=output_dir,
+        pipeline_source=pipeline_source,
+        preflight_result=preflight_result,
+        normalized_samplesheet=normalized_samplesheet,
+        staged_samplesheet=staged_samplesheet,
+        samplesheet_summary=samplesheet_summary,
+    )
+
+
+def _prepare_samplesheet(
+    args: argparse.Namespace,
+    output_dir: Path,
+    *,
+    staging_dir: Path | None,
+) -> tuple[Path, Path, dict[str, object]]:
+    if args.demo:
+        return _prepare_demo_samplesheet(args, output_dir, staging_dir=staging_dir)
+    return _prepare_user_samplesheet(args, output_dir, staging_dir=staging_dir)
+
+
+def _prepare_demo_samplesheet(
+    args: argparse.Namespace,
+    output_dir: Path,
+    *,
+    staging_dir: Path | None,
+) -> tuple[Path, Path, dict[str, object]]:
+    # Apply demo overrides first so all subsequent callers see star.
+    if args.preset != "star":
+        print(
+            f"WARNING: --demo forces preset=star (requested: {args.preset!r}). "
+            "The nf-core test profile ships STAR-compatible data.",
+            file=sys.stderr,
+        )
+    args.preset = "star"
+    args.skip_cellbender = True
+
+    normalized_samplesheet = _final_samplesheet_path(output_dir, demo=True)
+    staged_samplesheet = _staged_samplesheet_path(output_dir, staging_dir=staging_dir, demo=True)
+    _write_demo_samplesheet(staged_samplesheet)
+    return normalized_samplesheet, staged_samplesheet, {
+        "normalized_path": normalized_samplesheet,
+        "sample_count": 0,
+        "sample_names": [],
+        "fastq_paths": [],
+        "unknown_columns": [],
+    }
+
+
+def _prepare_user_samplesheet(
+    args: argparse.Namespace,
+    output_dir: Path,
+    *,
+    staging_dir: Path | None,
+) -> tuple[Path, Path, dict[str, object]]:
+    if not args.input:
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.MISSING_INPUT,
+            message="An input samplesheet is required unless --demo is used.",
+            fix="Provide --input <samplesheet.csv> or run with --demo.",
+            details={},
+        )
+    normalized_samplesheet = _final_samplesheet_path(output_dir)
+    staged_samplesheet = _staged_samplesheet_path(output_dir, staging_dir=staging_dir)
+    samplesheet_summary = validate_and_normalize_samplesheet(
+        Path(args.input).expanduser().resolve(),
+        staged_samplesheet,
+        expected_cells_override=args.expected_cells,
+        preset=args.preset,
+    )
+    samplesheet_summary["normalized_path"] = normalized_samplesheet
+    _warn_about_preserved_unknown_columns(samplesheet_summary)
+    return normalized_samplesheet, staged_samplesheet, samplesheet_summary
+
+
+def _final_samplesheet_path(output_dir: Path, *, demo: bool = False) -> Path:
+    filename = "samplesheet.demo.csv" if demo else "samplesheet.valid.csv"
+    return output_dir / "reproducibility" / filename
+
+
+def _staged_samplesheet_path(output_dir: Path, *, staging_dir: Path | None, demo: bool = False) -> Path:
+    if staging_dir is not None:
+        filename = "samplesheet.demo.csv" if demo else "samplesheet.valid.csv"
+        return staging_dir / filename
+    return _final_samplesheet_path(output_dir, demo=demo)
+
+
+def _warn_about_preserved_unknown_columns(samplesheet_summary: dict[str, object]) -> None:
+    unknown_columns = samplesheet_summary.get("unknown_columns", [])
+    if unknown_columns:
+        print(
+            f"WARNING: samplesheet contains unrecognised columns that will be preserved: {unknown_columns}",
+            file=sys.stderr,
+        )
+
+
+def _write_check_mode_result(
+    output_dir: Path,
+    *,
+    preflight_result: dict[str, object],
+    pipeline_source: dict[str, object],
+) -> int:
+    payload = {
+        "ok": True,
+        "skill": SKILL_NAME,
+        "preflight": preflight_result,
+        "pipeline_source": pipeline_source,
+    }
+    write_check_result(output_dir, payload)
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+def _run_execution_mode(
+    args: argparse.Namespace,
+    *,
+    output_dir: Path,
+    pipeline_source: dict[str, object],
+    preflight_result: dict[str, object],
+    normalized_samplesheet: Path,
+    staged_samplesheet: Path,
+    samplesheet_summary: dict[str, object],
+) -> int:
+    params_payload = build_effective_params(
+        args,
+        normalized_samplesheet=normalized_samplesheet,
+        output_dir=output_dir,
+    )
+    _check_resume_params_checksum(args, output_dir=output_dir, params_payload=params_payload)
+    _commit_validated_samplesheet(staged_samplesheet, normalized_samplesheet)
+    params_path = write_params_yaml(params_payload, output_dir=output_dir)
+    command, command_str = _build_nextflow_invocation(args, output_dir, pipeline_source, params_path)
+    nextflow_cwd = _nextflow_execution_cwd(output_dir)
+    execution_result = execute_nextflow(
+        command,
+        cwd=nextflow_cwd,
+        output_dir=output_dir,
+        timeout_seconds=DEFAULT_TIMEOUT_SECONDS,
+    )
+    parsed_outputs = _parse_outputs_with_effective_aligner(output_dir, args)
+    _write_success_outputs(
+        output_dir,
+        args=args,
+        pipeline_source=pipeline_source,
+        preflight_result=preflight_result,
+        params_path=params_path,
+        params_payload=params_payload,
+        normalized_samplesheet=normalized_samplesheet,
+        samplesheet_summary=samplesheet_summary,
+        parsed_outputs=parsed_outputs,
+        execution_result=execution_result,
+        command_str=_nextflow_replay_command(command_str, nextflow_cwd),
+    )
+    _run_downstream_handoff(args, parsed_outputs=parsed_outputs, output_dir=output_dir)
+    print(f"Wrapper completed successfully. Output: {output_dir}")
+    return 0
+
+
+def _commit_validated_samplesheet(staged_samplesheet: Path, normalized_samplesheet: Path) -> None:
+    if staged_samplesheet == normalized_samplesheet:
+        return
+    normalized_samplesheet.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(staged_samplesheet, normalized_samplesheet)
+
+
+def _check_resume_params_checksum(
+    args: argparse.Namespace,
+    *,
+    output_dir: Path,
+    params_payload: dict[str, object],
+) -> None:
+    if not args.resume:
+        return
+    manifest_path = output_dir / "reproducibility" / "manifest.json"
+    if not manifest_path.exists():
+        return
+    params_checksum = _params_payload_checksum(params_payload)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if manifest.get("params_checksum") == params_checksum:
+        return
+    raise SkillError(
+        stage="preflight",
+        error_code=ErrorCode.INVALID_RESUME_STATE,
+        message="Resume state does not match the effective params.yaml for this run.",
+        fix="Use the same arguments as the original run or remove --resume.",
+        details={
+            "previous_params_checksum": manifest.get("params_checksum"),
+            "requested_params_checksum": params_checksum,
+        },
+    )
+
+
+def _params_payload_checksum(params_payload: dict[str, object]) -> str:
+    return hashlib.sha256(serialize_params_yaml(params_payload).encode("utf-8")).hexdigest()
+
+
+def _build_nextflow_invocation(
+    args: argparse.Namespace,
+    output_dir: Path,
+    pipeline_source: dict[str, object],
+    params_path: Path,
+) -> tuple[list[str], str]:
+    return build_nextflow_command(
+        pipeline_source=pipeline_source,
+        profile=f"test,{args.profile}" if args.demo else args.profile,
+        params_path=params_path,
+        resume=args.resume,
+        work_dir=output_dir / "upstream" / "work",
+        extra_configs=_build_extra_nextflow_configs(args, output_dir),
+    )
+
+
+def _build_extra_nextflow_configs(args: argparse.Namespace, output_dir: Path) -> list[Path]:
+    # The VirtioFS EDEADLK fix is macOS-specific:
+    #   Linux native: no VirtioFS; Docker bind-mounts are direct overlayfs.
+    #   Windows/WSL2: Nextflow runs inside WSL2 (reports "Linux"); work dir is on ext4.
+    #   Windows native: not officially supported by Nextflow; users should use WSL2.
+    if platform.system() == "Darwin" and args.profile == "docker":
+        return [_write_macos_docker_config(output_dir)]
+    return []
+
+
+def _nextflow_execution_cwd(output_dir: Path) -> Path:
+    # params.input is written relative to output_dir so it stays schema-safe even
+    # when the absolute workspace path contains spaces.
+    return output_dir
+
+
+def _nextflow_replay_command(command_str: str, cwd: Path) -> str:
+    return f"cd {shlex.quote(cwd.as_posix())} && {command_str}"
+
+
+def _parse_outputs_with_effective_aligner(output_dir: Path, args: argparse.Namespace) -> dict[str, object]:
+    return {
+        **parse_outputs(output_dir),
+        "aligner_effective": PRESET_ALIGNERS[args.preset],
+    }
+
+
+def _write_success_outputs(
+    output_dir: Path,
+    *,
+    args: argparse.Namespace,
+    pipeline_source: dict[str, object],
+    preflight_result: dict[str, object],
+    params_path: Path,
+    params_payload: dict[str, object],
+    normalized_samplesheet: Path,
+    samplesheet_summary: dict[str, object],
+    parsed_outputs: dict[str, object],
+    execution_result: dict[str, object],
+    command_str: str,
+) -> None:
+    write_repro_commands(output_dir, args=args)
+    write_provenance_bundle(
+        output_dir,
+        args=args,
+        pipeline_source=pipeline_source,
+        preflight_result=preflight_result,
+        params_path=params_path,
+        params_payload=params_payload,
+        normalized_samplesheet=normalized_samplesheet,
+        samplesheet_summary=samplesheet_summary,
+        parsed_outputs=parsed_outputs,
+        execution_result=execution_result,
+        command_str=command_str,
+    )
+    write_report(
+        output_dir,
+        args=args,
+        pipeline_source=pipeline_source,
+        preflight_result=preflight_result,
+        parsed_outputs=parsed_outputs,
+        command_str=command_str,
+    )
+    write_result(
+        output_dir,
+        args=args,
+        pipeline_source=pipeline_source,
+        parsed_outputs=parsed_outputs,
+        command_str=command_str,
+    )
+
+
+_SCRNA_ORCHESTRATOR_DEFAULT = _SKILL_DIR.parent / "scrna-orchestrator" / "scrna_orchestrator.py"
+
+
+def _resolve_scrna_orchestrator() -> Path | None:
+    env_path = os.environ.get("CLAWBIO_SCRNA_ORCHESTRATOR")
+    if env_path:
+        p = Path(env_path)
+        return p if p.exists() else None
+    return _SCRNA_ORCHESTRATOR_DEFAULT if _SCRNA_ORCHESTRATOR_DEFAULT.exists() else None
+
+
+def _run_downstream_handoff(
+    args: argparse.Namespace,
+    *,
+    parsed_outputs: dict[str, object],
+    output_dir: Path,
+) -> None:
+    if not getattr(args, "run_downstream", False) or getattr(args, "skip_downstream", False):
+        return
+    preferred_h5ad = str(parsed_outputs.get("preferred_h5ad", "")).strip()
+    if not preferred_h5ad:
+        return
+    orchestrator = _resolve_scrna_orchestrator()
+    if orchestrator is None:
+        print(
+            "WARNING: scrna_orchestrator not found. "
+            "Set CLAWBIO_SCRNA_ORCHESTRATOR=/path/to/scrna_orchestrator.py to enable automatic handoff.",
+            file=sys.stderr,
+        )
+        return
+    downstream_output = output_dir / "scrna_analysis"
+    cmd = [
+        sys.executable,
+        str(orchestrator),
+        "--input", preferred_h5ad,
+        "--output", str(downstream_output),
+    ]
+    print("Handing off to scrna_orchestrator...")
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=_DOWNSTREAM_HANDOFF_TIMEOUT_SECONDS,
+            cwd=str(_PROJECT_ROOT),
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            "WARNING: downstream scrna_orchestrator timed out. "
+            "The nf-core pipeline completed successfully; run downstream analysis manually if needed.",
+            file=sys.stderr,
+        )
+        return
+    if result.returncode != 0:
+        print(
+            f"WARNING: downstream scrna_orchestrator exited with code {result.returncode}. "
+            "The nf-core pipeline completed successfully; inspect scrna_analysis/ manually.",
+            file=sys.stderr,
+        )
+
+
+def _handle_skill_error(output_dir: Path, exc: SkillError) -> int:
+    payload = exc.to_dict()
+    _write_error_result_if_safe(output_dir, payload)
+    print(json.dumps(payload, indent=2), file=sys.stderr)
+    return 1
+
+
+def _handle_unexpected_error(output_dir: Path, exc: Exception) -> int:
+    payload = {
+        "ok": False,
+        "stage": "internal",
+        "error_code": ErrorCode.UNEXPECTED_ERROR,
+        "message": str(exc),
+        "fix": "Report this as a bug. Include the full traceback and your command arguments.",
+        "details": {
+            "exception_type": type(exc).__name__,
+            "traceback": traceback.format_exc(),
+        },
+    }
+    _write_error_result_if_safe(output_dir, payload)
+    print(json.dumps(payload, indent=2), file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/nfcore-scrnaseq-wrapper/outputs_parser.py
+++ b/skills/nfcore-scrnaseq-wrapper/outputs_parser.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SKILL_DIR = Path(__file__).resolve().parent
+if str(_SKILL_DIR) not in sys.path:
+    sys.path.insert(0, str(_SKILL_DIR))
+
+from errors import ErrorCode, SkillError
+from schemas import PREFERRED_H5AD_ORDER
+
+
+def _first_match(root: Path, pattern: str) -> str:
+    matches = sorted(root.glob(pattern))
+    return str(matches[0]) if matches else ""
+
+
+def parse_outputs(output_dir: Path) -> dict[str, object]:
+    upstream_dir = _require_upstream_results_dir(output_dir)
+    h5ad_candidates = find_h5ad_candidates(upstream_dir)
+    rds_candidates = find_rds_outputs(upstream_dir)
+    preferred_h5ad = select_preferred_h5ad(h5ad_candidates)
+
+    return {
+        "upstream_dir": str(upstream_dir),
+        "multiqc_report": find_multiqc_report(upstream_dir),
+        "pipeline_info_dir": find_pipeline_info_dir(upstream_dir),
+        "h5ad_candidates": h5ad_candidates,
+        "rds_candidates": rds_candidates,
+        "preferred_h5ad": preferred_h5ad,
+        "preferred_h5ad_selection_log": build_selection_log(h5ad_candidates, preferred_h5ad),
+        "handoff_available": bool(preferred_h5ad),
+        "samples_detected": detect_sample_names(h5ad_candidates),
+        "cellbender_used": detect_cellbender_outputs(h5ad_candidates),
+    }
+
+
+def build_selection_log(h5ad_candidates: list[str], preferred_h5ad: str) -> str:
+    if not h5ad_candidates:
+        return "No h5ad output files found."
+    if not preferred_h5ad:
+        return (
+            f"No canonical h5ad selected — {len(h5ad_candidates)} candidate(s) found "
+            "but selection is ambiguous. Inspect h5ad_candidates in result.json."
+        )
+    name = Path(preferred_h5ad).name
+    all_names = [Path(c).name for c in h5ad_candidates]
+    return f"Selected '{name}' from {len(h5ad_candidates)} candidate(s). All candidates: {all_names}."
+
+
+def _require_upstream_results_dir(output_dir: Path) -> Path:
+    upstream_dir = output_dir / "upstream" / "results"
+    if upstream_dir.exists():
+        return upstream_dir
+    raise SkillError(
+        stage="parsing",
+        error_code=ErrorCode.EXPECTED_OUTPUTS_NOT_FOUND,
+        message="Pipeline output directory was not created.",
+        fix="Re-run the wrapper after checking the Nextflow logs.",
+        details={"expected_dir": str(upstream_dir)},
+    )
+
+
+def find_h5ad_candidates(upstream_dir: Path) -> list[str]:
+    return sorted(str(path) for path in upstream_dir.rglob("*.h5ad"))
+
+
+def find_rds_outputs(upstream_dir: Path) -> list[str]:
+    return sorted(str(path) for path in upstream_dir.rglob("*.rds"))
+
+
+def find_multiqc_report(upstream_dir: Path) -> str:
+    return _first_match(upstream_dir, "multiqc/**/multiqc_report.html") or _first_match(
+        upstream_dir, "**/multiqc_report.html"
+    )
+
+
+def find_pipeline_info_dir(upstream_dir: Path) -> str:
+    pipeline_info_dir = upstream_dir / "pipeline_info"
+    return str(pipeline_info_dir) if pipeline_info_dir.exists() else ""
+
+
+def select_preferred_h5ad(h5ad_candidates: list[str]) -> str:
+    for preferred_name in PREFERRED_H5AD_ORDER:
+        preferred_matches = _find_candidates_named(h5ad_candidates, preferred_name)
+        if len(preferred_matches) == 1:
+            return preferred_matches[0]
+        if len(preferred_matches) > 1:
+            return ""
+    # A single sample output is safe to hand off; multiple sample outputs are ambiguous.
+    return h5ad_candidates[0] if len(h5ad_candidates) == 1 else ""
+
+
+def _find_candidates_named(h5ad_candidates: list[str], filename: str) -> list[str]:
+    return [candidate for candidate in h5ad_candidates if Path(candidate).name == filename]
+
+
+def detect_sample_names(h5ad_candidates: list[str]) -> list[str]:
+    return sorted(
+        {
+            _sample_name_from_h5ad(candidate)
+            for candidate in h5ad_candidates
+            if _sample_name_from_h5ad(candidate)
+        }
+    )
+
+
+def _sample_name_from_h5ad(candidate: str) -> str:
+    sample_name = (
+        Path(candidate).name
+        .replace("_cellbender_filter_matrix.h5ad", "")
+        .replace("_filtered_matrix.h5ad", "")
+        .replace("_raw_matrix.h5ad", "")
+    )
+    if sample_name == "combined" or sample_name.endswith(".h5ad"):
+        return ""
+    return sample_name
+
+
+def detect_cellbender_outputs(h5ad_candidates: list[str]) -> bool:
+    return any("cellbender" in path.lower() for path in h5ad_candidates)

--- a/skills/nfcore-scrnaseq-wrapper/params_builder.py
+++ b/skills/nfcore-scrnaseq-wrapper/params_builder.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+_SKILL_DIR = Path(__file__).resolve().parent
+if str(_SKILL_DIR) not in sys.path:
+    sys.path.insert(0, str(_SKILL_DIR))
+
+from errors import ErrorCode, SkillError
+from schemas import PRESET_ALIGNERS
+
+_WHITESPACE_RE = re.compile(r"\s")
+
+_SKIP_FLAGS = (
+    "skip_fastqc",
+    "skip_multiqc",
+    "skip_cellranger_renaming",
+    "skip_cellrangermulti_vdjref",
+)
+
+_REFERENCE_PATH_FIELDS = (
+    "fasta",
+    "gtf",
+    "transcript_fasta",
+    "txp2gene",
+    "simpleaf_index",
+    "kallisto_index",
+    "star_index",
+    "cellranger_index",
+    "barcode_whitelist",
+    "kb_t1c",
+    "kb_t2c",
+    "motifs",
+    "cellrangerarc_config",
+    "cellranger_vdj_index",
+    "gex_frna_probe_set",
+    "gex_target_panel",
+    "gex_cmo_set",
+    "fb_reference",
+    "vdj_inner_enrichment_primers",
+    "gex_barcode_sample_assignment",
+    "cellranger_multi_barcodes",
+)
+
+
+def _posix(value: str) -> str:
+    """Resolve a user-supplied path to absolute and convert to forward-slash notation.
+
+    Nextflow (Java) accepts forward slashes on all platforms, including Windows.
+    Using as_posix() avoids YAML escape-sequence ambiguity with backslashes and
+    ensures relative paths are anchored before Nextflow changes its working directory.
+    """
+    return Path(value).expanduser().resolve().as_posix()
+
+
+def build_params_file(args, *, normalized_samplesheet: Path, output_dir: Path) -> tuple[Path, dict[str, object]]:
+    params = build_effective_params(args, normalized_samplesheet=normalized_samplesheet, output_dir=output_dir)
+    params_path = write_params_yaml(params, output_dir=output_dir)
+    return params_path, params
+
+
+def build_effective_params(args, *, normalized_samplesheet: Path, output_dir: Path) -> dict[str, object]:
+    params = _build_base_params(args, normalized_samplesheet=normalized_samplesheet, output_dir=output_dir)
+    _add_input_metadata_params(params, args)
+    _add_skip_params(params, args)
+    _add_aligner_tuning_params(params, args)
+    _add_symbolic_reference_params(params, args)
+    _add_save_flags(params, args)
+    _add_reference_path_params(params, args)
+    return params
+
+
+def _build_base_params(args, *, normalized_samplesheet: Path, output_dir: Path) -> dict[str, object]:
+    upstream_outdir = output_dir / "upstream" / "results"
+    params: dict[str, object] = {
+        # Forward slashes: safe on all platforms and unambiguous in YAML.
+        "outdir": upstream_outdir.as_posix(),
+        "aligner": PRESET_ALIGNERS[args.preset],
+        "skip_cellbender": _skip_cellbender_enabled(args),
+    }
+    if not args.demo:
+        params["input"] = _schema_safe_input_path(normalized_samplesheet, output_dir=output_dir)
+    else:
+        # nf-schema 4.x validates igenomes_base (an S3 URL) even when the test
+        # profile provides explicit fasta/gtf. DNS failure aborts before any task
+        # runs. igenomes_ignore suppresses that validation when iGenomes is unused.
+        params["igenomes_ignore"] = True
+    if args.protocol:
+        params["protocol"] = args.protocol
+    return params
+
+
+def _skip_cellbender_enabled(args) -> bool:
+    return bool(getattr(args, "skip_cellbender", False) or getattr(args, "skip_emptydrops", False))
+
+
+def _schema_safe_input_path(normalized_samplesheet: Path, *, output_dir: Path) -> str:
+    """Return an nf-core schema-compatible path to the normalized samplesheet.
+
+    nf-core/scrnaseq 4.1.0 validates --input with ``^\\S+\\.csv$``. The wrapper
+    stores the normalized samplesheet under ``output/reproducibility`` and runs
+    Nextflow from ``output`` so this can be a stable, whitespace-free relative
+    path even when the repository or output directory contains spaces.
+    """
+    normalized_samplesheet = normalized_samplesheet.resolve()
+    output_dir = output_dir.resolve()
+    try:
+        input_path = normalized_samplesheet.relative_to(output_dir).as_posix()
+    except ValueError:
+        input_path = normalized_samplesheet.as_posix()
+    if _WHITESPACE_RE.search(input_path):
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.INVALID_SAMPLESHEET,
+            message="The normalized samplesheet path is not compatible with the nf-core/scrnaseq schema.",
+            fix=(
+                "Use an output directory layout where the relative path to "
+                "reproducibility/samplesheet.valid.csv contains no whitespace."
+            ),
+            details={"input_path": input_path},
+        )
+    return input_path
+
+
+def _add_input_metadata_params(params: dict[str, object], args) -> None:
+    # Input/output metadata — only written when provided.
+    if getattr(args, "email", None):
+        params["email"] = args.email
+    if getattr(args, "multiqc_title", None):
+        params["multiqc_title"] = args.multiqc_title
+
+
+def _add_skip_params(params: dict[str, object], args) -> None:
+    # Skip flags — only written when True to keep params.yaml clean.
+    for flag_name in _SKIP_FLAGS:
+        if getattr(args, flag_name, False):
+            params[flag_name] = True
+
+
+def _add_aligner_tuning_params(params: dict[str, object], args) -> None:
+    # STARsolo extras.
+    if getattr(args, "star_ignore_sjdbgtf", False):
+        # Schema type is 'string' (not boolean) — write "true" to pass nf-core JSON schema validation.
+        # Groovy evaluates any non-empty string as truthy, so this correctly disables sjdbGTF.
+        params["star_ignore_sjdbgtf"] = "true"
+    if getattr(args, "seq_center", None):
+        params["seq_center"] = args.seq_center
+
+    # Aligner-specific tuning — only written when explicitly set.
+    if getattr(args, "star_feature", None):
+        params["star_feature"] = args.star_feature
+    if getattr(args, "simpleaf_umi_resolution", None):
+        params["simpleaf_umi_resolution"] = args.simpleaf_umi_resolution
+    if getattr(args, "kb_workflow", None):
+        params["kb_workflow"] = args.kb_workflow
+
+
+def _add_symbolic_reference_params(params: dict[str, object], args) -> None:
+    # iGenomes shortcut and CellRanger ARC reference — symbolic names, not paths.
+    if getattr(args, "genome", None):
+        params["genome"] = args.genome
+    if getattr(args, "cellrangerarc_reference", None):
+        params["cellrangerarc_reference"] = args.cellrangerarc_reference
+
+
+def _add_save_flags(params: dict[str, object], args) -> None:
+    if getattr(args, "save_reference", False):
+        params["save_reference"] = True
+    if getattr(args, "save_align_intermeds", False):
+        params["save_align_intermeds"] = True
+
+
+def _add_reference_path_params(params: dict[str, object], args) -> None:
+    # All file paths — resolved to absolute POSIX before writing so Nextflow
+    # can locate them regardless of its own working directory at runtime.
+    explicit_refs = []
+    for param_name in _REFERENCE_PATH_FIELDS:
+        value = getattr(args, param_name, None)
+        if value:
+            params[param_name] = _posix(value)
+            explicit_refs.append(param_name)
+    # When fasta/gtf are provided explicitly, iGenomes is unused. Suppress
+    # nf-schema DNS validation of the default igenomes_base S3 URL.
+    if explicit_refs and "fasta" in explicit_refs:
+        params.setdefault("igenomes_ignore", True)
+
+
+def write_params_yaml(params: dict[str, object], *, output_dir: Path) -> Path:
+    repro_dir = output_dir / "reproducibility"
+    repro_dir.mkdir(parents=True, exist_ok=True)
+    params_path = repro_dir / "params.yaml"
+    params_path.write_text(serialize_params_yaml(params), encoding="utf-8")
+    return params_path
+
+
+def serialize_params_yaml(params: dict[str, object]) -> str:
+    return yaml.dump(params, allow_unicode=True, sort_keys=False)

--- a/skills/nfcore-scrnaseq-wrapper/pipeline_source.py
+++ b/skills/nfcore-scrnaseq-wrapper/pipeline_source.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_SKILL_DIR = Path(__file__).resolve().parent
+if str(_SKILL_DIR) not in sys.path:
+    sys.path.insert(0, str(_SKILL_DIR))
+
+from errors import ErrorCode, SkillError
+from schemas import DEFAULT_LOCAL_PIPELINE_DIR, DEFAULT_REMOTE_PIPELINE, PIPELINE_REQUIRED_FILES
+
+
+_GIT_TIMEOUT = 10
+
+
+def _path_has_whitespace(path: Path) -> bool:
+    return any(" " in part for part in path.parts)
+
+
+def _git_stdout(path: Path, args: list[str]) -> str:
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=str(path),
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=_GIT_TIMEOUT,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return ""
+    return proc.stdout.strip()
+
+
+def resolve_pipeline_source(
+    *,
+    requested_version: str,
+    local_pipeline_dir: Path | None = None,
+) -> dict[str, str | bool]:
+    local_dir = (local_pipeline_dir or DEFAULT_LOCAL_PIPELINE_DIR).resolve()
+    if local_dir.exists() and _path_has_whitespace(local_dir):
+        print(
+            f"WARNING: Local scrnaseq checkout at '{local_dir}' contains whitespace in its path. "
+            "Docker on macOS cannot reliably execute scripts from paths with spaces (errno 35). "
+            "Falling back to the remote nf-core/scrnaseq pipeline.",
+            file=sys.stderr,
+        )
+    elif local_dir.exists():
+        missing = [name for name in PIPELINE_REQUIRED_FILES if not (local_dir / name).exists()]
+        if missing:
+            raise SkillError(
+                stage="preflight",
+                error_code=ErrorCode.PIPELINE_SOURCE_INVALID,
+                message="Local scrnaseq checkout is missing required files.",
+                fix="Ensure the sibling `scrnaseq` repository is present and complete.",
+                details={"path": str(local_dir), "missing_files": missing},
+            )
+
+        branch = _git_stdout(local_dir, ["branch", "--show-current"])
+        commit = _git_stdout(local_dir, ["rev-parse", "HEAD"])
+        # No --untracked-files=no: untracked files are intentionally included so that
+        # locally-added config overrides or data files are reflected in dirty=True.
+        # git respects .gitignore, so build artifacts (work/, .nextflow/) stay invisible
+        # as long as the pipeline checkout carries a proper .gitignore.
+        status = _git_stdout(local_dir, ["status", "--porcelain"])
+        return {
+            "source_kind": "local_checkout",
+            "source_ref": str(local_dir),
+            "resolved_version": commit or requested_version,
+            "branch": branch,
+            "dirty": bool(status),
+        }
+
+    return {
+        "source_kind": "remote_repo",
+        "source_ref": DEFAULT_REMOTE_PIPELINE,
+        "resolved_version": requested_version,
+        "branch": "",
+        "dirty": False,
+    }

--- a/skills/nfcore-scrnaseq-wrapper/preflight.py
+++ b/skills/nfcore-scrnaseq-wrapper/preflight.py
@@ -1,0 +1,757 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+_SKILL_DIR = Path(__file__).resolve().parent
+if str(_SKILL_DIR) not in sys.path:
+    sys.path.insert(0, str(_SKILL_DIR))
+
+from errors import ErrorCode, SkillError
+from schemas import (
+    COMMON_GENOMES,
+    JAVA_MIN_VERSION,
+    NEXTFLOW_MIN_VERSION,
+    PRESET_REQUIREMENTS,
+    SUPPORTED_PRESETS,
+    SUPPORTED_PROFILES,
+)
+
+
+_SUBPROCESS_TIMEOUT = 30
+_FASTA_SCHEMA_RE = re.compile(r"^\S+\.fn?a(sta)?(\.gz)?$")
+_EMAIL_SCHEMA_RE = re.compile(r"^([a-zA-Z0-9_\-.]+)@([a-zA-Z0-9_\-.]+)\.([a-zA-Z]{2,5})$")
+
+
+def _command_output(args: list[str]) -> str:
+    try:
+        proc = subprocess.run(
+            args, capture_output=True, text=True, errors="replace", timeout=_SUBPROCESS_TIMEOUT
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return ""
+    if proc.returncode != 0:
+        return ""
+    return (proc.stdout or proc.stderr).strip()
+
+
+def _pad_version(t: tuple[int, ...], length: int = 3) -> tuple[int, ...]:
+    return t + (0,) * max(0, length - len(t))
+
+
+def _parse_version_tuple(text: str) -> tuple[int, ...]:
+    m = re.search(r'\b(\d+)\.(\d+)\.(\d+)\b', text)
+    if m:
+        return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+    m = re.search(r'\b(\d+)\.(\d+)\b', text)
+    if m:
+        return (int(m.group(1)), int(m.group(2)))
+    m = re.search(r'\b(\d+)\b', text)
+    if m:
+        return (int(m.group(1)),)
+    return ()
+
+
+def _check_executable(name: str) -> str:
+    path = shutil.which(name)
+    if not path:
+        raise SkillError(
+            stage="preflight",
+            error_code=f"MISSING_{name.upper().replace('-', '_')}",
+            message=f"Required executable `{name}` was not found.",
+            fix=f"Install `{name}` and ensure it is available on PATH.",
+            details={"executable": name},
+        )
+    return path
+
+
+def _check_java() -> dict[str, str]:
+    java_path = _check_executable("java")
+    version_text = _command_output(["java", "-version"])
+    version_tuple = _parse_version_tuple(version_text)
+    if not version_tuple:
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.MISSING_JAVA,
+            message="Java is installed but its version could not be determined.",
+            fix="Install Java 17 or newer and ensure `java -version` works.",
+            details={"java_path": java_path},
+        )
+    if version_tuple[0] < JAVA_MIN_VERSION:
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.JAVA_VERSION_TOO_OLD,
+            message="Java version is too old for this wrapper.",
+            fix="Install Java 17 or newer.",
+            details={"detected_version": ".".join(map(str, version_tuple))},
+        )
+    return {"path": java_path, "version": ".".join(map(str, version_tuple))}
+
+
+def _check_nextflow() -> dict[str, str]:
+    nextflow_path = _check_executable("nextflow")
+    version_text = _command_output(["nextflow", "-version"])
+    version_tuple = _parse_version_tuple(version_text)
+    if not version_tuple:
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.MISSING_NEXTFLOW,
+            message="Nextflow is installed but its version could not be determined.",
+            fix="Install Nextflow 25.04.0 or newer and ensure `nextflow -version` works.",
+            details={"nextflow_path": nextflow_path},
+        )
+    if _pad_version(version_tuple) < _pad_version(NEXTFLOW_MIN_VERSION):
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.NEXTFLOW_VERSION_TOO_OLD,
+            message="Nextflow version is too old for this wrapper.",
+            fix="Upgrade Nextflow to 25.04.0 or newer.",
+            details={"detected_version": ".".join(map(str, version_tuple))},
+        )
+    return {"path": nextflow_path, "version": ".".join(map(str, version_tuple))}
+
+
+def _check_profile(profile: str) -> dict[str, str | bool]:
+    if profile not in SUPPORTED_PROFILES:
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.INVALID_PROFILE,
+            message="Unsupported execution profile.",
+            fix=f"Choose one of: {', '.join(sorted(SUPPORTED_PROFILES))}.",
+            details={"profile": profile},
+        )
+    if profile == "docker":
+        return _check_docker_profile(profile)
+    if profile == "conda":
+        return _check_conda_profile(profile)
+    if profile == "mamba":
+        return _check_mamba_profile(profile)
+    if profile == "podman":
+        return _check_podman_profile(profile)
+    if profile in {"shifter", "charliecloud"}:
+        return _check_hpc_profile(profile)
+    return _check_singularity_compatible_profile(profile)
+
+
+def _check_docker_profile(profile: str) -> dict[str, str | bool]:
+    docker_path = shutil.which("docker")
+    if not docker_path:
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.MISSING_DOCKER,
+            message="Docker profile was selected but Docker is not installed.",
+            fix="Install Docker or choose another supported profile.",
+            details={"profile": profile},
+        )
+    try:
+        info = subprocess.run(["docker", "info"], capture_output=True, text=True, timeout=_SUBPROCESS_TIMEOUT)
+        docker_ok = info.returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        docker_ok = False
+    if not docker_ok:
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.DOCKER_NOT_RUNNING,
+            message="Docker is installed but the daemon is not available.",
+            fix="Start Docker Desktop or the Docker daemon before running this skill.",
+            details={"profile": profile},
+        )
+    return {"profile": profile, "backend_path": docker_path, "backend_ready": True}
+
+
+def _check_conda_profile(profile: str) -> dict[str, str | bool]:
+    # Prefer conda (matches the profile name); fall back to mamba.
+    # _check_mamba_profile uses the opposite order: mamba-first, conda-fallback.
+    backend = shutil.which("conda") or shutil.which("mamba")
+    if not backend:
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.MISSING_CONDA,
+            message="Conda profile was selected but neither conda nor mamba is installed.",
+            fix="Install conda or mamba, or choose another profile.",
+            details={"profile": profile},
+        )
+    return {"profile": profile, "backend_path": backend, "backend_ready": True}
+
+
+def _check_singularity_compatible_profile(profile: str) -> dict[str, str | bool]:
+    # Singularity and Apptainer are API-compatible; accept either binary for either profile.
+    # Many modern HPC clusters ship only one of the two, or renamed the binary during the
+    # SingularityCE → Apptainer transition.
+    primary = "apptainer" if profile == "apptainer" else "singularity"
+    fallback = "singularity" if profile == "apptainer" else "apptainer"
+    backend = shutil.which(primary) or shutil.which(fallback)
+    if not backend:
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.MISSING_SINGULARITY,
+            message=(
+                f"{profile} profile was selected but neither `{primary}` nor `{fallback}` "
+                "was found on PATH."
+            ),
+            fix=(
+                f"Install Singularity or Apptainer and ensure it is available on PATH, "
+                f"or choose a different profile (docker, conda)."
+            ),
+            details={"profile": profile, "tried": [primary, fallback]},
+        )
+    return {"profile": profile, "backend_path": backend, "backend_ready": True}
+
+
+def _check_mamba_profile(profile: str) -> dict[str, str | bool]:
+    backend = shutil.which("mamba") or shutil.which("conda")
+    if not backend:
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.MISSING_CONDA,
+            message="Mamba profile was selected but neither mamba nor conda is installed.",
+            fix="Install mamba or conda, or choose another profile.",
+            details={"profile": profile},
+        )
+    return {"profile": profile, "backend_path": backend, "backend_ready": True}
+
+
+def _check_podman_profile(profile: str) -> dict[str, str | bool]:
+    podman_path = shutil.which("podman")
+    if not podman_path:
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.MISSING_PODMAN,
+            message="Podman profile was selected but Podman is not installed.",
+            fix="Install Podman or choose another supported profile.",
+            details={"profile": profile},
+        )
+    try:
+        info = subprocess.run(["podman", "info"], capture_output=True, text=True, timeout=_SUBPROCESS_TIMEOUT)
+        podman_ok = info.returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        podman_ok = False
+    if not podman_ok:
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.PODMAN_NOT_RUNNING,
+            message="Podman is installed but the service is not available.",
+            fix="Start the Podman service or socket before running this skill.",
+            details={"profile": profile},
+        )
+    return {"profile": profile, "backend_path": podman_path, "backend_ready": True}
+
+
+def _check_hpc_profile(profile: str) -> dict[str, str | bool]:
+    # HPC runtimes (shifter, charliecloud) are user-space tools that don't run a
+    # persistent daemon, so binary presence is the only liveness check needed.
+    binary_map = {"shifter": "shifter", "charliecloud": "ch-run"}
+    binary = binary_map[profile]
+    path = shutil.which(binary)
+    if not path:
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.MISSING_HPC_RUNTIME,
+            message=f"{profile} profile was selected but `{binary}` was not found on PATH.",
+            fix=f"Install {profile} and ensure `{binary}` is available on PATH, or choose a different profile.",
+            details={"profile": profile, "binary": binary},
+        )
+    return {"profile": profile, "backend_path": path, "backend_ready": True}
+
+
+_IGNORED_ROOT_NAMES = frozenset({".DS_Store", ".gitkeep", ".gitignore", "Thumbs.db", "check_result.json"})
+_ALLOWED_REPRO_FILES = frozenset({"samplesheet.valid.csv", "samplesheet.demo.csv", "params.yaml"})
+
+
+def _check_output_dir(output_dir: Path, *, resume: bool) -> None:
+    if output_dir.exists() and not output_dir.is_dir():
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.OUTPUT_DIR_NOT_WRITABLE,
+            message="Output path exists but is not a directory.",
+            fix="Choose a directory path for --output, not an existing file.",
+            details={"output_dir": str(output_dir)},
+        )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if not os.access(output_dir, os.W_OK):
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.OUTPUT_DIR_NOT_WRITABLE,
+            message="Output directory is not writable.",
+            fix="Choose a writable location for --output.",
+            details={"output_dir": str(output_dir)},
+        )
+    materialized_entries = []
+    for entry in output_dir.iterdir():
+        if entry.name in _IGNORED_ROOT_NAMES:
+            continue
+        if entry.name == "reproducibility" and entry.is_dir():
+            repro_entries = [
+                child for child in entry.iterdir()
+                if child.name not in _ALLOWED_REPRO_FILES and child.name not in _IGNORED_ROOT_NAMES
+            ]
+            if repro_entries:
+                materialized_entries.append(entry)
+            continue
+        materialized_entries.append(entry)
+    if materialized_entries and not resume:
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.OUTPUT_DIR_NOT_EMPTY,
+            message="Output directory already contains files.",
+            fix=(
+                "Choose a new empty output directory, or re-run with --resume only if the previous run "
+                "completed successfully (manifest.json must exist)."
+            ),
+            details={"output_dir": str(output_dir)},
+        )
+
+
+def check_output_dir_available(output_dir: Path, *, resume: bool) -> None:
+    """Validate output-dir reuse policy before writing wrapper artifacts."""
+    _check_output_dir(output_dir, resume=resume)
+
+
+# Fields that are string identifiers, not local paths — never existence-checked.
+_SYMBOLIC_REFERENCE_FIELDS = frozenset({"genome", "cellrangerarc_reference"})
+
+# Primary genome/index fields used to satisfy preset reference requirements.
+_PRIMARY_REFERENCE_FIELDS = (
+    "fasta", "gtf", "transcript_fasta", "txp2gene",
+    "simpleaf_index", "kallisto_index", "star_index", "cellranger_index", "barcode_whitelist",
+)
+
+# Additional optional file paths — existence-checked when provided, but not part of requires_any.
+_OPTIONAL_PATH_FIELDS = (
+    "kb_t1c", "kb_t2c",
+    "motifs", "cellrangerarc_config",
+    "cellranger_vdj_index",
+    "gex_frna_probe_set", "gex_target_panel", "gex_cmo_set", "fb_reference",
+    "vdj_inner_enrichment_primers", "gex_barcode_sample_assignment", "cellranger_multi_barcodes",
+)
+
+_EXPLICIT_REFERENCE_FIELDS = _PRIMARY_REFERENCE_FIELDS + _OPTIONAL_PATH_FIELDS
+
+
+def _check_references(args) -> dict[str, str]:
+    resolved = _collect_reference_values(args)
+    _reject_conflicting_reference_styles(resolved)
+    satisfied_group = _find_satisfied_reference_group(args.preset, resolved)
+    _check_preset_specific_requirements(args.preset, resolved, satisfied_group)
+    _check_reference_paths_exist(resolved)
+    return resolved
+
+
+def _collect_reference_values(args) -> dict[str, str]:
+    genome = getattr(args, "genome", None) or ""
+    cellrangerarc_reference = getattr(args, "cellrangerarc_reference", None) or ""
+    resolved = {"genome": genome, "cellrangerarc_reference": cellrangerarc_reference}
+    for field in _EXPLICIT_REFERENCE_FIELDS:
+        resolved[field] = getattr(args, field, None) or ""
+    return resolved
+
+
+def _reject_conflicting_reference_styles(resolved: dict[str, str]) -> None:
+    if resolved["genome"] and any(resolved[f] for f in _PRIMARY_REFERENCE_FIELDS if f != "barcode_whitelist"):
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.CONFLICTING_REFERENCES,
+            message="--genome (iGenomes shortcut) and explicit reference paths are mutually exclusive.",
+            fix="Use either --genome <shortcut> or explicit --fasta/--gtf/--index flags, not both.",
+            details={"genome": resolved["genome"]},
+        )
+
+
+def _find_satisfied_reference_group(preset: str, resolved: dict[str, str]) -> tuple[str, ...]:
+    requirements = PRESET_REQUIREMENTS[preset]["requires_any"]
+    for option_group in requirements:
+        if all(resolved.get(name, "") for name in option_group):
+            return option_group
+    raise SkillError(
+        stage="preflight",
+        error_code=ErrorCode.MISSING_REFERENCE,
+        message="The selected preset is missing required references or indexes.",
+        fix="Provide one of the supported reference/index combinations for this preset.",
+        details={"preset": preset, "accepted_combinations": [list(group) for group in requirements]},
+    )
+
+
+def _check_preset_specific_requirements(
+    preset: str,
+    resolved: dict[str, str],
+    satisfied_group: tuple[str, ...],
+) -> None:
+    if preset == "cellrangerarc" and satisfied_group != ("cellranger_index",):
+        _check_cellrangerarc_config_pairing(resolved)
+    requires_also = PRESET_REQUIREMENTS[preset].get("requires_also", [])
+    _require_additional_preset_fields(preset, resolved, requires_also, reason="for this preset")
+
+
+def _check_cellrangerarc_config_pairing(resolved: dict[str, str]) -> None:
+    """Mirror upstream ARC rules: motifs are optional, config/reference are paired."""
+    has_config = bool(resolved.get("cellrangerarc_config", ""))
+    has_reference = bool(resolved.get("cellrangerarc_reference", ""))
+    if has_config == has_reference:
+        return
+    missing_field = "cellrangerarc_reference" if has_config else "cellrangerarc_config"
+    flag = "--" + missing_field.replace("_", "-")
+    raise SkillError(
+        stage="preflight",
+        error_code=ErrorCode.INVALID_PRESET_CONFIGURATION,
+        message="CellRanger ARC custom config and reference name must be provided together.",
+        fix=(
+            f"Add {flag}, or omit both ARC config fields and let the pipeline build the reference "
+            "from --fasta/--gtf or --genome."
+        ),
+        details={"preset": "cellrangerarc", "missing_field": missing_field},
+    )
+
+
+def _require_additional_preset_fields(
+    preset: str,
+    resolved: dict[str, str],
+    fields: list[str],
+    *,
+    reason: str,
+) -> None:
+    for field in fields:
+        if not resolved.get(field, ""):
+            flag = "--" + field.replace("_", "-")
+            raise SkillError(
+                stage="preflight",
+                error_code=ErrorCode.INVALID_PRESET_CONFIGURATION,
+                message=f"The {preset!r} preset requires {flag} {reason}.",
+                fix=f"Add {flag} to your command. See the skill documentation for details.",
+                details={"preset": preset, "missing_field": field},
+            )
+
+
+def _check_reference_paths_exist(resolved: dict[str, str]) -> None:
+    for key, value in resolved.items():
+        if key in _SYMBOLIC_REFERENCE_FIELDS:
+            continue  # symbolic identifiers, not local paths
+        _check_upstream_path_schema_compatibility(key, value)
+        if value and not Path(value).expanduser().exists():
+            raise SkillError(
+                stage="preflight",
+                error_code=ErrorCode.MISSING_REFERENCE,
+                message="A required reference or index path was not found.",
+                fix="Correct the missing reference path and try again.",
+                details={"field": key, "path": value},
+            )
+
+
+def _check_upstream_path_schema_compatibility(key: str, value: str) -> None:
+    if key != "fasta" or not value:
+        return
+    fasta_path = Path(value).expanduser().as_posix()
+    if _FASTA_SCHEMA_RE.match(fasta_path):
+        return
+    raise SkillError(
+        stage="preflight",
+        error_code=ErrorCode.INVALID_PRESET_CONFIGURATION,
+        message="FASTA paths must match the nf-core/scrnaseq 4.1.0 schema.",
+        fix=(
+            "Use a whitespace-free FASTA path ending in .fa, .fna, .fasta, .fa.gz, "
+            ".fna.gz, or .fasta.gz, then pass it via --fasta."
+        ),
+        details={"field": key, "path": value, "schema_pattern": r"^\S+\.fn?a(sta)?(\.gz)?$"},
+    )
+
+
+def _check_parameter_schema_compatibility(args) -> None:
+    """Validate non-path parameters whose upstream schema would fail predictably."""
+    _check_email_schema_compatibility(getattr(args, "email", None))
+
+
+def _check_email_schema_compatibility(email: str | None) -> None:
+    if not email or _EMAIL_SCHEMA_RE.match(email):
+        return
+    raise SkillError(
+        stage="preflight",
+        error_code=ErrorCode.INVALID_PRESET_CONFIGURATION,
+        message="Email address does not match the nf-core/scrnaseq 4.1.0 schema.",
+        fix="Use a simple email address such as user@example.org, or omit --email.",
+        details={"field": "email", "value": email, "schema_pattern": _EMAIL_SCHEMA_RE.pattern},
+    )
+
+
+def run_preflight(
+    args,
+    *,
+    pipeline_source: dict[str, str | bool],
+    samplesheet_summary: dict[str, object],
+) -> dict[str, object]:
+    _warn_if_native_windows()
+    _check_supported_preset(args.preset)
+    _check_parameter_schema_compatibility(args)
+    _check_protocol_compatibility(args)
+    java_info = _check_java()
+    nextflow_info = _check_nextflow()
+    profile_info = _check_profile(args.profile)
+    output_dir = Path(args.output).expanduser().resolve()
+    # Belt-and-suspenders: main() already called check_output_dir_available() before
+    # samplesheet normalization. This second call keeps run_preflight() self-consistent
+    # when invoked directly (e.g., tests). reproducibility/samplesheet.valid.csv written
+    # between the two calls is allowlisted in _ALLOWED_REPRO_FILES and does not trigger
+    # OUTPUT_DIR_NOT_EMPTY.
+    check_output_dir_available(output_dir, resume=args.resume)
+    refs = {} if args.demo else _check_references(args)
+    _check_samplesheet_driven_preset_requirements(args, samplesheet_summary=samplesheet_summary)
+    _check_resume_compatibility(args, output_dir=output_dir, pipeline_source=pipeline_source)
+    _warn_if_macos_docker_tmp(args.profile, output_dir)
+
+    return {
+        "ok": True,
+        "java": java_info,
+        "nextflow": nextflow_info,
+        "profile": profile_info,
+        "pipeline_source": pipeline_source,
+        "references": refs,
+        "samplesheet": {
+            "sample_count": samplesheet_summary["sample_count"],
+            "unknown_columns": samplesheet_summary["unknown_columns"],
+            "sample_types": samplesheet_summary.get("sample_types", []),
+            "feature_types": samplesheet_summary.get("feature_types", []),
+        },
+    }
+
+
+def _check_samplesheet_driven_preset_requirements(args, *, samplesheet_summary: dict[str, object]) -> None:
+    if args.demo or args.preset != "cellrangermulti":
+        return
+    feature_types = {str(value).lower() for value in samplesheet_summary.get("feature_types", [])}
+    _check_cellrangermulti_feature_references(args, feature_types)
+    _check_cellrangermulti_vdj_reference_policy(args, feature_types)
+    _check_cellrangermulti_multiplexing_policy(args, feature_types)
+
+
+def _check_cellrangermulti_feature_references(args, feature_types: set[str]) -> None:
+    if "ab" in feature_types and not getattr(args, "fb_reference", None):
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.INVALID_PRESET_CONFIGURATION,
+            message="cellrangermulti antibody-capture rows require a feature-barcode reference.",
+            fix="Provide --fb-reference for feature_type=ab rows.",
+            details={"preset": args.preset, "missing_field": "fb_reference", "feature_type": "ab"},
+        )
+
+
+def _check_cellrangermulti_vdj_reference_policy(args, feature_types: set[str]) -> None:
+    if "vdj" not in feature_types or not getattr(args, "skip_cellrangermulti_vdjref", False):
+        return
+    if getattr(args, "cellranger_vdj_index", None):
+        return
+    raise SkillError(
+        stage="preflight",
+        error_code=ErrorCode.INVALID_PRESET_CONFIGURATION,
+        message="cellrangermulti VDJ rows need a VDJ reference unless mkvdjref is allowed to run.",
+        fix="Remove --skip-cellrangermulti-vdjref, or provide --cellranger-vdj-index for feature_type=vdj rows.",
+        details={
+            "preset": args.preset,
+            "feature_type": "vdj",
+            "missing_field": "cellranger_vdj_index",
+            "conflicting_flag": "skip_cellrangermulti_vdjref",
+        },
+    )
+
+
+def _check_cellrangermulti_multiplexing_policy(args, feature_types: set[str]) -> None:
+    has_cmo_rows = "cmo" in feature_types
+    has_ffpe_probe_set = bool(getattr(args, "gex_frna_probe_set", None))
+    has_cmo_reference = bool(getattr(args, "gex_cmo_set", None))
+    has_ocm_assignment = bool(getattr(args, "gex_barcode_sample_assignment", None))
+    multiplexing_modes = {
+        "cmo": has_cmo_rows or has_cmo_reference,
+        "ffpe": has_ffpe_probe_set,
+        "ocm": has_ocm_assignment,
+    }
+    active_modes = [mode for mode, active in multiplexing_modes.items() if active]
+    if len(active_modes) > 1:
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.INVALID_PRESET_CONFIGURATION,
+            message="cellrangermulti multiplexing modes are mutually exclusive.",
+            fix="Use only one multiplexing strategy per run: CMO, FFPE probe-set demultiplexing, or OCM assignment.",
+            details={"preset": args.preset, "active_modes": active_modes},
+        )
+    if has_ffpe_probe_set and not getattr(args, "cellranger_multi_barcodes", None):
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.INVALID_PRESET_CONFIGURATION,
+            message="cellrangermulti FFPE probe-set demultiplexing requires a barcode-to-sample samplesheet.",
+            fix="Provide --cellranger-multi-barcodes when using --gex-frna-probe-set.",
+            details={"preset": args.preset, "missing_field": "cellranger_multi_barcodes", "field": "gex_frna_probe_set"},
+        )
+    if "cmo" in feature_types and not getattr(args, "cellranger_multi_barcodes", None):
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.INVALID_PRESET_CONFIGURATION,
+            message="cellrangermulti CMO multiplexing requires a barcode-to-sample samplesheet.",
+            fix="Provide --cellranger-multi-barcodes for feature_type=cmo rows.",
+            details={"preset": args.preset, "missing_field": "cellranger_multi_barcodes", "feature_type": "cmo"},
+        )
+
+
+def _check_protocol_compatibility(args) -> None:
+    if getattr(args, "demo", False):
+        return
+    protocol = (getattr(args, "protocol", None) or "auto").strip()
+    preset = getattr(args, "preset", "")
+    if preset in {"standard", "star", "kallisto"} and protocol == "auto":
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.INVALID_PRESET_CONFIGURATION,
+            message="The selected preset requires an explicit non-auto protocol.",
+            fix=(
+                "Provide --protocol (for example 10XV2, 10XV3, dropseq, "
+                "or a custom chemistry string supported by the aligner)."
+            ),
+            details={"preset": preset, "protocol": protocol},
+        )
+    if preset == "standard" and protocol.lower() == "smartseq":
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.INVALID_PRESET_CONFIGURATION,
+            message="The standard preset uses Simpleaf, which does not support smartseq in nf-core/scrnaseq.",
+            fix="Use --preset star or --preset kallisto for smartseq, or choose a Simpleaf-supported protocol.",
+            details={"preset": preset, "protocol": protocol},
+        )
+
+
+def _prompt_for_genome() -> str | None:
+    """Interactively ask the user to pick a genome from COMMON_GENOMES.
+
+    Returns the genome string, or None if stdin is not a TTY or the user
+    presses Enter / supplies an unrecognised selection.
+    """
+    if not sys.stdin.isatty():
+        return None
+    lines = ["\nNo reference genome specified. Choose a common iGenomes shortcut:"]
+    for i, g in enumerate(COMMON_GENOMES, start=1):
+        lines.append(f"  {i:2d}. {g}")
+    lines.append("\nEnter number or genome name (or press Enter to skip): ")
+    try:
+        raw = input("".join(lines)).strip()
+    except (EOFError, KeyboardInterrupt):
+        return None
+    if not raw:
+        return None
+    if raw.isdigit():
+        idx = int(raw) - 1
+        if 0 <= idx < len(COMMON_GENOMES):
+            return COMMON_GENOMES[idx]
+        return None
+    if raw in COMMON_GENOMES:
+        return raw
+    return None
+
+
+def _warn_if_macos_docker_tmp(profile: str, output_dir: Path) -> None:
+    # Colima (a common macOS Docker runtime) only 9p-mounts the user HOME directory
+    # into its VM.  /tmp and /private/tmp live on the VM's own ext4 and are NOT shared
+    # with the host, so Nextflow's work-dir files are invisible to containers.
+    # Docker Desktop handles /tmp differently and is unlikely to hit this, but the safe
+    # guidance for macOS + any Docker backend is to keep output dirs under HOME.
+    if sys.platform != "darwin" or profile != "docker":
+        return
+    private_tmp = Path("/private/tmp").resolve()
+    tmp = Path("/tmp").resolve()
+    try:
+        out = output_dir.resolve()
+        under_tmp = out == tmp or out == private_tmp or tmp in out.parents or private_tmp in out.parents
+    except Exception:
+        return
+    if under_tmp:
+        print(
+            "WARNING: Output directory is under /tmp. On macOS with Colima, Docker containers "
+            "cannot see files written to /tmp (the VM uses its own separate /tmp). "
+            "Move --output to a path under your home directory to avoid 'No such file or directory' errors.",
+            file=sys.stderr,
+        )
+
+
+def _warn_if_native_windows() -> None:
+    if sys.platform != "win32":
+        return
+    # Nextflow is not officially supported on native Windows.
+    # The recommended path is WSL2, which reports platform as Linux.
+    print(
+        "WARNING: Running on native Windows. Nextflow is not officially supported "
+        "outside WSL2 on Windows. If you encounter issues, run from WSL2 instead.",
+        file=sys.stderr,
+    )
+
+
+def _check_supported_preset(preset: str) -> None:
+    if preset not in SUPPORTED_PRESETS:
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.UNSUPPORTED_MODE,
+            message="Unsupported preset requested.",
+            fix=f"Choose one of: {', '.join(sorted(SUPPORTED_PRESETS))}.",
+            details={"preset": preset},
+        )
+
+
+def _check_resume_compatibility(
+    args,
+    *,
+    output_dir: Path,
+    pipeline_source: dict[str, str | bool],
+) -> None:
+    if not args.resume:
+        return
+    manifest_path = output_dir / "reproducibility" / "manifest.json"
+    if not manifest_path.exists():
+        raise SkillError(
+            stage="preflight",
+            error_code=ErrorCode.INVALID_RESUME_STATE,
+            message="Resume was requested but no previous manifest was found.",
+            fix="Remove --resume or point --output to a compatible prior run directory.",
+            details={"manifest": str(manifest_path)},
+        )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    _check_resume_preset_and_profile(args, manifest)
+    _check_resume_pipeline_source(pipeline_source, manifest)
+
+
+def _check_resume_preset_and_profile(args, manifest: dict[str, object]) -> None:
+    if manifest.get("preset") == args.preset and manifest.get("profile") == args.profile:
+        return
+    raise SkillError(
+        stage="preflight",
+        error_code=ErrorCode.INVALID_RESUME_STATE,
+        message="Resume state does not match the requested preset/profile.",
+        fix="Use the same preset/profile as the original run or start in a new output directory.",
+        details={
+            "previous_preset": manifest.get("preset"),
+            "previous_profile": manifest.get("profile"),
+            "requested_preset": args.preset,
+            "requested_profile": args.profile,
+        },
+    )
+
+
+def _check_resume_pipeline_source(
+    pipeline_source: dict[str, str | bool],
+    manifest: dict[str, object],
+) -> None:
+    previous_source = manifest.get("pipeline_source", {})
+    if not isinstance(previous_source, dict):
+        previous_source = {}
+    if (
+        previous_source.get("source_kind") == pipeline_source.get("source_kind")
+        and previous_source.get("resolved_version") == pipeline_source.get("resolved_version")
+    ):
+        return
+    raise SkillError(
+        stage="preflight",
+        error_code=ErrorCode.INVALID_RESUME_STATE,
+        message="Resume state does not match the requested pipeline source.",
+        fix="Resume only with the same pipeline source/ref as the original run.",
+        details={
+            "previous_source": previous_source,
+            "requested_source": pipeline_source,
+        },
+    )

--- a/skills/nfcore-scrnaseq-wrapper/preflight.py
+++ b/skills/nfcore-scrnaseq-wrapper/preflight.py
@@ -135,6 +135,10 @@ def _check_profile(profile: str) -> dict[str, str | bool]:
         return _check_podman_profile(profile)
     if profile in {"shifter", "charliecloud"}:
         return _check_hpc_profile(profile)
+    if profile in {"wave", "gpu"}:
+        # Wave and GPU are Nextflow-native features, not external runtimes.
+        # No binary check is needed; Nextflow handles them internally.
+        return {"profile": profile, "backend_path": None, "backend_ready": True}
     return _check_singularity_compatible_profile(profile)
 
 

--- a/skills/nfcore-scrnaseq-wrapper/provenance.py
+++ b/skills/nfcore-scrnaseq-wrapper/provenance.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import json
+import platform
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from clawbio.common.checksums import sha256_file
+from clawbio.common.reproducibility import write_checksums, write_environment_yml
+
+_SKILL_DIR = Path(__file__).resolve().parent
+if str(_SKILL_DIR) not in sys.path:
+    sys.path.insert(0, str(_SKILL_DIR))
+
+from schemas import DEFAULT_REMOTE_PIPELINE, JAVA_MIN_VERSION, NEXTFLOW_MIN_VERSION, SKILL_ALIAS, SKILL_NAME, SKILL_VERSION
+
+
+def write_provenance_bundle(
+    output_dir: Path,
+    *,
+    args,
+    pipeline_source: dict[str, Any],
+    preflight_result: dict[str, Any],
+    params_path: Path,
+    params_payload: dict[str, Any],
+    normalized_samplesheet: Path,
+    samplesheet_summary: dict[str, Any],
+    parsed_outputs: dict[str, Any],
+    execution_result: dict[str, Any],
+    command_str: str,
+) -> tuple[Path, Path]:
+    provenance_dir = output_dir / "provenance"
+    provenance_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).isoformat()
+    payloads = build_provenance_payloads(
+        output_dir,
+        args=args,
+        pipeline_source=pipeline_source,
+        preflight_result=preflight_result,
+        params_path=params_path,
+        params_payload=params_payload,
+        normalized_samplesheet=normalized_samplesheet,
+        samplesheet_summary=samplesheet_summary,
+        parsed_outputs=parsed_outputs,
+        command_str=command_str,
+        timestamp=timestamp,
+    )
+    _write_provenance_payloads(provenance_dir, payloads)
+    write_reproducibility_environment(output_dir, preflight_result=preflight_result)
+    checksum_file = write_reproducibility_checksums(
+        output_dir,
+        normalized_samplesheet=normalized_samplesheet,
+        params_path=params_path,
+        preflight_result=preflight_result,
+        parsed_outputs=parsed_outputs,
+        execution_result=execution_result,
+    )
+    manifest_path = write_reproducibility_manifest(
+        output_dir,
+        args=args,
+        upstream=payloads["upstream.json"],
+        inputs=payloads["inputs.json"],
+        runtime=payloads["runtime.json"],
+        checksum_file=checksum_file,
+    )
+    return provenance_dir, manifest_path
+
+
+def build_provenance_payloads(
+    output_dir: Path,
+    *,
+    args,
+    pipeline_source: dict[str, Any],
+    preflight_result: dict[str, Any],
+    params_path: Path,
+    params_payload: dict[str, Any],
+    normalized_samplesheet: Path,
+    samplesheet_summary: dict[str, Any],
+    parsed_outputs: dict[str, Any],
+    command_str: str,
+    timestamp: str,
+) -> dict[str, dict[str, Any]]:
+    return {
+        "runtime.json": build_runtime_payload(
+            output_dir,
+            args=args,
+            preflight_result=preflight_result,
+            command_str=command_str,
+            timestamp=timestamp,
+        ),
+        "upstream.json": build_upstream_payload(pipeline_source),
+        "invocation.json": build_invocation_payload(args, timestamp=timestamp),
+        "inputs.json": build_inputs_payload(
+            normalized_samplesheet=normalized_samplesheet,
+            samplesheet_summary=samplesheet_summary,
+            preflight_result=preflight_result,
+            params_path=params_path,
+        ),
+        "outputs.json": build_outputs_payload(parsed_outputs),
+        "skill.json": build_skill_payload(params_payload),
+        "preflight.json": preflight_result,
+    }
+
+
+def build_runtime_payload(
+    output_dir: Path,
+    *,
+    args,
+    preflight_result: dict[str, Any],
+    command_str: str,
+    timestamp: str,
+) -> dict[str, Any]:
+    return {
+        "timestamp": timestamp,
+        "os": platform.system(),
+        "arch": platform.machine(),
+        "python_version": platform.python_version(),
+        "profile": args.profile,
+        "resume_used": bool(args.resume),
+        "cwd": str(Path.cwd()),
+        "work_dir": str(output_dir / "upstream" / "work"),
+        "command": command_str,
+        "java_version": preflight_result["java"]["version"],
+        "nextflow_version": preflight_result["nextflow"]["version"],
+    }
+
+
+def build_upstream_payload(pipeline_source: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "pipeline": DEFAULT_REMOTE_PIPELINE,
+        "source_kind": pipeline_source["source_kind"],
+        "source_ref": pipeline_source["source_ref"],
+        "resolved_version": pipeline_source["resolved_version"],
+        "branch": pipeline_source.get("branch", ""),
+        "dirty": pipeline_source.get("dirty", False),
+    }
+
+
+def build_invocation_payload(args, *, timestamp: str) -> dict[str, Any]:
+    return {
+        "timestamp": timestamp,
+        "preset": args.preset,
+        "demo": bool(args.demo),
+        "check_only": bool(args.check),
+        "profile": args.profile,
+        "pipeline_version": args.pipeline_version,
+    }
+
+
+def build_inputs_payload(
+    *,
+    normalized_samplesheet: Path,
+    samplesheet_summary: dict[str, Any],
+    preflight_result: dict[str, Any],
+    params_path: Path,
+) -> dict[str, Any]:
+    return {
+        "samplesheet": str(normalized_samplesheet),
+        "samplesheet_checksum": sha256_file(normalized_samplesheet),
+        "sample_count": samplesheet_summary["sample_count"],
+        "fastq_paths": [Path(p).as_posix() for p in samplesheet_summary["fastq_paths"]],
+        "reference_paths": preflight_result.get("references", {}),
+        "params_path": str(params_path),
+        "params_checksum": sha256_file(params_path),
+    }
+
+
+def build_outputs_payload(parsed_outputs: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "preferred_h5ad": parsed_outputs.get("preferred_h5ad", ""),
+        "multiqc_report": parsed_outputs.get("multiqc_report", ""),
+        "pipeline_info_dir": parsed_outputs.get("pipeline_info_dir", ""),
+        "h5ad_candidates": parsed_outputs.get("h5ad_candidates", []),
+        "rds_candidates": parsed_outputs.get("rds_candidates", []),
+        "handoff_available": parsed_outputs.get("handoff_available", False),
+    }
+
+
+def build_skill_payload(params_payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": SKILL_NAME,
+        "cli_alias": SKILL_ALIAS,
+        "version": SKILL_VERSION,
+        "params": params_payload,
+    }
+
+
+def _write_provenance_payloads(provenance_dir: Path, payloads: dict[str, Any]) -> None:
+    for filename, payload in payloads.items():
+        (provenance_dir / filename).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def write_reproducibility_environment(output_dir: Path, *, preflight_result: dict[str, Any]) -> None:
+    write_environment_yml(
+        output_dir,
+        env_name="clawbio-nfcore-scrnaseq-wrapper",
+        pip_deps=[],
+        conda_deps=[
+            f"openjdk>={JAVA_MIN_VERSION}",
+            f"nextflow>={'.'.join(map(str, NEXTFLOW_MIN_VERSION))}",
+        ],
+        python_version=f"{platform.python_version_tuple()[0]}.{platform.python_version_tuple()[1]}",
+    )
+
+
+def write_reproducibility_checksums(
+    output_dir: Path,
+    *,
+    normalized_samplesheet: Path,
+    params_path: Path,
+    preflight_result: dict[str, Any],
+    parsed_outputs: dict[str, Any],
+    execution_result: dict[str, Any],
+) -> Path:
+    checksum_paths: list[Path] = [
+        normalized_samplesheet,
+        params_path,
+        Path(execution_result["stdout_path"]),
+        Path(execution_result["stderr_path"]),
+    ]
+    for ref_path in preflight_result.get("references", {}).values():
+        if ref_path:
+            p = Path(str(ref_path))
+            if p.is_file():
+                checksum_paths.append(p)
+    for candidate in parsed_outputs.get("h5ad_candidates", []):
+        checksum_paths.append(Path(candidate))
+    if parsed_outputs.get("multiqc_report"):
+        checksum_paths.append(Path(str(parsed_outputs["multiqc_report"])))
+    checksum_paths = list(dict.fromkeys(Path(p) for p in checksum_paths if p))
+    return write_checksums(checksum_paths, output_dir, anchor=output_dir)
+
+
+def write_reproducibility_manifest(
+    output_dir: Path,
+    *,
+    args,
+    upstream: dict[str, Any],
+    inputs: dict[str, Any],
+    runtime: dict[str, Any],
+    checksum_file: Path,
+) -> Path:
+    manifest = {
+        "skill_name": SKILL_NAME,
+        "skill_version": SKILL_VERSION,
+        "pipeline_source": upstream,
+        "preset": args.preset,
+        "profile": args.profile,
+        "resume_used": bool(args.resume),
+        "generated_at": runtime["timestamp"],
+        "java_version": runtime["java_version"],
+        "nextflow_version": runtime["nextflow_version"],
+        "python_version": runtime["python_version"],
+        "environment_yml_mode": "install_recipe",
+        "params_checksum": inputs["params_checksum"],
+        "samplesheet_checksum": inputs["samplesheet_checksum"],
+        "checksums_file": str(checksum_file),
+    }
+    manifest_path = output_dir / "reproducibility" / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return manifest_path

--- a/skills/nfcore-scrnaseq-wrapper/remap_paths.py
+++ b/skills/nfcore-scrnaseq-wrapper/remap_paths.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""
+remap_paths.py — Make this reproducibility bundle portable across machines.
+
+FASTQ paths and the --output directory in commands.sh are stored as absolute
+paths (required by Nextflow). Before replaying on a different machine:
+
+  1. Update FASTQ paths in the samplesheet:
+       python remap_paths.py --old /original/data/dir --new /new/data/dir
+
+  2. Update the --output path in commands.sh (if output dir changed):
+       python remap_paths.py --output-dir /new/output/dir
+
+  3. Verify everything is ready:
+       python remap_paths.py --verify
+
+  Preview any change without modifying files by adding --dry-run.
+
+  On a machine where ClawBio is installed at a non-standard location, set:
+       CLAWBIO_REPO=/path/to/ClawBio bash commands.sh
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import shutil
+import sys
+from pathlib import Path
+
+_BUNDLE_DIR = Path(__file__).resolve().parent
+_FASTQ_COLUMNS = ("fastq_1", "fastq_2", "fastq_barcode")
+# Matches `    --output /path \` lines — requires line to start with whitespace
+# (not #) so comment lines containing --output are never modified.
+_OUTPUT_FLAG_RE = re.compile(r"^([ \t]+--output[ \t]+)(\S+)([ \t]*(?:\\[ \t]*)?)$", re.MULTILINE)
+
+
+def find_samplesheet(bundle_dir: Path | None = None) -> Path | None:
+    search_dir = bundle_dir or _BUNDLE_DIR
+    for name in ("samplesheet.valid.csv", "samplesheet.demo.csv"):
+        p = search_dir / name
+        if p.exists():
+            return p
+    return None
+
+
+def find_commands_sh(bundle_dir: Path | None = None) -> Path | None:
+    search_dir = bundle_dir or _BUNDLE_DIR
+    p = search_dir / "commands.sh"
+    return p if p.exists() else None
+
+
+def remap_csv(
+    samplesheet: Path,
+    old_prefix: str,
+    new_prefix: str,
+    *,
+    dry_run: bool,
+) -> list[tuple[str, str, str]]:
+    """Return list of (column, old_path, new_path) for every changed cell."""
+    text = samplesheet.read_text(encoding="utf-8")
+    fieldnames = list(csv.DictReader(text.splitlines()).fieldnames or [])
+    rows = list(csv.DictReader(text.splitlines()))
+    changes: list[tuple[str, str, str]] = []
+
+    for row in rows:
+        for col in _FASTQ_COLUMNS:
+            if col in row and row[col] and row[col].startswith(old_prefix):
+                new_val = new_prefix + row[col][len(old_prefix):]
+                changes.append((col, row[col], new_val))
+                if not dry_run:
+                    row[col] = new_val
+
+    if not dry_run and changes:
+        backup = samplesheet.with_suffix(".bak")
+        shutil.copy2(samplesheet, backup)
+        with samplesheet.open("w", newline="", encoding="utf-8") as fh:
+            writer = csv.DictWriter(fh, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
+
+    return changes
+
+
+def verify_paths(samplesheet: Path) -> list[str]:
+    """Return FASTQ paths in the samplesheet that don't exist on disk."""
+    missing: list[str] = []
+    for row in csv.DictReader(samplesheet.read_text(encoding="utf-8").splitlines()):
+        for col in _FASTQ_COLUMNS:
+            if col in row and row[col] and not Path(row[col]).exists():
+                missing.append(row[col])
+    return missing
+
+
+def update_commands_output(commands_sh: Path, new_output_dir: str) -> bool:
+    """Replace the --output value in commands.sh. Return True if changed."""
+    original = commands_sh.read_text(encoding="utf-8")
+    if not _OUTPUT_FLAG_RE.search(original):
+        return False
+    updated = _OUTPUT_FLAG_RE.sub(
+        lambda m: f"{m.group(1)}{new_output_dir}{m.group(3)}",
+        original,
+    )
+    if updated == original:
+        return False
+    backup = commands_sh.with_suffix(".sh.bak")
+    shutil.copy2(commands_sh, backup)
+    commands_sh.write_text(updated, encoding="utf-8")
+    return True
+
+
+def cmd_remap(
+    old_prefix: str,
+    new_prefix: str,
+    *,
+    dry_run: bool,
+    bundle_dir: Path | None = None,
+) -> int:
+    samplesheet = find_samplesheet(bundle_dir=bundle_dir)
+    if samplesheet is None:
+        print("ERROR: No samplesheet found in this bundle directory.", file=sys.stderr)
+        return 1
+
+    label = "[DRY RUN] " if dry_run else ""
+    print(f"{label}Remapping FASTQ paths in: {samplesheet.name}")
+
+    changes = remap_csv(samplesheet, old_prefix, new_prefix, dry_run=dry_run)
+
+    if not changes:
+        print(f"No FASTQ paths start with {old_prefix!r} — nothing to change.")
+        return 0
+
+    verb = "Would change" if dry_run else "Changed"
+    print(f"\n{verb} {len(changes)} path(s):")
+    for col, old_val, new_val in changes:
+        print(f"  [{col}]")
+        print(f"    - {old_val}")
+        print(f"    + {new_val}")
+
+    if dry_run:
+        print("\nRe-run without --dry-run to apply these changes.")
+        return 0
+
+    print(f"\nBackup saved: {samplesheet.with_suffix('.bak').name}")
+
+    missing = verify_paths(samplesheet)
+    if missing:
+        print(f"\nWARNING: {len(missing)} path(s) do not exist on this machine:")
+        for m in missing:
+            print(f"  {m}")
+        print("\nCorrect the paths and run again, or verify the FASTQ files are accessible.")
+        return 1
+
+    print("\nAll FASTQ paths verified — ready to replay:")
+    print(f"  bash {samplesheet.parent / 'commands.sh'}")
+    return 0
+
+
+def cmd_update_output(new_output_dir: str, *, dry_run: bool, bundle_dir: Path | None = None) -> int:
+    commands_sh = find_commands_sh(bundle_dir=bundle_dir)
+    if commands_sh is None:
+        print("ERROR: commands.sh not found in this bundle directory.", file=sys.stderr)
+        return 1
+
+    if dry_run:
+        content = commands_sh.read_text(encoding="utf-8")
+        m = _OUTPUT_FLAG_RE.search(content)
+        if not m:
+            print("No --output flag found in commands.sh — nothing to change.")
+            return 0
+        print(f"[DRY RUN] Would change --output in commands.sh:")
+        print(f"    - {m.group(2)}")
+        print(f"    + {new_output_dir}")
+        return 0
+
+    changed = update_commands_output(commands_sh, new_output_dir)
+    if not changed:
+        print("No --output flag found in commands.sh — nothing to change.")
+        return 0
+
+    print(f"Updated --output in commands.sh → {new_output_dir}")
+    print(f"Backup saved: {commands_sh.with_suffix('.sh.bak').name}")
+    return 0
+
+
+def cmd_verify(bundle_dir: Path | None = None) -> int:
+    samplesheet = find_samplesheet(bundle_dir=bundle_dir)
+    if samplesheet is None:
+        print("ERROR: No samplesheet found in this bundle directory.", file=sys.stderr)
+        return 1
+
+    ok = True
+    missing = verify_paths(samplesheet)
+    if not missing:
+        print(f"FASTQ paths: all exist in {samplesheet.name}")
+    else:
+        ok = False
+        print(f"FASTQ paths: {len(missing)} missing in {samplesheet.name}:")
+        for m in missing:
+            print(f"  {m}")
+        print("  → fix: python remap_paths.py --old <old_prefix> --new <new_prefix>")
+
+    commands_sh = find_commands_sh(bundle_dir=bundle_dir)
+    if commands_sh is not None:
+        content = commands_sh.read_text(encoding="utf-8")
+        m = _OUTPUT_FLAG_RE.search(content)
+        if m:
+            output_path = m.group(2)
+            if Path(output_path).exists():
+                print(f"Output dir:  exists ({output_path})")
+            else:
+                ok = False
+                print(f"Output dir:  missing ({output_path})")
+                print("  → fix: python remap_paths.py --output-dir <new_output_dir>")
+
+    if ok:
+        print(f"\nAll checks passed — ready to replay:")
+        print(f"  bash {(bundle_dir or _BUNDLE_DIR) / 'commands.sh'}")
+    return 0 if ok else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Make this reproducibility bundle portable across machines.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+examples:
+  Remap FASTQ paths (required when FASTQs live at a different prefix):
+    python remap_paths.py --old /Users/alice/fastqs --new /home/bob/fastqs
+
+  Update the --output directory in commands.sh:
+    python remap_paths.py --output-dir /home/bob/my_run
+
+  Preview any change without modifying files:
+    python remap_paths.py --old /Users/alice/fastqs --new /home/bob/fastqs --dry-run
+
+  Verify everything is ready to replay:
+    python remap_paths.py --verify
+
+  If ClawBio is installed at a non-standard path on this machine:
+    CLAWBIO_REPO=/path/to/ClawBio bash commands.sh
+""",
+    )
+    parser.add_argument("--old", metavar="PREFIX", help="Original FASTQ path prefix to replace")
+    parser.add_argument("--new", metavar="PREFIX", help="New FASTQ path prefix for this machine")
+    parser.add_argument("--output-dir", metavar="PATH", help="New --output directory for commands.sh")
+    parser.add_argument("--dry-run", action="store_true", help="Preview changes without modifying files")
+    parser.add_argument("--verify", action="store_true", help="Check all paths exist on this machine")
+    args = parser.parse_args()
+
+    if args.verify:
+        return cmd_verify()
+    if args.output_dir is not None:
+        return cmd_update_output(args.output_dir, dry_run=args.dry_run)
+    if args.old is not None and args.new is not None:
+        return cmd_remap(args.old, args.new, dry_run=args.dry_run)
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/nfcore-scrnaseq-wrapper/reporting.py
+++ b/skills/nfcore-scrnaseq-wrapper/reporting.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from clawbio.common.portable_commands import write_portable_commands_sh
+from clawbio.common.report import generate_report_footer, generate_report_header, write_result_json
+
+_SKILL_DIR = Path(__file__).resolve().parent
+if str(_SKILL_DIR) not in sys.path:
+    sys.path.insert(0, str(_SKILL_DIR))
+
+from schemas import SKILL_ALIAS, SKILL_DIR, SKILL_NAME, SKILL_VERSION
+
+_CLAWBIO_SCRIPT = (SKILL_DIR.parent.parent / "clawbio.py").as_posix()
+
+_REPRO_PATH_FLAGS = (
+    "fasta",
+    "gtf",
+    "transcript_fasta",
+    "txp2gene",
+    "simpleaf_index",
+    "kallisto_index",
+    "star_index",
+    "cellranger_index",
+    "barcode_whitelist",
+    "kb_t1c",
+    "kb_t2c",
+    "motifs",
+    "cellrangerarc_config",
+    "cellranger_vdj_index",
+    "gex_frna_probe_set",
+    "gex_target_panel",
+    "gex_cmo_set",
+    "fb_reference",
+    "vdj_inner_enrichment_primers",
+    "gex_barcode_sample_assignment",
+    "cellranger_multi_barcodes",
+)
+
+
+def write_report(
+    output_dir: Path,
+    *,
+    args,
+    pipeline_source: dict[str, object],
+    preflight_result: dict[str, object],
+    parsed_outputs: dict[str, object],
+    command_str: str,
+) -> Path:
+    lines = build_report_lines(
+        output_dir,
+        args=args,
+        pipeline_source=pipeline_source,
+        preflight_result=preflight_result,
+        parsed_outputs=parsed_outputs,
+        command_str=command_str,
+    )
+    report_path = output_dir / "report.md"
+    report_path.write_text("\n".join(lines), encoding="utf-8")
+    return report_path
+
+
+def build_report_lines(
+    output_dir: Path,
+    *,
+    args,
+    pipeline_source: dict[str, object],
+    preflight_result: dict[str, object],
+    parsed_outputs: dict[str, object],
+    command_str: str,
+) -> list[str]:
+    header = generate_report_header(
+        "nf-core/scrnaseq Wrapper Report",
+        SKILL_NAME,
+        extra_metadata={
+            "Preset": args.preset,
+            "Profile": args.profile,
+            "Pipeline source": str(pipeline_source["source_kind"]),
+            "Pipeline ref": str(pipeline_source["resolved_version"]),
+        },
+    )
+    preferred_h5ad = str(parsed_outputs.get("preferred_h5ad", ""))
+    return [
+        header,
+        "## Summary",
+        "",
+        f"- Preset: `{args.preset}`",
+        f"- Effective aligner: `{parsed_outputs.get('aligner_effective', '')}`",
+        f"- Pipeline source: `{pipeline_source['source_kind']}`",
+        f"- Pipeline ref: `{pipeline_source['resolved_version']}`",
+        f"- Output root: `{output_dir}`",
+        "",
+        "## Preflight",
+        "",
+        f"- Java: `{preflight_result['java']['version']}`",
+        f"- Nextflow: `{preflight_result['nextflow']['version']}`",
+        f"- Backend profile: `{args.profile}`",
+        f"- Samples: `{len(parsed_outputs.get('samples_detected', []))}`",
+        "",
+        "## Outputs",
+        "",
+        f"- Preferred h5ad: `{preferred_h5ad or 'not available'}`",
+        f"- MultiQC report: `{parsed_outputs.get('multiqc_report', '') or 'not found'}`",
+        f"- Pipeline info: `{parsed_outputs.get('pipeline_info_dir', '') or 'not found'}`",
+        f"- CellBender detected: `{parsed_outputs.get('cellbender_used', False)}`",
+        "",
+        "## Reproducibility",
+        "",
+        f"- Command: `{command_str}`",
+        f"- Repro bundle: `{output_dir / 'reproducibility'}`",
+        "",
+        *_build_handoff_lines(preferred_h5ad),
+        generate_report_footer(),
+    ]
+
+
+def _build_handoff_lines(preferred_h5ad: str) -> list[str]:
+    if preferred_h5ad:
+        return [
+            "## Next Steps",
+            "",
+            f"- `python {_CLAWBIO_SCRIPT} run scrna --input {preferred_h5ad} --output <dir>`",
+            f"- `python {_CLAWBIO_SCRIPT} run scrna-embedding --input {preferred_h5ad} --output <dir>`",
+            "",
+        ]
+    return [
+        "## Next Steps",
+        "",
+        "- No canonical `.h5ad` was selected automatically. Inspect `result.json` and the upstream outputs before chaining downstream skills.",
+        "",
+    ]
+
+
+_PORTABILITY_NOTICE = """\
+
+# ── Portability notice ────────────────────────────────────────────────────────
+# FASTQ paths in samplesheet.valid.csv are absolute (required by Nextflow).
+# Before replaying on a different machine:
+#
+#   1. Remap FASTQ paths:
+#        python reproducibility/remap_paths.py --old /original/prefix --new /new/prefix
+#
+#   2. Update the --output path above if the output directory changed:
+#        python reproducibility/remap_paths.py --output-dir /new/output/dir
+#
+#   3. Verify everything:
+#        python reproducibility/remap_paths.py --verify
+#
+# If ClawBio is installed at a non-standard path on this machine:
+#   CLAWBIO_REPO=/path/to/ClawBio bash reproducibility/commands.sh
+"""
+
+# Injected into commands.sh after the walk-up block to allow replay when the
+# output directory is outside the repo tree (the typical case).
+_CLAWBIO_REPO_FALLBACK = (
+    'if [[ ! -d "$REPO_ROOT/skills" ]]; then\n'
+    '  echo "ERROR: Could not locate repo root (no skills/ directory found)" >&2\n'
+    '  exit 1\n'
+    'fi'
+)
+_CLAWBIO_REPO_FALLBACK_PATCHED = (
+    'if [[ ! -d "$REPO_ROOT/skills" ]]; then\n'
+    '  if [[ -n "${CLAWBIO_REPO:-}" && -d "${CLAWBIO_REPO}/skills" ]]; then\n'
+    '    REPO_ROOT="$CLAWBIO_REPO"\n'
+    '  else\n'
+    '    echo "ERROR: Could not locate repo root (no skills/ directory found)" >&2\n'
+    '    echo "If ClawBio is installed elsewhere, set CLAWBIO_REPO:" >&2\n'
+    '    echo "  CLAWBIO_REPO=/path/to/ClawBio bash commands.sh" >&2\n'
+    '    exit 1\n'
+    '  fi\n'
+    'fi'
+)
+
+_REMAP_SCRIPT_SRC = SKILL_DIR / "remap_paths.py"
+
+
+def write_repro_commands(
+    output_dir: Path,
+    *,
+    args,
+) -> None:
+    repro_dir = output_dir / "reproducibility"
+    command_args = build_repro_command_args(output_dir, args=args)
+    write_portable_commands_sh(
+        repro_dir,
+        skill_name=SKILL_NAME,
+        script_name="nfcore_scrnaseq_wrapper.py",
+        args=command_args,
+        generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+    )
+    commands_sh = repro_dir / "commands.sh"
+    _patch_commands_sh_repo_fallback(commands_sh)
+    if not getattr(args, "demo", False):
+        with commands_sh.open("a", encoding="utf-8") as fh:
+            fh.write(_PORTABILITY_NOTICE)
+    _write_remap_script(repro_dir)
+
+
+def _patch_commands_sh_repo_fallback(commands_sh: Path) -> None:
+    if not commands_sh.exists():
+        return
+    content = commands_sh.read_text(encoding="utf-8")
+    if _CLAWBIO_REPO_FALLBACK not in content:
+        return
+    commands_sh.write_text(
+        content.replace(_CLAWBIO_REPO_FALLBACK, _CLAWBIO_REPO_FALLBACK_PATCHED),
+        encoding="utf-8",
+    )
+
+
+def _write_remap_script(repro_dir: Path) -> None:
+    repro_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(_REMAP_SCRIPT_SRC, repro_dir / "remap_paths.py")
+
+
+def build_repro_command_args(output_dir: Path, *, args) -> dict[str, str | None]:
+    command_args = _base_repro_command_args(output_dir, args=args)
+    _add_optional_value_flags(command_args, args)
+    _add_optional_boolean_flags(command_args, args)
+    _add_repro_path_flags(command_args, args)
+    return command_args
+
+
+def _base_repro_command_args(output_dir: Path, *, args) -> dict[str, str | None]:
+    command_args: dict[str, str | None] = {
+        "--output": output_dir.as_posix(),
+        "--preset": args.preset,
+        "--profile": args.profile,
+        "--pipeline-version": args.pipeline_version,
+    }
+    if args.demo:
+        command_args["--demo"] = None
+    else:
+        # Resolve to absolute + forward slashes so the repro script works
+        # when pasted into bash on any platform (including Windows Git Bash / WSL2).
+        command_args["--input"] = Path(args.input).expanduser().resolve().as_posix()
+    return command_args
+
+
+def _add_optional_value_flags(command_args: dict[str, str | None], args) -> None:
+    if args.protocol:
+        command_args["--protocol"] = args.protocol
+    if getattr(args, "email", None):
+        command_args["--email"] = args.email
+    if getattr(args, "multiqc_title", None):
+        command_args["--multiqc-title"] = args.multiqc_title
+    if getattr(args, "expected_cells", None) is not None and not args.demo:
+        command_args["--expected-cells"] = str(args.expected_cells)
+    if getattr(args, "skip_cellbender", False) or getattr(args, "skip_emptydrops", False):
+        command_args["--skip-cellbender"] = None
+    if getattr(args, "skip_fastqc", False):
+        command_args["--skip-fastqc"] = None
+    if getattr(args, "skip_multiqc", False):
+        command_args["--skip-multiqc"] = None
+    if getattr(args, "skip_cellranger_renaming", False):
+        command_args["--skip-cellranger-renaming"] = None
+    if getattr(args, "skip_cellrangermulti_vdjref", False):
+        command_args["--skip-cellrangermulti-vdjref"] = None
+    if getattr(args, "star_ignore_sjdbgtf", False):
+        command_args["--star-ignore-sjdbgtf"] = None
+    if getattr(args, "seq_center", None):
+        command_args["--seq-center"] = args.seq_center
+    if getattr(args, "star_feature", None):
+        command_args["--star-feature"] = args.star_feature
+    if getattr(args, "simpleaf_umi_resolution", None):
+        command_args["--simpleaf-umi-resolution"] = args.simpleaf_umi_resolution
+    if getattr(args, "kb_workflow", None):
+        command_args["--kb-workflow"] = args.kb_workflow
+    if getattr(args, "genome", None):
+        command_args["--genome"] = args.genome
+    if getattr(args, "cellrangerarc_reference", None):
+        command_args["--cellrangerarc-reference"] = args.cellrangerarc_reference
+
+
+def _add_optional_boolean_flags(command_args: dict[str, str | None], args) -> None:
+    if getattr(args, "save_reference", False):
+        command_args["--save-reference"] = None
+    if getattr(args, "save_align_intermeds", False):
+        command_args["--save-align-intermeds"] = None
+    if args.resume:
+        command_args["--resume"] = None
+    if getattr(args, "run_downstream", False):
+        command_args["--run-downstream"] = None
+
+
+def _add_repro_path_flags(command_args: dict[str, str | None], args) -> None:
+    for flag_name in _REPRO_PATH_FLAGS:
+        value = getattr(args, flag_name, None)
+        if value:
+            command_args[f"--{flag_name.replace('_', '-')}"] = Path(value).expanduser().resolve().as_posix()
+
+
+def write_result(
+    output_dir: Path,
+    *,
+    args,
+    pipeline_source: dict[str, object],
+    parsed_outputs: dict[str, object],
+    command_str: str,
+) -> Path:
+    output_artifacts = build_output_artifacts(parsed_outputs)
+    summary = build_result_summary(
+        args=args,
+        pipeline_source=pipeline_source,
+        parsed_outputs=parsed_outputs,
+        output_artifacts=output_artifacts,
+    )
+    data = build_result_data(parsed_outputs=parsed_outputs, output_artifacts=output_artifacts, command_str=command_str)
+    return write_result_json(
+        output_dir,
+        skill=SKILL_ALIAS,
+        version=SKILL_VERSION,
+        summary=summary,
+        data=data,
+    )
+
+
+def build_output_artifacts(parsed_outputs: dict[str, object]) -> dict[str, object]:
+    return {
+        "preferred_h5ad": parsed_outputs.get("preferred_h5ad", ""),
+        "multiqc_report": parsed_outputs.get("multiqc_report", ""),
+        "pipeline_info_dir": parsed_outputs.get("pipeline_info_dir", ""),
+        "h5ad_candidates": parsed_outputs.get("h5ad_candidates", []),
+        "rds_candidates": parsed_outputs.get("rds_candidates", []),
+    }
+
+
+def build_result_summary(
+    *,
+    args,
+    pipeline_source: dict[str, object],
+    parsed_outputs: dict[str, object],
+    output_artifacts: dict[str, object],
+) -> dict[str, object]:
+    return {
+        "preset": args.preset,
+        "aligner_effective": parsed_outputs.get("aligner_effective", ""),
+        "pipeline_source_kind": pipeline_source["source_kind"],
+        "pipeline_version_or_commit": pipeline_source["resolved_version"],
+        "profile": args.profile,
+        "resume_used": bool(args.resume),
+        "multiqc_report": parsed_outputs.get("multiqc_report", ""),
+        "pipeline_info_dir": parsed_outputs.get("pipeline_info_dir", ""),
+        "preferred_h5ad": parsed_outputs.get("preferred_h5ad", ""),
+        "handoff_available": parsed_outputs.get("handoff_available", False),
+        "samples_detected": len(parsed_outputs.get("samples_detected", [])),
+        "cellbender_used": parsed_outputs.get("cellbender_used", False),
+        "output_artifacts": output_artifacts,
+    }
+
+
+def build_result_data(
+    *,
+    parsed_outputs: dict[str, object],
+    output_artifacts: dict[str, object],
+    command_str: str,
+) -> dict[str, object]:
+    return {
+        "canonical_skill_name": SKILL_NAME,
+        "cli_alias": SKILL_ALIAS,
+        "command": command_str,
+        "output_artifacts": output_artifacts,
+        "outputs": parsed_outputs,
+    }
+
+
+def write_check_result(output_dir: Path, payload: dict[str, object]) -> Path:
+    path = output_dir / "check_result.json"
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path

--- a/skills/nfcore-scrnaseq-wrapper/reproducibility/compatibility_policy.json
+++ b/skills/nfcore-scrnaseq-wrapper/reproducibility/compatibility_policy.json
@@ -1,0 +1,31 @@
+{
+  "mode": "stable",
+  "update_policy": {
+    "pipeline_version": "Manual updates only after validation.",
+    "local_checkout": "Preferred when a sibling scrnaseq checkout is present; record commit, branch, and dirty state.",
+    "remote_repo": "Allowed only with an explicit pinned version or tag; never use latest."
+  },
+  "validation_required_before_update": [
+    "Run the wrapper unit test suite.",
+    "Run preflight against a representative samplesheet.",
+    "Run the upstream demo profile when Nextflow and the selected backend are available.",
+    "Verify MultiQC, pipeline_info, h5ad detection, provenance, and reproducibility outputs."
+  ],
+  "breaking_change_review": [
+    "Review nf-core/scrnaseq schema changes.",
+    "Review supported presets and aligner names.",
+    "Review required reference/index combinations.",
+    "Review output path conventions for h5ad, rds, MultiQC, and pipeline_info.",
+    "Verify upstream nextflow.config save_align_intermeds default has not changed (currently true in 4.1.0)."
+  ],
+  "resume_policy": {
+    "requires_same_pipeline_source": true,
+    "requires_same_resolved_version": true,
+    "requires_same_preset": true,
+    "requires_same_profile": true,
+    "requires_same_params_checksum": true
+  },
+  "execution_policy": {
+    "work_dir": "output/upstream/work"
+  }
+}

--- a/skills/nfcore-scrnaseq-wrapper/reproducibility/pinned_versions.json
+++ b/skills/nfcore-scrnaseq-wrapper/reproducibility/pinned_versions.json
@@ -1,0 +1,35 @@
+{
+  "mode": "stable",
+  "skill": {
+    "name": "nfcore-scrnaseq-wrapper",
+    "version": "0.1.0"
+  },
+  "pipeline": {
+    "name": "nf-core/scrnaseq",
+    "default_version": "4.1.0",
+    "source_preference": "local_checkout_then_remote"
+  },
+  "minimum_versions": {
+    "java": "17",
+    "nextflow": "25.04.0",
+    "python": "3.11"
+  },
+  "supported_profiles": [
+    "docker",
+    "conda",
+    "mamba",
+    "singularity",
+    "apptainer",
+    "podman",
+    "shifter",
+    "charliecloud"
+  ],
+  "supported_presets": [
+    "standard",
+    "star",
+    "kallisto",
+    "cellranger",
+    "cellrangerarc",
+    "cellrangermulti"
+  ]
+}

--- a/skills/nfcore-scrnaseq-wrapper/reproducibility/pinned_versions.json
+++ b/skills/nfcore-scrnaseq-wrapper/reproducibility/pinned_versions.json
@@ -22,7 +22,9 @@
     "apptainer",
     "podman",
     "shifter",
-    "charliecloud"
+    "charliecloud",
+    "wave",
+    "gpu"
   ],
   "supported_presets": [
     "standard",

--- a/skills/nfcore-scrnaseq-wrapper/samplesheet_builder.py
+++ b/skills/nfcore-scrnaseq-wrapper/samplesheet_builder.py
@@ -1,0 +1,573 @@
+from __future__ import annotations
+
+import csv
+import os
+import re
+import sys
+from pathlib import Path
+
+_SKILL_DIR = Path(__file__).resolve().parent
+if str(_SKILL_DIR) not in sys.path:
+    sys.path.insert(0, str(_SKILL_DIR))
+
+from errors import ErrorCode, SkillError
+from schemas import (
+    REQUIRED_SAMPLE_COLUMNS,
+    SUPPORTED_FEATURE_TYPE_VALUES,
+    SUPPORTED_SAMPLE_COLUMNS,
+    SUPPORTED_SAMPLE_TYPE_VALUES,
+)
+
+_SAMPLE_NAME_RE = re.compile(r"^\S+$")
+_SAMPLE_WHITESPACE_RE = re.compile(r"\s+")
+_FASTQ_BASENAME_RE = re.compile(r"^[^\s/]+\.f(ast)?q\.gz$")
+_CELLRANGER_READ_MARKER_RE = re.compile(r"(?P<prefix>.*)(?P<marker>_R[12])(?P<suffix>(?:_001)?\.f(?:ast)?q\.gz)$")
+_TENX_FASTQ_RE = re.compile(r"^[^\s/]+_S\d+_L\d{3}_(R1|R2|R3|I1|I2)_001\.fastq\.gz$")
+_FASTQ_SUFFIXES = (".fastq.gz", ".fq.gz")
+_BASE_OUTPUT_COLUMNS = ("sample", "fastq_1", "fastq_2", "expected_cells", "seq_center")
+_REQUIRED_FASTQ_COLUMNS = ("fastq_1", "fastq_2")
+_OPTIONAL_FASTQ_COLUMNS = ("fastq_barcode",)
+
+
+def validate_and_normalize_samplesheet(
+    input_path: Path,
+    output_path: Path,
+    *,
+    expected_cells_override: int | None = None,
+    preset: str | None = None,
+) -> dict[str, object]:
+    fieldnames, rows = _read_samplesheet(input_path)
+    _validate_preset_columns(fieldnames, preset=preset)
+    unknown_columns = _unknown_columns(fieldnames)
+    output_columns = _build_output_columns(fieldnames)
+    normalized_rows, sample_names, fastq_paths = _normalize_rows(
+        rows,
+        input_path=input_path,
+        output_columns=output_columns,
+        expected_cells_override=expected_cells_override,
+        preset=preset,
+    )
+    _write_normalized_samplesheet(output_path, output_columns, normalized_rows)
+
+    return {
+        "normalized_path": output_path,
+        "sample_count": len(normalized_rows),
+        "sample_names": sample_names,
+        "fastq_paths": fastq_paths,
+        "sample_types": sorted({row.get("sample_type", "") for row in normalized_rows if row.get("sample_type", "")}),
+        "feature_types": sorted(
+            {row.get("feature_type", "") for row in normalized_rows if row.get("feature_type", "")}
+        ),
+        "unknown_columns": unknown_columns,
+    }
+
+
+def _read_samplesheet(input_path: Path) -> tuple[list[str], list[dict[str, str]]]:
+    if not input_path.exists():
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.MISSING_INPUT,
+            message="Samplesheet was not found.",
+            fix="Provide a valid --input path to a samplesheet.csv file.",
+            details={"path": str(input_path)},
+        )
+
+    with input_path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        fieldnames = reader.fieldnames or []
+        _validate_required_columns(fieldnames)
+        _validate_required_column_order(fieldnames)
+        rows = list(reader)
+
+    if not rows:
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.INVALID_SAMPLESHEET,
+            message="Samplesheet is empty.",
+            fix="Add at least one sample row to the input CSV.",
+            details={"path": str(input_path)},
+        )
+    return fieldnames, rows
+
+
+def _validate_required_columns(fieldnames: list[str]) -> None:
+    missing_columns = [name for name in REQUIRED_SAMPLE_COLUMNS if name not in fieldnames]
+    if missing_columns:
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.INVALID_SAMPLESHEET,
+            message="Samplesheet is missing required columns.",
+            fix="Ensure the header contains sample, fastq_1, and fastq_2.",
+            details={"missing_columns": missing_columns},
+        )
+
+
+def _validate_required_column_order(fieldnames: list[str]) -> None:
+    first_columns = tuple(fieldnames[: len(REQUIRED_SAMPLE_COLUMNS)])
+    if first_columns != REQUIRED_SAMPLE_COLUMNS:
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.INVALID_SAMPLESHEET,
+            message="Samplesheet first columns must match the nf-core/scrnaseq input contract.",
+            fix="Use sample, fastq_1, fastq_2 as the first three columns, in that exact order.",
+            details={
+                "expected_first_columns": list(REQUIRED_SAMPLE_COLUMNS),
+                "observed_first_columns": list(first_columns),
+            },
+        )
+
+
+def _validate_preset_columns(fieldnames: list[str], *, preset: str | None) -> None:
+    required_by_preset = {
+        "cellrangerarc": ("sample_type", "fastq_barcode"),
+        "cellrangermulti": ("feature_type",),
+    }
+    missing_columns = [name for name in required_by_preset.get(preset or "", ()) if name not in fieldnames]
+    if missing_columns:
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.INVALID_SAMPLESHEET,
+            message="Samplesheet is missing columns required by the selected preset.",
+            fix=f"Add the required columns for preset {preset!r}: {', '.join(missing_columns)}.",
+            details={"preset": preset, "missing_columns": missing_columns},
+        )
+
+
+def _unknown_columns(fieldnames: list[str]) -> list[str]:
+    return [name for name in fieldnames if name not in SUPPORTED_SAMPLE_COLUMNS]
+
+
+def _build_output_columns(fieldnames: list[str]) -> list[str]:
+    extra_columns = [name for name in fieldnames if name not in _BASE_OUTPUT_COLUMNS]
+    return list(dict.fromkeys([*_BASE_OUTPUT_COLUMNS, *extra_columns]))
+
+
+def _normalize_rows(
+    rows: list[dict[str, str]],
+    *,
+    input_path: Path,
+    output_columns: list[str],
+    expected_cells_override: int | None,
+    preset: str | None,
+) -> tuple[list[dict[str, str]], list[str], list[Path]]:
+    normalized_rows: list[dict[str, str]] = []
+    sample_names: list[str] = []
+    fastq_paths: list[Path] = []
+    seen_rows: set[tuple[str, str, str]] = set()
+    raw_samples_by_normalized_sample: dict[str, str] = {}
+    metadata_by_sample: dict[str, dict[str, str]] = {}
+
+    for line_number, row in enumerate(rows, start=2):
+        normalized, sample, resolved_fastqs = _normalize_samplesheet_row(
+            row,
+            line_number=line_number,
+            input_path=input_path,
+            output_columns=output_columns,
+            expected_cells_override=expected_cells_override,
+            preset=preset,
+        )
+        _reject_sample_name_collision(raw_samples_by_normalized_sample, row, line_number, sample)
+        _reject_inconsistent_repeated_sample_metadata(metadata_by_sample, line_number, sample, normalized)
+        _reject_duplicate_fastq_row(seen_rows, line_number, sample, resolved_fastqs)
+        normalized_rows.append(normalized)
+        sample_names.append(sample)
+        fastq_paths.extend(resolved_fastqs.values())
+
+    return normalized_rows, sample_names, fastq_paths
+
+
+def _normalize_samplesheet_row(
+    row: dict[str, str],
+    *,
+    line_number: int,
+    input_path: Path,
+    output_columns: list[str],
+    expected_cells_override: int | None,
+    preset: str | None,
+) -> tuple[dict[str, str], str, dict[str, Path]]:
+    sample = _validate_sample_name(row, line_number)
+    sample_type = _validate_sample_type(row, line_number, preset=preset)
+    feature_type = _validate_feature_type(row, line_number, preset=preset)
+    resolved_fastqs = _resolve_fastq_columns(row, line_number=line_number, input_path=input_path, preset=preset)
+    _validate_preset_fastq_naming(resolved_fastqs, preset=preset, line_number=line_number)
+    expected_cells = _validate_expected_cells(row, line_number, expected_cells_override)
+    normalized = {column: str(row.get(column, "")).strip() for column in output_columns}
+    normalized.update(
+        {
+            "sample": sample,
+            "fastq_1": resolved_fastqs["fastq_1"].as_posix(),
+            "fastq_2": resolved_fastqs["fastq_2"].as_posix(),
+            "expected_cells": expected_cells,
+            "seq_center": str(row.get("seq_center", "")).strip(),
+        }
+    )
+    if sample_type:
+        normalized["sample_type"] = sample_type
+    if feature_type:
+        normalized["feature_type"] = feature_type
+    for optional_fastq in _optional_fastq_columns_for_preset(preset):
+        if optional_fastq in resolved_fastqs:
+            normalized[optional_fastq] = resolved_fastqs[optional_fastq].as_posix()
+    return normalized, sample, resolved_fastqs
+
+
+def _validate_sample_name(row: dict[str, str], line_number: int) -> str:
+    raw_sample = str(row.get("sample", "")).strip()
+    sample = _normalize_sample_name(raw_sample)
+    if not sample or not _SAMPLE_NAME_RE.match(sample):
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.INVALID_SAMPLESHEET,
+            message="Sample names must be non-empty and cannot contain whitespace after normalization.",
+            fix="Provide a non-empty sample value; whitespace is normalized to underscores before validation.",
+            details={"line": line_number, "sample": raw_sample, "normalized_sample": sample},
+        )
+    return sample
+
+
+def _normalize_sample_name(raw_sample: str) -> str:
+    return _SAMPLE_WHITESPACE_RE.sub("_", raw_sample.strip())
+
+
+def _validate_sample_type(row: dict[str, str], line_number: int, *, preset: str | None) -> str:
+    sample_type = str(row.get("sample_type", "")).strip().lower()
+    if preset == "cellrangerarc" and not sample_type:
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.INVALID_SAMPLESHEET,
+            message="cellrangerarc rows require sample_type to identify ATAC versus GEX libraries.",
+            fix="Set sample_type to either 'atac' or 'gex' for every cellrangerarc row.",
+            details={"line": line_number, "column": "sample_type"},
+        )
+    if not sample_type:
+        return sample_type
+    if preset == "cellrangerarc" and sample_type not in SUPPORTED_SAMPLE_TYPE_VALUES:
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.INVALID_SAMPLESHEET,
+            message="sample_type must be one of the values supported by nf-core/scrnaseq.",
+            fix=f"Use one of: {', '.join(sorted(SUPPORTED_SAMPLE_TYPE_VALUES))}.",
+            details={"line": line_number, "sample_type": sample_type},
+        )
+    return sample_type
+
+
+def _validate_feature_type(row: dict[str, str], line_number: int, *, preset: str | None) -> str:
+    feature_type = str(row.get("feature_type", "")).strip().lower()
+    if preset == "cellrangermulti" and not feature_type:
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.INVALID_SAMPLESHEET,
+            message="cellrangermulti rows require feature_type to identify each library type.",
+            fix=f"Set feature_type to one of: {', '.join(sorted(SUPPORTED_FEATURE_TYPE_VALUES))}.",
+            details={"line": line_number, "column": "feature_type"},
+        )
+    if not feature_type:
+        return feature_type
+    if preset == "cellrangermulti" and feature_type not in SUPPORTED_FEATURE_TYPE_VALUES:
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.INVALID_SAMPLESHEET,
+            message="feature_type must be one of the values supported by nf-core/scrnaseq.",
+            fix=f"Use one of: {', '.join(sorted(SUPPORTED_FEATURE_TYPE_VALUES))}.",
+            details={"line": line_number, "feature_type": feature_type},
+        )
+    return feature_type
+
+
+def _resolve_fastq_columns(
+    row: dict[str, str],
+    *,
+    line_number: int,
+    input_path: Path,
+    preset: str | None,
+) -> dict[str, Path]:
+    resolved = {
+        column: _resolve_required_fastq(row, column, line_number=line_number, input_path=input_path)
+        for column in _REQUIRED_FASTQ_COLUMNS
+    }
+    for column in _optional_fastq_columns_for_preset(preset):
+        raw_value = str(row.get(column, "")).strip()
+        if _row_requires_fastq_barcode(row, column=column, preset=preset):
+            resolved[column] = _resolve_required_fastq(row, column, line_number=line_number, input_path=input_path)
+            continue
+        if _looks_like_fastq_path(raw_value):
+            resolved[column] = _resolve_existing_fastq(
+                raw_value,
+                column,
+                line_number=line_number,
+                input_path=input_path,
+            )
+    return resolved
+
+
+def _resolve_required_fastq(row: dict[str, str], column: str, *, line_number: int, input_path: Path) -> Path:
+    raw_value = str(row.get(column, "")).strip()
+    if not raw_value:
+        _raise_missing_fastq_column(column, line_number)
+    return _resolve_existing_fastq(raw_value, column, line_number=line_number, input_path=input_path)
+
+
+def _raise_missing_fastq_column(column: str, line_number: int) -> None:
+    if column == "fastq_barcode":
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.INVALID_SAMPLESHEET,
+            message="CellRanger ARC ATAC rows require fastq_barcode to point to a barcode FASTQ file.",
+            fix="Provide fastq_barcode for each cellrangerarc row with sample_type=atac.",
+            details={"line": line_number, "column": column},
+        )
+    raise SkillError(
+        stage="validation",
+        error_code=ErrorCode.INVALID_SAMPLESHEET,
+        message="This wrapper requires paired-end FASTQs; both fastq_1 and fastq_2 must be provided for every row.",
+        fix="Provide both FASTQ mates for each row.",
+        details={"line": line_number, "column": column},
+    )
+
+
+def _optional_fastq_columns_for_preset(preset: str | None) -> tuple[str, ...]:
+    return _OPTIONAL_FASTQ_COLUMNS if preset in {"cellrangerarc", "cellrangermulti"} else ()
+
+
+def _row_requires_fastq_barcode(row: dict[str, str], *, column: str, preset: str | None) -> bool:
+    sample_type = str(row.get("sample_type", "")).strip().lower()
+    return preset == "cellrangerarc" and column == "fastq_barcode" and sample_type == "atac"
+
+
+def _looks_like_fastq_path(value: str) -> bool:
+    if not value:
+        return False
+    return value.endswith(_FASTQ_SUFFIXES)
+
+
+def _resolve_existing_fastq(raw_path: str, column: str, *, line_number: int, input_path: Path) -> Path:
+    fastq_path = Path(raw_path).expanduser()
+    fastq_path = (input_path.parent / fastq_path).resolve() if not fastq_path.is_absolute() else fastq_path.resolve()
+    _validate_fastq_path(fastq_path, raw_path, column, line_number)
+    return fastq_path
+
+
+def _validate_fastq_path(fastq_path: Path, raw_path: str, column: str, line_number: int) -> None:
+    if not fastq_path.exists():
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.MISSING_FASTQ,
+            message="A FASTQ file listed in the samplesheet does not exist.",
+            fix="Correct the path in the samplesheet before re-running.",
+            details={"line": line_number, "column": column, "path": raw_path},
+        )
+    if not _FASTQ_BASENAME_RE.match(fastq_path.name):
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.INVALID_FASTQ,
+            message="FASTQ filenames must match the nf-core/scrnaseq schema.",
+            fix="Use a basename without whitespace and with lowercase .fastq.gz or .fq.gz extension.",
+            details={"line": line_number, "column": column, "path": raw_path, "filename": fastq_path.name},
+        )
+    if not fastq_path.is_file():
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.FASTQ_NOT_READABLE,
+            message="A FASTQ path does not point to a readable file.",
+            fix="Ensure the FASTQ path refers to a regular file.",
+            details={"line": line_number, "column": column, "path": raw_path},
+        )
+    if not os.access(fastq_path, os.R_OK):
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.FASTQ_NOT_READABLE,
+            message="A FASTQ file exists but is not readable by the current user.",
+            fix="Check file permissions and ensure the file is readable.",
+            details={"line": line_number, "column": column, "path": raw_path},
+        )
+
+
+def _validate_preset_fastq_naming(
+    resolved_fastqs: dict[str, Path],
+    *,
+    preset: str | None,
+    line_number: int,
+) -> None:
+    if preset == "cellranger":
+        _validate_cellranger_fastq_pair(resolved_fastqs, line_number=line_number)
+    if preset == "cellrangerarc":
+        _validate_cellrangerarc_fastq_names(resolved_fastqs, line_number=line_number)
+
+
+def _validate_cellranger_fastq_pair(resolved_fastqs: dict[str, Path], *, line_number: int) -> None:
+    r1_name = resolved_fastqs["fastq_1"].name
+    r2_name = resolved_fastqs["fastq_2"].name
+    r1_key = _cellranger_pair_key(r1_name, expected_marker="_R1")
+    r2_key = _cellranger_pair_key(r2_name, expected_marker="_R2")
+    if r1_key and r1_key == r2_key:
+        return
+    raise SkillError(
+        stage="validation",
+        error_code=ErrorCode.INVALID_SAMPLESHEET,
+        message="Cell Ranger FASTQ pairs must differ only by R1/R2.",
+        fix="Use matched FASTQ basenames such as sample_S1_L001_R1_001.fastq.gz and sample_S1_L001_R2_001.fastq.gz.",
+        details={"line": line_number, "preset": "cellranger", "fastq_1": r1_name, "fastq_2": r2_name},
+    )
+
+
+def _cellranger_pair_key(filename: str, *, expected_marker: str) -> str:
+    match = _CELLRANGER_READ_MARKER_RE.match(filename)
+    if not match or match.group("marker") != expected_marker:
+        return ""
+    return f"{match.group('prefix')}<READ>{match.group('suffix')}"
+
+
+def _validate_cellrangerarc_fastq_names(resolved_fastqs: dict[str, Path], *, line_number: int) -> None:
+    for column, fastq_path in resolved_fastqs.items():
+        if _TENX_FASTQ_RE.match(fastq_path.name):
+            continue
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.INVALID_FASTQ,
+            message="Cell Ranger ARC FASTQ filenames must follow the 10x naming convention.",
+            fix=(
+                "Use names like sample_S1_L001_R1_001.fastq.gz, sample_S1_L001_R2_001.fastq.gz, "
+                "and sample_S1_L001_I2_001.fastq.gz."
+            ),
+            details={
+                "line": line_number,
+                "preset": "cellrangerarc",
+                "column": column,
+                "filename": fastq_path.name,
+            },
+        )
+
+
+def _validate_expected_cells(
+    row: dict[str, str],
+    line_number: int,
+    expected_cells_override: int | None,
+) -> str:
+    expected_cells = expected_cells_override if expected_cells_override is not None else row.get("expected_cells", "")
+    expected_cells_str = str(expected_cells).strip()
+    if not expected_cells_str:
+        return expected_cells_str
+    try:
+        expected_cells_int = int(expected_cells_str)
+    except ValueError as exc:
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.INVALID_SAMPLESHEET,
+            message="expected_cells must be an integer when provided.",
+            fix="Use an integer value for expected_cells or leave it blank.",
+            details={"line": line_number, "value": expected_cells_str},
+        ) from exc
+    if expected_cells_int < 1:
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.INVALID_SAMPLESHEET,
+            message="expected_cells must be a positive integer (>= 1).",
+            fix="Set expected_cells to a positive integer or leave the column blank.",
+            details={"line": line_number, "value": expected_cells_int},
+        )
+    return expected_cells_str
+
+
+def _reject_sample_name_collision(
+    raw_samples_by_normalized_sample: dict[str, str],
+    row: dict[str, str],
+    line_number: int,
+    normalized_sample: str,
+) -> None:
+    raw_sample = str(row.get("sample", "")).strip()
+    normalized_raw_sample = _normalize_sample_name(raw_sample)
+    if normalized_raw_sample != normalized_sample:
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.INVALID_SAMPLESHEET,
+            message="Sample name normalization was inconsistent.",
+            fix="Report this as a bug with the offending samplesheet row.",
+            details={
+                "line": line_number,
+                "sample": raw_sample,
+                "normalized_sample": normalized_sample,
+                "renormalized_sample": normalized_raw_sample,
+            },
+        )
+    previous_raw_sample = raw_samples_by_normalized_sample.setdefault(normalized_sample, raw_sample)
+    if previous_raw_sample == raw_sample:
+        return
+    raise SkillError(
+        stage="validation",
+        error_code=ErrorCode.INVALID_SAMPLESHEET,
+        message="Distinct sample names collapse to the same normalized nf-core sample identifier.",
+        fix=(
+            "Rename samples so they remain unique after whitespace is converted to underscores "
+            "(for example, avoid using both 'sample A' and 'sample_A')."
+        ),
+        details={
+            "line": line_number,
+            "sample": raw_sample,
+            "previous_sample": previous_raw_sample,
+            "normalized_sample": normalized_sample,
+        },
+    )
+
+
+def _reject_duplicate_fastq_row(
+    seen_rows: set[tuple[str, str, str]],
+    line_number: int,
+    sample: str,
+    resolved_fastqs: dict[str, Path],
+) -> None:
+    row_key = (sample, resolved_fastqs["fastq_1"].as_posix(), resolved_fastqs["fastq_2"].as_posix())
+    if row_key in seen_rows:
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.INVALID_SAMPLESHEET,
+            message="Samplesheet contains a duplicate FASTQ row.",
+            fix="Remove exact duplicate rows; repeated sample names are allowed only for distinct FASTQ pairs.",
+            details={"line": line_number, "sample": sample},
+        )
+    seen_rows.add(row_key)
+
+
+def _reject_inconsistent_repeated_sample_metadata(
+    metadata_by_sample: dict[str, dict[str, str]],
+    line_number: int,
+    sample: str,
+    normalized_row: dict[str, str],
+) -> None:
+    current_metadata = {
+        "expected_cells": str(normalized_row.get("expected_cells", "")).strip(),
+        "seq_center": str(normalized_row.get("seq_center", "")).strip(),
+    }
+    previous_metadata = metadata_by_sample.setdefault(sample, current_metadata)
+    for column, current_value in current_metadata.items():
+        previous_value = previous_metadata.get(column, "")
+        if current_value == previous_value:
+            continue
+        raise SkillError(
+            stage="validation",
+            error_code=ErrorCode.INVALID_SAMPLESHEET,
+            message=f"Repeated sample rows must use the same {column} value.",
+            fix=(
+                f"Use the same {column} for every row of sample {sample!r}, "
+                "or split runs from different metadata groups into distinct sample names."
+            ),
+            details={
+                "line": line_number,
+                "sample": sample,
+                "column": column,
+                "previous_value": previous_value,
+                "value": current_value,
+            },
+        )
+
+
+def _write_normalized_samplesheet(
+    output_path: Path,
+    output_columns: list[str],
+    normalized_rows: list[dict[str, str]],
+) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=output_columns)
+        writer.writeheader()
+        writer.writerows(normalized_rows)

--- a/skills/nfcore-scrnaseq-wrapper/schemas.py
+++ b/skills/nfcore-scrnaseq-wrapper/schemas.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+SKILL_NAME = "nfcore-scrnaseq-wrapper"
+SKILL_ALIAS = "scrnaseq-pipeline"
+SKILL_VERSION = "0.1.0"
+SKILL_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = SKILL_DIR.parent.parent
+REPO_PARENT = PROJECT_ROOT.parent
+DEFAULT_LOCAL_PIPELINE_DIR = REPO_PARENT / "scrnaseq"
+DEFAULT_REMOTE_PIPELINE = "nf-core/scrnaseq"
+DEFAULT_PIPELINE_VERSION = "4.1.0"
+DEFAULT_PROFILE = "docker"
+DEFAULT_PRESET = "standard"
+DEFAULT_TIMEOUT_SECONDS = 60 * 60 * 12
+SUPPORTED_PRESETS = {"standard", "star", "kallisto", "cellranger", "cellrangerarc", "cellrangermulti"}
+SUPPORTED_PROFILES = {
+    "docker", "conda", "mamba",
+    "singularity", "apptainer",
+    "podman", "shifter", "charliecloud",
+}
+JAVA_MIN_VERSION = 17
+NEXTFLOW_MIN_VERSION = (25, 4, 0)
+PIPELINE_REQUIRED_FILES = ("main.nf", "nextflow.config", "assets/schema_input.json")
+SUPPORTED_SAMPLE_COLUMNS = {
+    "sample",
+    "fastq_1",
+    "fastq_2",
+    "expected_cells",
+    "seq_center",
+    "sample_type",
+    "fastq_barcode",
+    "feature_type",
+}
+REQUIRED_SAMPLE_COLUMNS = ("sample", "fastq_1", "fastq_2")
+SUPPORTED_SAMPLE_TYPE_VALUES = {"atac", "gex"}
+SUPPORTED_FEATURE_TYPE_VALUES = {"gex", "vdj", "ab", "crispr", "cmo"}
+PREFERRED_H5AD_ORDER = (
+    "combined_cellbender_filter_matrix.h5ad",
+    "combined_filtered_matrix.h5ad",
+    "combined_raw_matrix.h5ad",
+)
+
+COMMON_GENOMES = (
+    "GRCh38",
+    "GRCh37",
+    "hg38",
+    "hg19",
+    "GRCm38",
+    "GRCm39",
+    "mm10",
+    "mm9",
+    "BDGP6",
+    "WBcel235",
+    "R64-1-1",
+    "CanFam3.1",
+    "UMD3.1",
+    "Mmul_8.0.1",
+    "Sscrofa11.1",
+)
+
+PRESET_ALIGNERS = {
+    "standard": "simpleaf",
+    "star": "star",
+    "kallisto": "kallisto",
+    "cellranger": "cellranger",
+    "cellrangerarc": "cellrangerarc",
+    "cellrangermulti": "cellrangermulti",
+}
+
+PRESET_REQUIREMENTS = {
+    "standard": {
+        "requires_any": [("genome",), ("simpleaf_index",), ("fasta", "gtf"), ("transcript_fasta", "txp2gene")],
+    },
+    "star": {
+        "requires_any": [("genome",), ("star_index",), ("fasta", "gtf")],
+    },
+    "kallisto": {
+        "requires_any": [("genome",), ("kallisto_index",), ("fasta", "gtf")],
+    },
+    "cellranger": {
+        "requires_any": [("genome",), ("cellranger_index",), ("fasta", "gtf")],
+    },
+    "cellrangerarc": {
+        "requires_any": [("genome",), ("cellranger_index",), ("fasta", "gtf")],
+    },
+    "cellrangermulti": {
+        "requires_any": [("genome",), ("cellranger_index",), ("fasta", "gtf")],
+    },
+}

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_command_builder.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_command_builder.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from command_builder import build_nextflow_command
+
+
+def test_local_checkout_command(tmp_path):
+    params_path = tmp_path / "params.yaml"
+    params_path.write_text("aligner: star\n", encoding="utf-8")
+    source = {
+        "source_kind": "local_checkout",
+        "source_ref": "/abs/path/to/scrnaseq",
+        "resolved_version": "abc1234",
+    }
+    cmd, cmd_str = build_nextflow_command(
+        pipeline_source=source,
+        profile="docker",
+        params_path=params_path,
+        resume=False,
+    )
+    assert cmd[0] == "nextflow"
+    assert cmd[1] == "run"
+    assert cmd[2] == "/abs/path/to/scrnaseq"
+    assert "-profile" in cmd
+    assert "docker" in cmd
+    assert "-params-file" in cmd
+    assert params_path.as_posix() in cmd  # forward slashes on all platforms
+    assert "-resume" not in cmd
+    assert "-r" not in cmd
+
+
+def test_work_dir_is_under_wrapper_output_when_provided(tmp_path):
+    params_path = tmp_path / "params.yaml"
+    params_path.write_text("aligner: star\n", encoding="utf-8")
+    work_dir = tmp_path / "upstream" / "work"
+    source = {
+        "source_kind": "local_checkout",
+        "source_ref": "/abs/path/to/scrnaseq",
+        "resolved_version": "abc1234",
+    }
+    cmd, _cmd_str = build_nextflow_command(
+        pipeline_source=source,
+        profile="docker",
+        params_path=params_path,
+        resume=False,
+        work_dir=work_dir,
+    )
+    assert "-work-dir" in cmd
+    assert cmd[cmd.index("-work-dir") + 1] == work_dir.as_posix()
+
+
+def test_remote_repo_command_includes_version(tmp_path):
+    params_path = tmp_path / "params.yaml"
+    params_path.write_text("aligner: star\n", encoding="utf-8")
+    source = {
+        "source_kind": "remote_repo",
+        "source_ref": "nf-core/scrnaseq",
+        "resolved_version": "4.1.0",
+    }
+    cmd, cmd_str = build_nextflow_command(
+        pipeline_source=source,
+        profile="singularity",
+        params_path=params_path,
+        resume=False,
+    )
+    assert "nf-core/scrnaseq" in cmd
+    assert "-r" in cmd
+    assert "4.1.0" in cmd
+    assert "singularity" in cmd
+
+
+def test_resume_flag_appended(tmp_path):
+    params_path = tmp_path / "params.yaml"
+    params_path.write_text("aligner: star\n", encoding="utf-8")
+    source = {
+        "source_kind": "local_checkout",
+        "source_ref": "/abs/path/to/scrnaseq",
+        "resolved_version": "abc1234",
+    }
+    cmd, _cmd_str = build_nextflow_command(
+        pipeline_source=source,
+        profile="docker",
+        params_path=params_path,
+        resume=True,
+    )
+    assert "-resume" in cmd
+
+
+def test_command_str_is_shell_safe(tmp_path):
+    params_path = tmp_path / "params with spaces.yaml"
+    params_path.write_text("aligner: star\n", encoding="utf-8")
+    source = {
+        "source_kind": "local_checkout",
+        "source_ref": "/abs/path to/scrnaseq",
+        "resolved_version": "abc1234",
+    }
+    _cmd, cmd_str = build_nextflow_command(
+        pipeline_source=source,
+        profile="docker",
+        params_path=params_path,
+        resume=False,
+    )
+    assert "'" in cmd_str or '"' in cmd_str or "\\ " in cmd_str
+
+
+def test_extra_configs_added_to_command(tmp_path):
+    params_path = tmp_path / "params.yaml"
+    params_path.write_text("aligner: star\n", encoding="utf-8")
+    cfg1 = tmp_path / "custom.config"
+    cfg1.write_text("process { }\n", encoding="utf-8")
+    cfg2 = tmp_path / "extra.config"
+    cfg2.write_text("docker { enabled = true }\n", encoding="utf-8")
+    source = {
+        "source_kind": "local_checkout",
+        "source_ref": "/abs/path/to/scrnaseq",
+        "resolved_version": "abc1234",
+    }
+    cmd, cmd_str = build_nextflow_command(
+        pipeline_source=source,
+        profile="docker",
+        params_path=params_path,
+        resume=False,
+        extra_configs=[cfg1, cfg2],
+    )
+    assert cmd.count("-c") == 2
+    assert cfg1.as_posix() in cmd  # forward slashes
+    assert cfg2.as_posix() in cmd
+
+
+def test_no_extra_configs_by_default(tmp_path):
+    params_path = tmp_path / "params.yaml"
+    params_path.write_text("aligner: star\n", encoding="utf-8")
+    source = {
+        "source_kind": "local_checkout",
+        "source_ref": "/abs/path/to/scrnaseq",
+        "resolved_version": "abc1234",
+    }
+    cmd, _cmd_str = build_nextflow_command(
+        pipeline_source=source,
+        profile="docker",
+        params_path=params_path,
+        resume=False,
+    )
+    assert "-c" not in cmd
+
+
+def test_resume_comes_after_configs(tmp_path):
+    params_path = tmp_path / "params.yaml"
+    params_path.write_text("aligner: star\n", encoding="utf-8")
+    cfg = tmp_path / "custom.config"
+    cfg.write_text("process { }\n", encoding="utf-8")
+    source = {
+        "source_kind": "local_checkout",
+        "source_ref": "/abs/path/to/scrnaseq",
+        "resolved_version": "abc1234",
+    }
+    cmd, _cmd_str = build_nextflow_command(
+        pipeline_source=source,
+        profile="docker",
+        params_path=params_path,
+        resume=True,
+        extra_configs=[cfg],
+    )
+    assert cmd.index("-resume") > cmd.index("-c")
+
+
+def test_command_uses_posix_paths(tmp_path):
+    """All file paths in the command list must use forward slashes (no backslashes)."""
+    params_path = tmp_path / "params.yaml"
+    params_path.write_text("aligner: star\n", encoding="utf-8")
+    cfg = tmp_path / "extra.config"
+    cfg.write_text("process { }\n", encoding="utf-8")
+    source = {
+        "source_kind": "local_checkout",
+        "source_ref": str(tmp_path / "scrnaseq"),
+        "resolved_version": "abc1234",
+    }
+    cmd, _cmd_str = build_nextflow_command(
+        pipeline_source=source,
+        profile="docker",
+        params_path=params_path,
+        resume=False,
+        extra_configs=[cfg],
+    )
+    for part in cmd:
+        assert "\\" not in part, f"Backslash found in command part: {part!r}"
+
+
+def test_local_checkout_source_ref_uses_posix_path(tmp_path):
+    """Local checkout source_ref is converted to forward slashes in the command."""
+    params_path = tmp_path / "params.yaml"
+    params_path.write_text("aligner: star\n", encoding="utf-8")
+    pipeline_dir = tmp_path / "scrnaseq"
+    source = {
+        "source_kind": "local_checkout",
+        "source_ref": str(pipeline_dir),
+        "resolved_version": "abc",
+    }
+    cmd, _ = build_nextflow_command(
+        pipeline_source=source,
+        profile="docker",
+        params_path=params_path,
+        resume=False,
+    )
+    assert cmd[2] == pipeline_dir.as_posix()

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_error_codes.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_error_codes.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from errors import ErrorCode, SkillError
+from schemas import (
+    DEFAULT_PIPELINE_VERSION,
+    JAVA_MIN_VERSION,
+    NEXTFLOW_MIN_VERSION,
+    SUPPORTED_PRESETS,
+    SUPPORTED_PROFILES,
+)
+
+
+def test_all_error_codes_are_string_constants():
+    import inspect
+    attrs = {k: v for k, v in inspect.getmembers(ErrorCode) if not k.startswith("_")}
+    assert attrs, "ErrorCode must define at least one constant"
+    assert all(isinstance(v, str) for v in attrs.values()), "All ErrorCode values must be strings"
+
+
+def test_skill_error_accepts_error_code_constant():
+    err = SkillError(
+        stage="preflight",
+        error_code=ErrorCode.MISSING_JAVA,
+        message="java missing",
+        fix="install java",
+    )
+    assert err.error_code == "MISSING_JAVA"
+
+
+def test_error_response_shape():
+    payload = SkillError(
+        stage="preflight",
+        error_code="MISSING_JAVA",
+        message="java missing",
+        fix="install java",
+    ).to_dict()
+    assert payload["ok"] is False
+    assert payload["error_code"] == "MISSING_JAVA"
+
+
+def test_skill_error_to_dict():
+    err = SkillError("validation", "INVALID_SAMPLESHEET", "bad", "fix")
+    payload = err.to_dict()
+    assert payload["stage"] == "validation"
+
+
+def test_pinned_versions_match_runtime_constants():
+    path = Path(__file__).resolve().parent.parent / "reproducibility" / "pinned_versions.json"
+    pinned = json.loads(path.read_text(encoding="utf-8"))
+    assert pinned["pipeline"]["default_version"] == DEFAULT_PIPELINE_VERSION
+    assert int(pinned["minimum_versions"]["java"]) == JAVA_MIN_VERSION
+    assert tuple(map(int, pinned["minimum_versions"]["nextflow"].split("."))) == NEXTFLOW_MIN_VERSION
+    assert set(pinned["supported_profiles"]) == SUPPORTED_PROFILES
+    assert set(pinned["supported_presets"]) == SUPPORTED_PRESETS
+
+
+def test_compatibility_policy_matches_runtime_execution_defaults():
+    path = Path(__file__).resolve().parent.parent / "reproducibility" / "compatibility_policy.json"
+    policy = json.loads(path.read_text(encoding="utf-8"))
+    assert policy["resume_policy"]["requires_same_params_checksum"] is True
+    assert policy["execution_policy"]["work_dir"] == "output/upstream/work"

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_executor.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_executor.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from errors import SkillError
+from executor import execute_nextflow
+
+
+class _MockProc:
+    """Minimal Popen replacement that avoids spawning a real process."""
+
+    def __init__(self, returncode: int = 0, timeout_on_first_wait: bool = False):
+        self._rc = returncode
+        self._timeout_on_first = timeout_on_first_wait
+        self._wait_calls = 0
+        self.killed = False
+        self.pid = 1234
+
+    def wait(self, timeout=None):
+        self._wait_calls += 1
+        if self._timeout_on_first and self._wait_calls == 1:
+            raise subprocess.TimeoutExpired(cmd=["nextflow"], timeout=timeout or 1)
+        return self._rc
+
+    def kill(self):
+        self.killed = True
+
+
+def test_execute_nextflow_creates_log_files_on_success(tmp_path, monkeypatch):
+    proc = _MockProc(returncode=0)
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: proc)
+    result = execute_nextflow(["nextflow", "run", "test"], cwd=tmp_path, output_dir=tmp_path, timeout_seconds=60)
+    assert result["exit_code"] == 0
+    assert (tmp_path / "logs" / "stdout.txt").exists()
+    assert (tmp_path / "logs" / "stderr.txt").exists()
+
+
+def test_execute_nextflow_raises_on_nonzero_exit(tmp_path, monkeypatch):
+    proc = _MockProc(returncode=1)
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: proc)
+    with pytest.raises(SkillError) as exc:
+        execute_nextflow(["nextflow", "run", "test"], cwd=tmp_path, output_dir=tmp_path, timeout_seconds=60)
+    assert exc.value.error_code == "EXECUTION_FAILED"
+    assert exc.value.details["exit_code"] == 1
+
+
+def test_execute_nextflow_log_files_created_on_failure(tmp_path, monkeypatch):
+    proc = _MockProc(returncode=1)
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: proc)
+    with pytest.raises(SkillError):
+        execute_nextflow(["nextflow", "run", "test"], cwd=tmp_path, output_dir=tmp_path, timeout_seconds=60)
+    assert (tmp_path / "logs" / "stdout.txt").exists()
+    assert (tmp_path / "logs" / "stderr.txt").exists()
+
+
+def test_execute_nextflow_kills_process_on_timeout(tmp_path, monkeypatch):
+    proc = _MockProc(returncode=0, timeout_on_first_wait=True)
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: proc)
+    monkeypatch.setattr(sys, "platform", "win32")
+    with pytest.raises(SkillError) as exc:
+        execute_nextflow(["nextflow", "run", "test"], cwd=tmp_path, output_dir=tmp_path, timeout_seconds=1)
+    assert exc.value.error_code == "EXECUTION_FAILED"
+    assert proc.killed, "Process must be killed on timeout"
+
+
+def test_execute_nextflow_starts_new_session_on_posix(tmp_path, monkeypatch):
+    proc = _MockProc(returncode=0)
+    popen_kwargs = {}
+
+    def fake_popen(*args, **kwargs):
+        popen_kwargs.update(kwargs)
+        return proc
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    execute_nextflow(["nextflow", "run", "test"], cwd=tmp_path, output_dir=tmp_path, timeout_seconds=60)
+    assert popen_kwargs["start_new_session"] is True
+
+
+def test_execute_nextflow_terminates_process_group_on_timeout(tmp_path, monkeypatch):
+    """killpg must receive the process GROUP id (pgid), not the process id (pid)."""
+    proc = _MockProc(returncode=0, timeout_on_first_wait=True)
+    proc.pid = 1234
+    _PGID = 5678  # intentionally different from pid
+
+    signals_sent: list[tuple[int, int]] = []
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: proc)
+    monkeypatch.setattr("executor.os.getpgid", lambda pid: _PGID)
+    monkeypatch.setattr("executor.os.killpg", lambda pgid, sig: signals_sent.append((pgid, sig)))
+
+    with pytest.raises(SkillError) as exc:
+        execute_nextflow(["nextflow", "run", "test"], cwd=tmp_path, output_dir=tmp_path, timeout_seconds=1)
+
+    assert exc.value.error_code == "EXECUTION_FAILED"
+    assert signals_sent, "Timeout should signal the process group on POSIX"
+    assert all(pgid == _PGID for pgid, _ in signals_sent), \
+        f"killpg must receive pgid={_PGID}, not pid={proc.pid}"
+    assert not proc.killed
+
+
+def test_execute_nextflow_timeout_falls_back_to_process_kill(tmp_path, monkeypatch):
+    proc = _MockProc(returncode=0, timeout_on_first_wait=True)
+    proc.pid = 1234
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: proc)
+    monkeypatch.setattr("executor.os.killpg", lambda *a, **kw: (_ for _ in ()).throw(OSError("no group")))
+    with pytest.raises(SkillError):
+        execute_nextflow(["nextflow", "run", "test"], cwd=tmp_path, output_dir=tmp_path, timeout_seconds=1)
+    assert proc.killed
+
+
+def test_execute_nextflow_result_contains_log_paths(tmp_path, monkeypatch):
+    proc = _MockProc(returncode=0)
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: proc)
+    result = execute_nextflow(["nextflow", "run", "test"], cwd=tmp_path, output_dir=tmp_path, timeout_seconds=60)
+    assert "stdout_path" in result
+    assert "stderr_path" in result
+    assert Path(result["stdout_path"]).name == "stdout.txt"
+    assert Path(result["stderr_path"]).name == "stderr.txt"
+
+
+def test_execute_nextflow_cleans_up_empty_logs_on_popen_failure(tmp_path, monkeypatch):
+    """Empty log files must be removed when Popen itself fails."""
+    def raise_os_error(*args, **kwargs):
+        raise OSError("nextflow: command not found")
+
+    monkeypatch.setattr(subprocess, "Popen", raise_os_error)
+    with pytest.raises(SkillError) as exc:
+        execute_nextflow(["nextflow", "run", "test"], cwd=tmp_path, output_dir=tmp_path, timeout_seconds=60)
+    assert exc.value.error_code == "EXECUTION_FAILED"
+    assert not (tmp_path / "logs" / "stdout.txt").exists()
+    assert not (tmp_path / "logs" / "stderr.txt").exists()

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_nfcore_scrnaseq_wrapper.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_nfcore_scrnaseq_wrapper.py
@@ -1,0 +1,592 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import runpy
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = SKILL_DIR / "nfcore_scrnaseq_wrapper.py"
+PROJECT_ROOT = SKILL_DIR.parent.parent
+CLAWBIO_PATH = PROJECT_ROOT / "clawbio.py"
+
+sys.path.insert(0, str(SKILL_DIR))
+
+from errors import SkillError
+
+
+def test_skill_modules_importable_without_running_script(tmp_path):
+    """Sibling-module imports must work when loading files directly."""
+    skill_root = Path(__file__).resolve().parent.parent
+    skill_dir = str(skill_root)
+    original = list(sys.path)
+    sibling_modules = {
+        "errors",
+        "schemas",
+        "command_builder",
+        "executor",
+        "outputs_parser",
+        "params_builder",
+        "pipeline_source",
+        "preflight",
+        "provenance",
+        "reporting",
+        "samplesheet_builder",
+    }
+    original_modules = {name: sys.modules.pop(name) for name in list(sys.modules) if name in sibling_modules}
+    sys.path = [p for p in sys.path if p != skill_dir]
+    try:
+        for module_path in sorted(skill_root.glob("*.py")):
+            if module_path.name == "nfcore_scrnaseq_wrapper.py":
+                continue
+            for name in sibling_modules:
+                sys.modules.pop(name, None)
+            spec = importlib.util.spec_from_file_location(f"isolated_{module_path.stem}", module_path)
+            assert spec is not None
+            assert spec.loader is not None
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules[spec.name] = mod
+            try:
+                spec.loader.exec_module(mod)
+            finally:
+                sys.modules.pop(spec.name, None)
+    finally:
+        for name in sibling_modules:
+            sys.modules.pop(name, None)
+        sys.modules.update(original_modules)
+        sys.path = original
+
+
+def _load_skill_module():
+    spec = importlib.util.spec_from_file_location("nfcore_scrnaseq_wrapper_module", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parser_accepts_expected_flags():
+    module = _load_skill_module()
+    parser = module.build_parser()
+    args = parser.parse_args(["--input", "samplesheet.csv", "--output", "out", "--preset", "star", "--resume"])
+    assert args.input == "samplesheet.csv"
+    assert args.output == "out"
+    assert args.preset == "star"
+    assert args.resume is True
+
+
+def test_parser_star_feature_rejects_invalid_value():
+    """--star-feature must reject values not in the nf-core schema enum."""
+    module = _load_skill_module()
+    parser = module.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--output", "out", "--star-feature", "Velocyto"])
+
+
+def test_parser_star_feature_accepts_gene_velocyto_with_space():
+    """'Gene Velocyto' (with space) is the correct schema enum value — must be accepted."""
+    module = _load_skill_module()
+    parser = module.build_parser()
+    args = parser.parse_args(["--output", "out", "--star-feature", "Gene Velocyto"])
+    assert args.star_feature == "Gene Velocyto"
+
+
+def test_parser_simpleaf_umi_resolution_rejects_invalid_value():
+    """--simpleaf-umi-resolution must reject values not in the nf-core schema enum."""
+    module = _load_skill_module()
+    parser = module.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--output", "out", "--simpleaf-umi-resolution", "invalid-strategy"])
+
+
+def test_parser_kb_workflow_rejects_invalid_value():
+    """--kb-workflow must reject values not in the nf-core schema enum."""
+    module = _load_skill_module()
+    parser = module.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--output", "out", "--kb-workflow", "unknown"])
+
+
+def test_main_writes_structured_error_when_input_missing(tmp_path, monkeypatch):
+    module = _load_skill_module()
+    monkeypatch.setattr(module, "resolve_pipeline_source", lambda **kw: {
+        "source_kind": "remote_repo",
+        "source_ref": "nf-core/scrnaseq",
+        "resolved_version": kw.get("requested_version", ""),
+        "branch": "",
+        "dirty": False,
+    })
+    monkeypatch.setattr(sys, "argv", ["nfcore_scrnaseq_wrapper.py", "--output", str(tmp_path)])
+    rc = module.main()
+    assert rc == 1
+    payload = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
+    assert payload["error_code"] == "MISSING_INPUT"
+
+
+def test_main_does_not_write_into_rejected_nonempty_output_dir(tmp_path, monkeypatch):
+    """OUTPUT_DIR_NOT_EMPTY must fail before writing wrapper artifacts into the directory.
+
+    Ordering dependency: check_output_dir_available() fires in main() *before*
+    validate_and_normalize_samplesheet(), so samplesheet.valid.csv is never written.
+    The second check inside run_preflight() is never reached in this path.
+    """
+    module = _load_skill_module()
+    out = tmp_path / "out"
+    out.mkdir()
+    sentinel = out / "result.json"
+    sentinel.write_text("do not overwrite", encoding="utf-8")
+    r1 = tmp_path / "r1.fastq.gz"
+    r2 = tmp_path / "r2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    samplesheet = tmp_path / "samplesheet.csv"
+    samplesheet.write_text(f"sample,fastq_1,fastq_2\nsampleA,{r1},{r2}\n", encoding="utf-8")
+    monkeypatch.setattr(module, "resolve_pipeline_source", lambda **kw: {
+        "source_kind": "remote_repo",
+        "source_ref": "nf-core/scrnaseq",
+        "resolved_version": kw.get("requested_version", ""),
+        "branch": "",
+        "dirty": False,
+    })
+    monkeypatch.setattr(sys, "argv", [
+        "nfcore_scrnaseq_wrapper.py",
+        "--input", str(samplesheet),
+        "--output", str(out),
+        "--genome", "GRCh38",
+    ])
+    rc = module.main()
+    assert rc == 1
+    assert sentinel.read_text(encoding="utf-8") == "do not overwrite"
+    assert not (out / "reproducibility" / "samplesheet.valid.csv").exists()
+
+
+def test_output_path_existing_file_returns_structured_error(tmp_path, monkeypatch, capsys):
+    module = _load_skill_module()
+    output_file = tmp_path / "not_a_directory"
+    output_file.write_text("already here", encoding="utf-8")
+    monkeypatch.setattr(module, "resolve_pipeline_source", lambda **kw: (_ for _ in ()).throw(AssertionError("should not resolve pipeline source")))
+    monkeypatch.setattr(sys, "argv", [
+        "nfcore_scrnaseq_wrapper.py",
+        "--output", str(output_file),
+        "--demo",
+    ])
+    rc = module.main()
+    assert rc == 1
+    assert output_file.read_text(encoding="utf-8") == "already here"
+    payload = json.loads(capsys.readouterr().err)
+    assert payload["stage"] == "preflight"
+    assert payload["error_code"] == "OUTPUT_DIR_NOT_WRITABLE"
+
+
+@pytest.mark.integration
+def test_clawbio_list_shows_skill():
+    proc = subprocess.run(
+        [sys.executable, str(CLAWBIO_PATH), "list"],
+        capture_output=True,
+        text=True,
+        cwd=str(PROJECT_ROOT),
+    )
+    assert proc.returncode == 0
+    assert "scrnaseq-pipeline" in proc.stdout
+
+
+@pytest.mark.integration
+def test_clawbio_registry_has_long_timeout_and_file_cap():
+    registry = runpy.run_path(str(CLAWBIO_PATH))["SKILLS"]
+    info = registry["scrnaseq-pipeline"]
+    assert info["default_timeout_seconds"] > 60 * 60 * 12
+    assert info["max_output_files_listed"] <= 50
+    assert "--run-downstream" in info["allowed_extra_flags"]
+    assert "--skip-downstream" in info["allowed_extra_flags_without_values"]
+
+
+def test_clawbio_runner_rejects_output_path_that_is_file(tmp_path):
+    output_file = tmp_path / "not_a_directory"
+    output_file.write_text("already here", encoding="utf-8")
+    run_skill = runpy.run_path(str(CLAWBIO_PATH))["run_skill"]
+
+    result = run_skill("scrnaseq-pipeline", output_dir=str(output_file), demo=True)
+
+    assert result["success"] is False
+    assert result["exit_code"] == -1
+    assert "Traceback" not in result["stderr"]
+    payload = json.loads(result["stderr"])
+    assert payload["stage"] == "preflight"
+    assert payload["error_code"] == "OUTPUT_DIR_NOT_WRITABLE"
+    assert output_file.read_text(encoding="utf-8") == "already here"
+
+
+def test_write_macos_docker_config_produces_valid_groovy(tmp_path):
+    module = _load_skill_module()
+    config_path = module._write_macos_docker_config(tmp_path)
+    assert config_path.exists()
+    content = config_path.read_text(encoding="utf-8")
+    assert "process {" in content
+    assert "stageInMode" in content
+    assert '"copy"' in content
+    assert "STAR_ALIGN" in content
+    assert '--outTmpDir' in content
+    assert 'ext.args' in content
+    assert 'resourceLimits' in content
+    assert "docker {" in content
+    assert "--platform linux/amd64" in content
+
+
+def test_write_macos_docker_config_creates_in_reproducibility_dir(tmp_path):
+    module = _load_skill_module()
+    repro_dir = tmp_path / "reproducibility"
+    repro_dir.mkdir()
+    config_path = module._write_macos_docker_config(tmp_path)
+    assert config_path.parent == repro_dir
+
+
+def test_resume_params_checksum_mismatch_preserves_previous_run_artifacts(tmp_path, monkeypatch, capsys):
+    """Invalid resume must not overwrite artifacts from the previous successful run."""
+    module = _load_skill_module()
+
+    fake_source = {
+        "source_kind": "remote_repo",
+        "source_ref": "nf-core/scrnaseq",
+        "resolved_version": "3.14.0",
+        "branch": "",
+        "dirty": False,
+    }
+    # Write a manifest with a checksum that will never match the generated params
+    repro_dir = tmp_path / "reproducibility"
+    repro_dir.mkdir(parents=True)
+    manifest = {
+        "preset": "star",
+        "profile": "docker",
+        "pipeline_source": fake_source,
+        "params_checksum": "deadbeef" * 8,
+    }
+    (repro_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    previous_samplesheet = repro_dir / "samplesheet.valid.csv"
+    previous_params = repro_dir / "params.yaml"
+    previous_result = tmp_path / "result.json"
+    previous_samplesheet.write_text("previous samplesheet\n", encoding="utf-8")
+    previous_params.write_text("previous params\n", encoding="utf-8")
+    previous_result.write_text('{"ok": true, "previous": true}', encoding="utf-8")
+
+    # Minimal samplesheet
+    r1 = tmp_path / "r1.fastq.gz"
+    r2 = tmp_path / "r2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    ss = tmp_path / "samplesheet.csv"
+    ss.write_text(f"sample,fastq_1,fastq_2\nsampleA,{r1},{r2}\n", encoding="utf-8")
+
+    monkeypatch.setattr(module, "resolve_pipeline_source", lambda **kw: fake_source)
+    monkeypatch.setattr(module, "run_preflight", lambda args, **kw: {
+        "ok": True,
+        "java": {"version": "21.0.0", "path": ""},
+        "nextflow": {"version": "25.4.0", "path": ""},
+        "profile": {"profile": "docker"},
+        "pipeline_source": fake_source,
+        "references": {},
+        "samplesheet": {"sample_count": 1, "unknown_columns": []},
+    })
+
+    monkeypatch.setattr(sys, "argv", [
+        "nfcore_scrnaseq_wrapper.py",
+        "--input", str(ss),
+        "--output", str(tmp_path),
+        "--preset", "star",
+        "--profile", "docker",
+        "--resume",
+        "--fasta", str(r1),
+        "--gtf", str(r2),
+    ])
+    rc = module.main()
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().err)
+    assert payload["error_code"] == "INVALID_RESUME_STATE"
+    assert previous_samplesheet.read_text(encoding="utf-8") == "previous samplesheet\n"
+    assert previous_params.read_text(encoding="utf-8") == "previous params\n"
+    assert json.loads(previous_result.read_text(encoding="utf-8")) == {"ok": True, "previous": True}
+
+
+def test_main_returns_1_and_writes_result_on_unexpected_exception(tmp_path, monkeypatch):
+    """An unexpected exception must produce a structured result.json with a traceback."""
+    module = _load_skill_module()
+
+    monkeypatch.setattr(module, "resolve_pipeline_source", lambda **kw: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(sys, "argv", [
+        "nfcore_scrnaseq_wrapper.py",
+        "--output", str(tmp_path),
+        "--demo",
+    ])
+    rc = module.main()
+    assert rc == 1
+    result_path = tmp_path / "result.json"
+    assert result_path.exists()
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert payload["error_code"] == "UNEXPECTED_ERROR"
+    assert "traceback" in payload["details"]
+    assert "RuntimeError" in payload["details"]["traceback"]
+
+
+def test_build_extra_nextflow_configs_returns_empty_on_linux(tmp_path, monkeypatch):
+    """`_build_extra_nextflow_configs` must return [] on Linux regardless of profile."""
+    module = _load_skill_module()
+    import argparse as _argparse
+    args = _argparse.Namespace(profile="docker")
+    with patch("platform.system", return_value="Linux"):
+        result = module._build_extra_nextflow_configs(args, tmp_path)
+    assert result == [], f"Expected [], got {result}"
+
+
+def test_build_extra_nextflow_configs_writes_config_on_macos_docker(tmp_path):
+    """`_build_extra_nextflow_configs` must write the VirtioFS config on macOS with docker."""
+    module = _load_skill_module()
+    import argparse as _argparse
+    args = _argparse.Namespace(profile="docker")
+    with patch("platform.system", return_value="Darwin"):
+        result = module._build_extra_nextflow_configs(args, tmp_path)
+    assert len(result) == 1
+    assert result[0].exists()
+    assert "stageInMode" in result[0].read_text(encoding="utf-8")
+
+
+def test_build_extra_nextflow_configs_returns_empty_on_macos_non_docker(tmp_path):
+    """`_build_extra_nextflow_configs` must return [] on macOS when profile is not docker."""
+    module = _load_skill_module()
+    import argparse as _argparse
+    args = _argparse.Namespace(profile="singularity")
+    with patch("platform.system", return_value="Darwin"):
+        result = module._build_extra_nextflow_configs(args, tmp_path)
+    assert result == []
+
+
+def test_prepare_demo_samplesheet_returns_three_tuple(tmp_path):
+    """_prepare_demo_samplesheet must return (normalized, staged, summary) — a 3-tuple.
+
+    Previously it returned only 2 values, causing a ValueError when the caller
+    unpacked: normalized_samplesheet, staged_samplesheet, samplesheet_summary = ...
+    """
+    module = _load_skill_module()
+    import argparse as _argparse
+    args = _argparse.Namespace(preset="star", skip_cellbender=False)
+    result = module._prepare_demo_samplesheet(args, tmp_path, staging_dir=None)
+    assert len(result) == 3, f"Expected 3-tuple, got {len(result)}-tuple"
+    normalized, staged, summary = result
+    assert isinstance(normalized, __import__("pathlib").Path)
+    assert isinstance(staged, __import__("pathlib").Path)
+    assert isinstance(summary, dict)
+    assert "sample_count" in summary
+    assert "normalized_path" in summary
+
+
+def test_prepare_demo_samplesheet_mutates_preset_before_writing(tmp_path):
+    """Preset mutation must happen before file I/O."""
+    module = _load_skill_module()
+    import argparse as _argparse
+    args = _argparse.Namespace(preset="kallisto", skip_cellbender=False)
+    _, _, summary = module._prepare_demo_samplesheet(args, tmp_path, staging_dir=None)
+    assert args.preset == "star"
+    assert args.skip_cellbender is True
+    assert summary["sample_count"] == 0
+
+
+def test_check_resume_params_checksum_does_not_raise_when_manifest_missing(tmp_path):
+    """When manifest.json is absent, _check_resume_params_checksum must return silently."""
+    module = _load_skill_module()
+    import argparse as _argparse
+    args = _argparse.Namespace(resume=True)
+    params_payload = {"aligner": "star", "outdir": "/tmp/out"}
+    module._check_resume_params_checksum(args, output_dir=tmp_path, params_payload=params_payload)
+
+
+def test_demo_samplesheet_written_as_demo_csv(tmp_path):
+    """Demo mode must write samplesheet.demo.csv, not samplesheet.valid.csv."""
+    module = _load_skill_module()
+    import argparse as _argparse
+    args = _argparse.Namespace(preset="star", skip_cellbender=False)
+    normalized, staged, _ = module._prepare_demo_samplesheet(args, tmp_path, staging_dir=None)
+    assert normalized.name == "samplesheet.demo.csv", \
+        f"Expected samplesheet.demo.csv, got {normalized.name}"
+
+
+def test_nextflow_execution_cwd_is_output_dir(tmp_path):
+    """Relative params.input paths must resolve from the wrapper output directory."""
+    module = _load_skill_module()
+
+    assert module._nextflow_execution_cwd(tmp_path) == tmp_path
+
+
+def test_nextflow_replay_command_records_launch_directory(tmp_path):
+    module = _load_skill_module()
+    output_dir = tmp_path / "output with spaces"
+
+    replay = module._nextflow_replay_command("nextflow run nf-core/scrnaseq", output_dir)
+
+    assert replay.startswith("cd ")
+    assert "output with spaces" in replay
+    assert replay.endswith("&& nextflow run nf-core/scrnaseq")
+
+
+# ---------------------------------------------------------------------------
+# Task 18: downstream scrna_orchestrator handoff
+# ---------------------------------------------------------------------------
+
+def test_parser_accepts_downstream_flags():
+    """Downstream handoff must be explicit, with --skip-downstream kept for compatibility."""
+    module = _load_skill_module()
+    parser = module.build_parser()
+    args = parser.parse_args(["--output", "out"])
+    assert hasattr(args, "run_downstream")
+    assert hasattr(args, "skip_downstream")
+    assert args.run_downstream is False
+    assert args.skip_downstream is False
+    run_args = parser.parse_args(["--output", "out", "--run-downstream"])
+    assert run_args.run_downstream is True
+    skip_args = parser.parse_args(["--output", "out", "--skip-downstream"])
+    assert skip_args.skip_downstream is True
+
+
+def test_run_downstream_handoff_skipped_when_no_h5ad(tmp_path, capsys):
+    """When parsed_outputs contains no preferred_h5ad, no subprocess must be launched."""
+    module = _load_skill_module()
+    import argparse as _argparse
+    import subprocess as _sp
+    args = _argparse.Namespace(run_downstream=True, skip_downstream=False)
+    launched = []
+    original_run = _sp.run
+    def fake_run(*a, **kw):
+        launched.append(a)
+        return original_run(["true"])
+    with patch("subprocess.run", fake_run):
+        module._run_downstream_handoff(args, parsed_outputs={"preferred_h5ad": ""}, output_dir=tmp_path)
+    assert not launched, "No subprocess should launch when preferred_h5ad is empty"
+
+
+def test_run_downstream_handoff_skipped_by_default(tmp_path):
+    """Downstream handoff must not launch unless --run-downstream is set."""
+    module = _load_skill_module()
+    import argparse as _argparse
+    args = _argparse.Namespace(run_downstream=False, skip_downstream=False)
+    h5ad = tmp_path / "data.h5ad"
+    h5ad.write_text("mock", encoding="utf-8")
+    launched = []
+    with patch("subprocess.run", lambda *a, **kw: launched.append(a)):
+        module._run_downstream_handoff(args, parsed_outputs={"preferred_h5ad": str(h5ad)}, output_dir=tmp_path)
+    assert not launched, "Downstream handoff should be opt-in"
+
+
+def test_run_downstream_handoff_skipped_when_flag_set(tmp_path):
+    """--skip-downstream must prevent handoff even if --run-downstream is set."""
+    module = _load_skill_module()
+    import argparse as _argparse
+    args = _argparse.Namespace(run_downstream=True, skip_downstream=True)
+    h5ad = tmp_path / "data.h5ad"
+    h5ad.write_text("mock", encoding="utf-8")
+    launched = []
+    with patch("subprocess.run", lambda *a, **kw: launched.append(a)):
+        module._run_downstream_handoff(args, parsed_outputs={"preferred_h5ad": str(h5ad)}, output_dir=tmp_path)
+    assert not launched, "--skip-downstream should prevent subprocess launch"
+
+
+def test_run_downstream_handoff_launches_scrna_orchestrator(tmp_path):
+    """When a preferred_h5ad is found, scrna_orchestrator must be invoked."""
+    module = _load_skill_module()
+    import argparse as _argparse
+    args = _argparse.Namespace(run_downstream=True, skip_downstream=False)
+    h5ad = tmp_path / "combined_filtered_matrix.h5ad"
+    h5ad.write_text("mock", encoding="utf-8")
+    fake_orchestrator = tmp_path / "scrna_orchestrator.py"
+    fake_orchestrator.write_text("# stub", encoding="utf-8")
+    captured = {}
+    def fake_run(cmd, **kw):
+        captured["cmd"] = cmd
+        class _R:
+            returncode = 0
+        return _R()
+    with patch("subprocess.run", fake_run), \
+         patch.object(module, "_resolve_scrna_orchestrator", return_value=fake_orchestrator):
+        module._run_downstream_handoff(args, parsed_outputs={"preferred_h5ad": str(h5ad)}, output_dir=tmp_path)
+    assert "cmd" in captured, "subprocess.run must be called when preferred_h5ad is set"
+    cmd = captured["cmd"]
+    assert any("scrna_orchestrator" in str(part) for part in cmd), \
+        f"scrna_orchestrator.py must appear in the command, got: {cmd}"
+
+
+def test_run_downstream_handoff_graceful_on_failure(tmp_path, capsys):
+    """A failure in the downstream handoff must NOT raise — it should warn and continue."""
+    module = _load_skill_module()
+    import argparse as _argparse
+    args = _argparse.Namespace(run_downstream=True, skip_downstream=False)
+    h5ad = tmp_path / "combined_filtered_matrix.h5ad"
+    h5ad.write_text("mock", encoding="utf-8")
+    fake_orchestrator = tmp_path / "scrna_orchestrator.py"
+    fake_orchestrator.write_text("# stub", encoding="utf-8")
+    def fake_run(cmd, **kw):
+        class _R:
+            returncode = 1
+            stderr = "scrna_orchestrator failed"
+        return _R()
+    with patch("subprocess.run", fake_run), \
+         patch.object(module, "_resolve_scrna_orchestrator", return_value=fake_orchestrator):
+        module._run_downstream_handoff(args, parsed_outputs={"preferred_h5ad": str(h5ad)}, output_dir=tmp_path)
+    # Must not raise; a warning should appear on stderr
+    err = capsys.readouterr().err
+    assert "WARNING" in err or "warn" in err.lower() or "downstream" in err.lower()
+
+
+def test_run_downstream_handoff_graceful_on_timeout(tmp_path, capsys):
+    """A downstream timeout must warn and preserve the successful upstream result."""
+    module = _load_skill_module()
+    import argparse as _argparse
+    import subprocess as _sp
+    args = _argparse.Namespace(run_downstream=True, skip_downstream=False)
+    h5ad = tmp_path / "combined_filtered_matrix.h5ad"
+    h5ad.write_text("mock", encoding="utf-8")
+    fake_orchestrator = tmp_path / "scrna_orchestrator.py"
+    fake_orchestrator.write_text("# stub", encoding="utf-8")
+
+    def fake_run(cmd, **kw):
+        raise _sp.TimeoutExpired(cmd=cmd, timeout=kw.get("timeout"))
+
+    with patch("subprocess.run", fake_run), \
+         patch.object(module, "_resolve_scrna_orchestrator", return_value=fake_orchestrator):
+        module._run_downstream_handoff(args, parsed_outputs={"preferred_h5ad": str(h5ad)}, output_dir=tmp_path)
+
+    err = capsys.readouterr().err
+    assert "timed out" in err
+
+
+def test_run_downstream_handoff_warns_when_orchestrator_missing(tmp_path, capsys):
+    """When scrna_orchestrator is not found, a WARNING must be printed to stderr."""
+    module = _load_skill_module()
+    import argparse as _argparse
+    args = _argparse.Namespace(run_downstream=True, skip_downstream=False)
+    h5ad = tmp_path / "combined_filtered_matrix.h5ad"
+    h5ad.write_text("mock", encoding="utf-8")
+    with patch.object(module, "_resolve_scrna_orchestrator", return_value=None):
+        module._run_downstream_handoff(args, parsed_outputs={"preferred_h5ad": str(h5ad)}, output_dir=tmp_path)
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "CLAWBIO_SCRNA_ORCHESTRATOR" in err
+
+
+def test_resolve_scrna_orchestrator_uses_env_var(tmp_path, monkeypatch):
+    """CLAWBIO_SCRNA_ORCHESTRATOR env var must override the default path."""
+    module = _load_skill_module()
+    custom_path = tmp_path / "custom_scrna_orchestrator.py"
+    custom_path.write_text("# stub", encoding="utf-8")
+    monkeypatch.setenv("CLAWBIO_SCRNA_ORCHESTRATOR", str(custom_path))
+    result = module._resolve_scrna_orchestrator()
+    assert result == custom_path
+
+
+def test_resolve_scrna_orchestrator_returns_none_when_env_path_missing(tmp_path, monkeypatch):
+    """CLAWBIO_SCRNA_ORCHESTRATOR pointing to a non-existent file must return None."""
+    module = _load_skill_module()
+    monkeypatch.setenv("CLAWBIO_SCRNA_ORCHESTRATOR", str(tmp_path / "nonexistent.py"))
+    result = module._resolve_scrna_orchestrator()
+    assert result is None

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_nfcore_scrnaseq_wrapper.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_nfcore_scrnaseq_wrapper.py
@@ -105,6 +105,48 @@ def test_parser_simpleaf_umi_resolution_rejects_invalid_value():
         parser.parse_args(["--output", "out", "--simpleaf-umi-resolution", "invalid-strategy"])
 
 
+def test_parser_simpleaf_umi_resolution_accepts_cr_like_em():
+    """cr-like-em is correct per the nf-core/scrnaseq 4.1.0 nextflow_schema.json enum."""
+    module = _load_skill_module()
+    parser = module.build_parser()
+    args = parser.parse_args(["--output", "out", "--simpleaf-umi-resolution", "cr-like-em"])
+    assert args.simpleaf_umi_resolution == "cr-like-em"
+
+
+def test_parser_simpleaf_umi_resolution_rejects_cr_like_emp():
+    """cr-like-emp (with trailing p) is NOT in the upstream schema enum and must be rejected."""
+    module = _load_skill_module()
+    parser = module.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--output", "out", "--simpleaf-umi-resolution", "cr-like-emp"])
+
+
+def test_parser_simpleaf_umi_resolution_rejects_parsimony_emp():
+    """parsimony-emp (with trailing p) is NOT in the upstream schema enum and must be rejected."""
+    module = _load_skill_module()
+    parser = module.build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--output", "out", "--simpleaf-umi-resolution", "parsimony-emp"])
+
+
+def test_parser_accepts_igenomes_base():
+    """--igenomes-base must be accepted and stored as args.igenomes_base."""
+    module = _load_skill_module()
+    parser = module.build_parser()
+    args = parser.parse_args(["--output", "out", "--igenomes-base", "/data/igenomes"])
+    assert args.igenomes_base == "/data/igenomes"
+
+
+def test_parser_wave_and_gpu_profiles_accepted():
+    """wave and gpu are valid nf-core profiles and must be accepted by --profile."""
+    module = _load_skill_module()
+    parser = module.build_parser()
+    args_wave = parser.parse_args(["--output", "out", "--profile", "wave"])
+    assert args_wave.profile == "wave"
+    args_gpu = parser.parse_args(["--output", "out", "--profile", "gpu"])
+    assert args_gpu.profile == "gpu"
+
+
 def test_parser_kb_workflow_rejects_invalid_value():
     """--kb-workflow must reject values not in the nf-core schema enum."""
     module = _load_skill_module()

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_outputs_parser.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_outputs_parser.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from errors import SkillError
+from outputs_parser import build_selection_log, parse_outputs
+
+
+def test_parse_outputs_prefers_cellbender_combined(tmp_path):
+    upstream = tmp_path / "upstream" / "results"
+    (upstream / "pipeline_info").mkdir(parents=True)
+    (upstream / "multiqc" / "simpleaf").mkdir(parents=True)
+    (upstream / "multiqc" / "simpleaf" / "multiqc_report.html").write_text("ok", encoding="utf-8")
+    preferred = upstream / "simpleaf" / "mtx_conversions" / "combined_cellbender_filter_matrix.h5ad"
+    preferred.parent.mkdir(parents=True)
+    preferred.write_text("h5ad", encoding="utf-8")
+    raw = upstream / "simpleaf" / "mtx_conversions" / "combined_raw_matrix.h5ad"
+    raw.write_text("h5ad", encoding="utf-8")
+    result = parse_outputs(tmp_path)
+    assert result["preferred_h5ad"] == str(preferred)
+    assert result["handoff_available"] is True
+    assert result["cellbender_used"] is True
+
+
+def test_parse_outputs_single_sample_fallback(tmp_path):
+    upstream = tmp_path / "upstream" / "results"
+    upstream.mkdir(parents=True)
+    sample = upstream / "star" / "mtx_conversions" / "sampleA_filtered_matrix.h5ad"
+    sample.parent.mkdir(parents=True)
+    sample.write_text("h5ad", encoding="utf-8")
+    result = parse_outputs(tmp_path)
+    assert result["preferred_h5ad"] == str(sample)
+    assert result["handoff_available"] is True
+
+
+def test_parse_outputs_no_canonical_h5ad_when_multiple_samples(tmp_path):
+    upstream = tmp_path / "upstream" / "results"
+    upstream.mkdir(parents=True)
+    for sample_name in ("sampleA", "sampleB"):
+        p = upstream / "star" / "mtx_conversions" / f"{sample_name}_filtered_matrix.h5ad"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("h5ad", encoding="utf-8")
+    result = parse_outputs(tmp_path)
+    assert result["preferred_h5ad"] == ""
+    assert result["handoff_available"] is False
+    assert len(result["h5ad_candidates"]) == 2
+
+
+def test_parse_outputs_raises_when_upstream_dir_missing(tmp_path):
+    with pytest.raises(SkillError) as exc:
+        parse_outputs(tmp_path)
+    assert exc.value.error_code == "EXPECTED_OUTPUTS_NOT_FOUND"
+
+
+def test_parse_outputs_detects_multiqc_and_pipeline_info(tmp_path):
+    upstream = tmp_path / "upstream" / "results"
+    info = upstream / "pipeline_info"
+    info.mkdir(parents=True)
+    mqc = upstream / "multiqc" / "star" / "multiqc_report.html"
+    mqc.parent.mkdir(parents=True)
+    mqc.write_text("report", encoding="utf-8")
+    result = parse_outputs(tmp_path)
+    assert result["multiqc_report"] == str(mqc)
+    assert result["pipeline_info_dir"] == str(info)
+
+
+def test_parse_outputs_exact_name_match_not_suffix(tmp_path):
+    upstream = tmp_path / "upstream" / "results"
+    upstream.mkdir(parents=True)
+    subdir = upstream / "star"
+    subdir.mkdir(parents=True)
+    # Both files: the correct preferred name and a file whose path only suffix-matches but name differs
+    (subdir / "not_combined_filtered_matrix.h5ad").write_text("h5ad", encoding="utf-8")
+    real_preferred = subdir / "combined_filtered_matrix.h5ad"
+    real_preferred.write_text("h5ad", encoding="utf-8")
+    result = parse_outputs(tmp_path)
+    assert result["preferred_h5ad"] == str(real_preferred)
+
+
+def test_parse_outputs_filtered_preferred_over_raw(tmp_path):
+    """combined_filtered_matrix.h5ad must be preferred over combined_raw_matrix.h5ad."""
+    upstream = tmp_path / "upstream" / "results"
+    upstream.mkdir(parents=True)
+    for name in ("combined_filtered_matrix.h5ad", "combined_raw_matrix.h5ad"):
+        (upstream / name).write_text("h5ad", encoding="utf-8")
+    result = parse_outputs(tmp_path)
+    assert Path(result["preferred_h5ad"]).name == "combined_filtered_matrix.h5ad"
+    assert result["handoff_available"] is True
+
+
+
+
+def test_parse_outputs_does_not_choose_between_duplicate_canonical_h5ad(tmp_path):
+    upstream = tmp_path / "upstream" / "results"
+    for aligner in ("star", "simpleaf"):
+        candidate = upstream / aligner / "mtx_conversions" / "combined_filtered_matrix.h5ad"
+        candidate.parent.mkdir(parents=True, exist_ok=True)
+        candidate.write_text("h5ad", encoding="utf-8")
+    result = parse_outputs(tmp_path)
+    assert result["preferred_h5ad"] == ""
+    assert result["handoff_available"] is False
+    assert len(result["h5ad_candidates"]) == 2
+
+
+def test_parse_outputs_sample_names_exclude_h5ad_suffix(tmp_path):
+    upstream = tmp_path / "upstream" / "results"
+    upstream.mkdir(parents=True)
+    # A file that doesn't match any known suffix pattern
+    unknown = upstream / "star" / "mysample.h5ad"
+    unknown.parent.mkdir(parents=True)
+    unknown.write_text("h5ad", encoding="utf-8")
+    result = parse_outputs(tmp_path)
+    # mysample.h5ad → after replacements still "mysample.h5ad" → must be filtered out
+    assert "mysample.h5ad" not in result["samples_detected"]
+    # Only one file, so it becomes the preferred fallback
+    assert result["preferred_h5ad"] == str(unknown)
+
+
+def test_selection_log_describes_selected_file():
+    candidates = ["/out/star/combined_filtered_matrix.h5ad", "/out/star/combined_raw_matrix.h5ad"]
+    log = build_selection_log(candidates, candidates[0])
+    assert "combined_filtered_matrix.h5ad" in log
+    assert "2 candidate(s)" in log
+
+
+def test_selection_log_no_h5ad():
+    assert build_selection_log([], "") == "No h5ad output files found."
+
+
+def test_selection_log_ambiguous():
+    candidates = ["/out/a/combined_filtered_matrix.h5ad", "/out/b/combined_filtered_matrix.h5ad"]
+    log = build_selection_log(candidates, "")
+    assert "ambiguous" in log
+    assert "2 candidate(s)" in log
+
+
+def test_parse_outputs_includes_selection_log(tmp_path):
+    upstream = tmp_path / "upstream" / "results"
+    upstream.mkdir(parents=True)
+    h5ad = upstream / "combined_filtered_matrix.h5ad"
+    h5ad.write_text("h5ad", encoding="utf-8")
+    result = parse_outputs(tmp_path)
+    assert "preferred_h5ad_selection_log" in result
+    assert "combined_filtered_matrix.h5ad" in result["preferred_h5ad_selection_log"]
+
+
+def test_preferred_h5ad_order_contains_no_phantom_entries():
+    """combined_matrix.h5ad is never produced by the pipeline — concat_h5ad.py always
+    writes <id>_<input_type>_matrix.h5ad where input_type is raw/filtered/cellbender_filter."""
+    from schemas import PREFERRED_H5AD_ORDER
+    assert "combined_matrix.h5ad" not in PREFERRED_H5AD_ORDER

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_params_builder.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_params_builder.py
@@ -1,0 +1,416 @@
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+import sys
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from params_builder import build_params_file
+
+
+def _base_args(tmp_path: Path, **overrides) -> Namespace:
+    defaults = dict(
+        demo=False,
+        preset="star",
+        protocol=None,
+        email=None,
+        multiqc_title=None,
+        skip_cellbender=False,
+        skip_fastqc=False,
+        skip_emptydrops=False,
+        skip_multiqc=False,
+        fasta=None,
+        gtf=None,
+        transcript_fasta=None,
+        txp2gene=None,
+        simpleaf_index=None,
+        kallisto_index=None,
+        star_index=None,
+        cellranger_index=None,
+        barcode_whitelist=None,
+        star_feature=None,
+        star_ignore_sjdbgtf=False,
+        seq_center=None,
+        simpleaf_umi_resolution=None,
+        kb_workflow=None,
+        kb_t1c=None,
+        kb_t2c=None,
+        skip_cellranger_renaming=False,
+        motifs=None,
+        cellrangerarc_config=None,
+        cellrangerarc_reference=None,
+        cellranger_vdj_index=None,
+        skip_cellrangermulti_vdjref=False,
+        gex_frna_probe_set=None,
+        gex_target_panel=None,
+        gex_cmo_set=None,
+        fb_reference=None,
+        vdj_inner_enrichment_primers=None,
+        gex_barcode_sample_assignment=None,
+        cellranger_multi_barcodes=None,
+        genome=None,
+        save_reference=False,
+        save_align_intermeds=False,
+    )
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+def test_build_params_file_standard(tmp_path):
+    samplesheet = tmp_path / "reproducibility" / "samplesheet.valid.csv"
+    samplesheet.parent.mkdir()
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, preset="standard", protocol="10XV2", fasta=str(tmp_path / "g.fa"), gtf=str(tmp_path / "g.gtf"))
+    path, payload = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert payload["aligner"] == "simpleaf"
+    # Keep --input schema-safe even when the absolute output path contains whitespace.
+    assert loaded["input"] == "reproducibility/samplesheet.valid.csv"
+    assert loaded["protocol"] == "10XV2"
+
+
+def test_input_path_is_relative_when_output_dir_contains_spaces(tmp_path):
+    output_dir = tmp_path / "output with spaces"
+    samplesheet = output_dir / "reproducibility" / "samplesheet.valid.csv"
+    samplesheet.parent.mkdir(parents=True)
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, preset="star")
+
+    path, _payload = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=output_dir)
+
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["input"] == "reproducibility/samplesheet.valid.csv"
+    assert " " not in loaded["input"]
+
+
+def test_build_params_file_demo_omits_input(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, demo=True, preset="star")
+    path, _payload = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert "input" not in loaded
+
+
+def test_build_params_file_produces_valid_yaml(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    kb_index = tmp_path / "kb_index"
+    kb_index.mkdir()
+    whitelist = tmp_path / "whitelist.txt"
+    whitelist.write_text("ACGT\n", encoding="utf-8")
+    args = _base_args(
+        tmp_path,
+        preset="kallisto",
+        protocol="10XV3",
+        skip_cellbender=True,
+        kallisto_index=str(kb_index),
+        barcode_whitelist=str(whitelist),
+    )
+    path, payload = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    assert path.suffix == ".yaml"
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["aligner"] == "kallisto"
+    assert loaded["skip_cellbender"] is True
+    # reference paths must be absolute POSIX paths (resolved, forward slashes)
+    assert loaded["kallisto_index"] == kb_index.resolve().as_posix()
+    assert loaded["barcode_whitelist"] == whitelist.resolve().as_posix()
+
+
+def test_params_paths_use_forward_slashes(tmp_path):
+    """No backslashes in any path written to params.yaml (cross-platform safety)."""
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    fasta = tmp_path / "genome.fa"
+    gtf = tmp_path / "genes.gtf"
+    fasta.write_text(">c\nACGT\n", encoding="utf-8")
+    gtf.write_text("", encoding="utf-8")
+    args = _base_args(tmp_path, preset="star", fasta=str(fasta), gtf=str(gtf))
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    text = path.read_text(encoding="utf-8")
+    assert "\\" not in text, f"Backslash found in params.yaml:\n{text}"
+
+
+def test_reference_paths_are_resolved_to_absolute(tmp_path):
+    """Relative reference paths must be resolved to absolute before writing to params."""
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    fasta = tmp_path / "genome.fa"
+    fasta.write_text(">c\nACGT\n", encoding="utf-8")
+    args = _base_args(tmp_path, preset="star", fasta=str(fasta))
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert Path(loaded["fasta"]).is_absolute()
+
+
+def test_outdir_uses_forward_slashes(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, demo=True, preset="star")
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert "\\" not in loaded["outdir"]
+    assert "/" in loaded["outdir"]
+
+
+# ── skip flags ────────────────────────────────────────────────────────────────
+
+def test_skip_fastqc_appears_in_params(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, skip_fastqc=True)
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["skip_fastqc"] is True
+
+
+def test_skip_emptydrops_maps_to_canonical_skip_cellbender_param(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, skip_emptydrops=True)
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["skip_cellbender"] is True
+    assert "skip_emptydrops" not in loaded
+
+
+def test_skip_multiqc_appears_in_params(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, skip_multiqc=True)
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["skip_multiqc"] is True
+
+
+def test_skip_flags_absent_when_false(tmp_path):
+    """Skip flags must not pollute params.yaml when not requested."""
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, skip_fastqc=False, skip_emptydrops=False, skip_multiqc=False)
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert "skip_fastqc" not in loaded
+    assert "skip_emptydrops" not in loaded
+    assert "skip_multiqc" not in loaded
+
+
+# ── aligner tuning ────────────────────────────────────────────────────────────
+
+def test_star_feature_appears_in_params(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, preset="star", star_feature="GeneFull")
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["star_feature"] == "GeneFull"
+
+
+def test_simpleaf_umi_resolution_appears_in_params(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, preset="standard", simpleaf_umi_resolution="cr-like-em")
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["simpleaf_umi_resolution"] == "cr-like-em"
+
+
+def test_kb_workflow_appears_in_params(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, preset="kallisto", kb_workflow="lamanno")
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["kb_workflow"] == "lamanno"
+
+
+def test_aligner_tuning_absent_when_none(tmp_path):
+    """Aligner tuning params must not appear in params.yaml when not set."""
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, star_feature=None, simpleaf_umi_resolution=None, kb_workflow=None)
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert "star_feature" not in loaded
+    assert "simpleaf_umi_resolution" not in loaded
+    assert "kb_workflow" not in loaded
+
+
+# ── reference management ──────────────────────────────────────────────────────
+
+def test_genome_shortcut_appears_in_params(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, genome="GRCh38")
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["genome"] == "GRCh38"
+
+
+def test_save_reference_appears_in_params(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, save_reference=True)
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["save_reference"] is True
+
+
+def test_save_align_intermeds_appears_in_params(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, save_align_intermeds=True)
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["save_align_intermeds"] is True
+
+
+def test_save_flags_absent_when_false(tmp_path):
+    """Neither save_reference nor save_align_intermeds must appear in params.yaml when not
+    explicitly requested. Omitting them lets the pipeline's nextflow.config defaults apply
+    (save_align_intermeds defaults to true in the upstream pipeline)."""
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, save_reference=False, save_align_intermeds=False)
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert "save_reference" not in loaded
+    assert "save_align_intermeds" not in loaded
+
+
+# ── input/output metadata ─────────────────────────────────────────────────────
+
+def test_email_appears_in_params(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, email="lab@example.com")
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["email"] == "lab@example.com"
+
+
+def test_multiqc_title_appears_in_params(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, multiqc_title="My Experiment QC")
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["multiqc_title"] == "My Experiment QC"
+
+
+# ── STARsolo additional options ───────────────────────────────────────────────
+
+def test_star_ignore_sjdbgtf_written_as_string(tmp_path):
+    """star_ignore_sjdbgtf schema type is 'string' — must be written as 'true', not boolean True,
+    to pass nf-core JSON schema validation."""
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, preset="star", star_ignore_sjdbgtf=True)
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["star_ignore_sjdbgtf"] == "true"
+    assert not isinstance(loaded["star_ignore_sjdbgtf"], bool)
+
+
+def test_seq_center_appears_in_params(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, seq_center="GenomicsCore")
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["seq_center"] == "GenomicsCore"
+
+
+# ── Kallisto RNA velocity ─────────────────────────────────────────────────────
+
+def test_kb_t1c_appears_in_params(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    t1c = tmp_path / "cdna_t2c.txt"
+    t1c.write_text("transcript\tgene\n", encoding="utf-8")
+    args = _base_args(tmp_path, preset="kallisto", kb_t1c=str(t1c))
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["kb_t1c"] == t1c.resolve().as_posix()
+
+
+def test_kb_t2c_appears_in_params(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    t2c = tmp_path / "intron_t2c.txt"
+    t2c.write_text("transcript\tgene\n", encoding="utf-8")
+    args = _base_args(tmp_path, preset="kallisto", kb_t2c=str(t2c))
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["kb_t2c"] == t2c.resolve().as_posix()
+
+
+# ── CellRanger ────────────────────────────────────────────────────────────────
+
+def test_skip_cellranger_renaming_appears_in_params(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, preset="cellranger", skip_cellranger_renaming=True)
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["skip_cellranger_renaming"] is True
+
+
+# ── CellRanger ARC ────────────────────────────────────────────────────────────
+
+def test_cellrangerarc_params_appear_in_params(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    motifs = tmp_path / "jaspar.motifs"
+    motifs.write_text("", encoding="utf-8")
+    arc_config = tmp_path / "arc.json"
+    arc_config.write_text("{}", encoding="utf-8")
+    args = _base_args(
+        tmp_path,
+        preset="cellrangerarc",
+        motifs=str(motifs),
+        cellrangerarc_config=str(arc_config),
+        cellrangerarc_reference="GRCh38-2024-A",
+    )
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["motifs"] == motifs.resolve().as_posix()
+    assert loaded["cellrangerarc_config"] == arc_config.resolve().as_posix()
+    assert loaded["cellrangerarc_reference"] == "GRCh38-2024-A"
+
+
+# ── CellRanger Multi ──────────────────────────────────────────────────────────
+
+def test_cellranger_multi_path_params_appear_in_params(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    vdj_index = tmp_path / "vdj_idx"
+    vdj_index.mkdir()
+    barcodes = tmp_path / "barcodes.csv"
+    barcodes.write_text("sample,barcode\n", encoding="utf-8")
+    cmo_set = tmp_path / "cmo.csv"
+    cmo_set.write_text("id,sequence\n", encoding="utf-8")
+    args = _base_args(
+        tmp_path,
+        preset="cellrangermulti",
+        cellranger_vdj_index=str(vdj_index),
+        cellranger_multi_barcodes=str(barcodes),
+        gex_cmo_set=str(cmo_set),
+    )
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["cellranger_vdj_index"] == vdj_index.resolve().as_posix()
+    assert loaded["cellranger_multi_barcodes"] == barcodes.resolve().as_posix()
+    assert loaded["gex_cmo_set"] == cmo_set.resolve().as_posix()
+
+
+def test_skip_cellrangermulti_vdjref_appears_in_params(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, preset="cellrangermulti", skip_cellrangermulti_vdjref=True)
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["skip_cellrangermulti_vdjref"] is True

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_params_builder.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_params_builder.py
@@ -167,10 +167,21 @@ def test_skip_fastqc_appears_in_params(tmp_path):
     assert loaded["skip_fastqc"] is True
 
 
-def test_skip_emptydrops_maps_to_canonical_skip_cellbender_param(tmp_path):
+def test_skip_emptydrops_writes_independent_param(tmp_path):
+    """skip_emptydrops is a distinct upstream param, not an alias for skip_cellbender."""
     samplesheet = tmp_path / "samplesheet.valid.csv"
     samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
     args = _base_args(tmp_path, skip_emptydrops=True)
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["skip_emptydrops"] is True
+    assert "skip_cellbender" not in loaded
+
+
+def test_skip_cellbender_appears_in_params(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, skip_cellbender=True)
     path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
     loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
     assert loaded["skip_cellbender"] is True
@@ -190,9 +201,10 @@ def test_skip_flags_absent_when_false(tmp_path):
     """Skip flags must not pollute params.yaml when not requested."""
     samplesheet = tmp_path / "samplesheet.valid.csv"
     samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
-    args = _base_args(tmp_path, skip_fastqc=False, skip_emptydrops=False, skip_multiqc=False)
+    args = _base_args(tmp_path, skip_cellbender=False, skip_fastqc=False, skip_emptydrops=False, skip_multiqc=False)
     path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
     loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert "skip_cellbender" not in loaded
     assert "skip_fastqc" not in loaded
     assert "skip_emptydrops" not in loaded
     assert "skip_multiqc" not in loaded
@@ -414,3 +426,38 @@ def test_skip_cellrangermulti_vdjref_appears_in_params(tmp_path):
     path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
     loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
     assert loaded["skip_cellrangermulti_vdjref"] is True
+
+
+# ── igenomes_ignore suppression ───────────────────────────────────────────────
+
+def test_igenomes_ignore_set_when_fasta_provided(tmp_path):
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    fasta = tmp_path / "genome.fa"
+    fasta.write_text(">c\nACGT\n", encoding="utf-8")
+    args = _base_args(tmp_path, preset="star", fasta=str(fasta))
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded.get("igenomes_ignore") is True
+
+
+def test_igenomes_ignore_set_when_star_index_provided(tmp_path):
+    """igenomes_ignore must be True whenever any explicit reference path is given, not just fasta."""
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    star_idx = tmp_path / "star_idx"
+    star_idx.mkdir()
+    args = _base_args(tmp_path, preset="star", star_index=str(star_idx))
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded.get("igenomes_ignore") is True
+
+
+def test_igenomes_ignore_absent_when_genome_shortcut_used(tmp_path):
+    """When using an iGenomes shortcut, igenomes_ignore must NOT be set."""
+    samplesheet = tmp_path / "samplesheet.valid.csv"
+    samplesheet.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    args = _base_args(tmp_path, preset="star", genome="GRCh38")
+    path, _ = build_params_file(args, normalized_samplesheet=samplesheet, output_dir=tmp_path)
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert "igenomes_ignore" not in loaded

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_pipeline_source.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_pipeline_source.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from errors import SkillError
+from pipeline_source import resolve_pipeline_source
+
+_requires_git = pytest.mark.skipif(shutil.which("git") is None, reason="git not on PATH")
+
+
+def test_resolves_to_remote_when_no_local_dir(tmp_path):
+    absent = tmp_path / "nonexistent_scrnaseq"
+    result = resolve_pipeline_source(
+        requested_version="4.1.0",
+        local_pipeline_dir=absent,
+    )
+    assert result["source_kind"] == "remote_repo"
+    assert result["resolved_version"] == "4.1.0"
+    assert result["source_ref"] == "nf-core/scrnaseq"
+    assert result["dirty"] is False
+
+
+def test_resolves_to_local_when_valid_checkout(tmp_path):
+    local = tmp_path / "scrnaseq"
+    local.mkdir()
+    (local / "main.nf").write_text("// main", encoding="utf-8")
+    (local / "nextflow.config").write_text("// config", encoding="utf-8")
+    assets = local / "assets"
+    assets.mkdir()
+    (assets / "schema_input.json").write_text("{}", encoding="utf-8")
+    result = resolve_pipeline_source(
+        requested_version="4.1.0",
+        local_pipeline_dir=local,
+    )
+    assert result["source_kind"] == "local_checkout"
+    assert result["source_ref"] == str(local.resolve())
+    # The test directory is not a git repo; all _git_stdout calls return "".
+    assert result["resolved_version"] == "4.1.0"
+    assert result["dirty"] is False
+    assert result["branch"] == ""
+
+
+def test_raises_when_local_dir_missing_required_files(tmp_path):
+    local = tmp_path / "scrnaseq"
+    local.mkdir()
+    (local / "main.nf").write_text("// main", encoding="utf-8")
+    with pytest.raises(SkillError) as exc:
+        resolve_pipeline_source(
+            requested_version="4.1.0",
+            local_pipeline_dir=local,
+        )
+    assert exc.value.error_code == "PIPELINE_SOURCE_INVALID"
+    assert "missing_files" in exc.value.details
+
+
+def _make_valid_local_checkout(path: Path) -> None:
+    """Create a minimal valid scrnaseq checkout at *path*."""
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "main.nf").write_text("// main", encoding="utf-8")
+    (path / "nextflow.config").write_text("// config", encoding="utf-8")
+    assets = path / "assets"
+    assets.mkdir()
+    (assets / "schema_input.json").write_text("{}", encoding="utf-8")
+
+
+def test_falls_back_to_remote_when_local_path_has_spaces(tmp_path, capsys):
+    local = tmp_path / "my scrnaseq checkout"
+    _make_valid_local_checkout(local)
+    result = resolve_pipeline_source(
+        requested_version="4.1.0",
+        local_pipeline_dir=local,
+    )
+    assert result["source_kind"] == "remote_repo", (
+        "Expected remote fallback when local path contains spaces"
+    )
+    assert result["resolved_version"] == "4.1.0"
+    captured = capsys.readouterr()
+    assert "whitespace" in captured.err.lower() or "space" in captured.err.lower(), (
+        "Expected a warning about whitespace in the local path"
+    )
+
+
+def test_local_path_without_spaces_uses_local_checkout(tmp_path):
+    local = tmp_path / "scrnaseq_no_spaces"
+    _make_valid_local_checkout(local)
+    result = resolve_pipeline_source(
+        requested_version="4.1.0",
+        local_pipeline_dir=local,
+    )
+    assert result["source_kind"] == "local_checkout"
+    assert result["source_ref"] == str(local.resolve())
+
+
+@_requires_git
+def test_local_checkout_dirty_includes_untracked_files(tmp_path):
+    local = tmp_path / "scrnaseq"
+    local.mkdir()
+    (local / "main.nf").write_text("// main", encoding="utf-8")
+    (local / "nextflow.config").write_text("// config", encoding="utf-8")
+    assets = local / "assets"
+    assets.mkdir()
+    (assets / "schema_input.json").write_text("{}", encoding="utf-8")
+    subprocess.run(["git", "init"], cwd=local, check=True, capture_output=True, text=True)
+    result = resolve_pipeline_source(
+        requested_version="4.1.0",
+        local_pipeline_dir=local,
+    )
+    assert result["dirty"] is True

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_preflight.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_preflight.py
@@ -1,0 +1,934 @@
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import preflight
+from errors import SkillError
+
+_PIPELINE_SOURCE = {
+    "source_kind": "local_checkout",
+    "source_ref": "scrnaseq-checkout",
+    "resolved_version": "abc123",
+    "branch": "main",
+    "dirty": False,
+}
+
+
+def _mock_env(monkeypatch):
+    monkeypatch.setattr(preflight, "_check_java", lambda: {"path": "/usr/bin/java", "version": "17.0.8"})
+    monkeypatch.setattr(preflight, "_check_nextflow", lambda: {"path": "/usr/bin/nextflow", "version": "25.04.0"})
+    monkeypatch.setattr(preflight, "_check_profile", lambda profile: {"profile": profile, "backend_path": "/usr/bin/docker", "backend_ready": True})
+
+
+def _args(tmp_path: Path) -> Namespace:
+    return Namespace(
+        output=str(tmp_path / "out"),
+        resume=False,
+        preset="star",
+        protocol="10XV3",
+        profile="docker",
+        demo=False,
+        email=None,
+        genome=None,
+        fasta=str(tmp_path / "genome.fa"),
+        gtf=str(tmp_path / "genes.gtf"),
+        transcript_fasta=None,
+        txp2gene=None,
+        simpleaf_index=None,
+        kallisto_index=None,
+        star_index=None,
+        cellranger_index=None,
+        barcode_whitelist=None,
+        cellrangerarc_reference=None,
+        cellrangerarc_config=None,
+        motifs=None,
+        kb_t1c=None,
+        kb_t2c=None,
+        cellranger_vdj_index=None,
+        skip_cellrangermulti_vdjref=False,
+        gex_frna_probe_set=None,
+        gex_target_panel=None,
+        gex_cmo_set=None,
+        fb_reference=None,
+        vdj_inner_enrichment_primers=None,
+        gex_barcode_sample_assignment=None,
+        cellranger_multi_barcodes=None,
+    )
+
+
+def test_preflight_happy_path(tmp_path, monkeypatch):
+    args = _args(tmp_path)
+    Path(args.fasta).write_text(">chr1\nACGT\n", encoding="utf-8")
+    Path(args.gtf).write_text("chr1\tsrc\tgene\t1\t4\t.\t+\t.\tgene_id \"g1\";\n", encoding="utf-8")
+    _mock_env(monkeypatch)
+    result = preflight.run_preflight(
+        args,
+        pipeline_source=_PIPELINE_SOURCE,
+        samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+    )
+    assert result["ok"] is True
+
+
+def test_preflight_rejects_missing_reference(tmp_path, monkeypatch):
+    args = _args(tmp_path)
+    _mock_env(monkeypatch)
+    with pytest.raises(SkillError) as exc:
+        preflight.run_preflight(
+            args,
+            pipeline_source=_PIPELINE_SOURCE,
+            samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+        )
+    assert exc.value.error_code == "MISSING_REFERENCE"
+
+
+def test_fasta_path_with_whitespace_fails_before_nextflow_schema(tmp_path, monkeypatch):
+    args = _args(tmp_path)
+    fasta_dir = tmp_path / "refs with spaces"
+    fasta_dir.mkdir()
+    fasta = fasta_dir / "genome.fa"
+    gtf = tmp_path / "genes.gtf"
+    fasta.write_text(">chr1\nACGT\n", encoding="utf-8")
+    gtf.write_text("chr1\tsrc\tgene\t1\t4\t.\t+\t.\tgene_id \"g1\";\n", encoding="utf-8")
+    args.fasta = str(fasta)
+    args.gtf = str(gtf)
+    _mock_env(monkeypatch)
+
+    with pytest.raises(SkillError) as exc:
+        preflight.run_preflight(
+            args,
+            pipeline_source=_PIPELINE_SOURCE,
+            samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+        )
+
+    assert exc.value.error_code == "INVALID_PRESET_CONFIGURATION"
+    assert exc.value.details["field"] == "fasta"
+
+
+def test_preflight_rejects_fasta_extension_not_matching_nfcore_schema(tmp_path, monkeypatch):
+    args = _args(tmp_path)
+    fasta = tmp_path / "genome.txt"
+    gtf = tmp_path / "genes.gtf"
+    fasta.write_text(">chr1\nACGT\n", encoding="utf-8")
+    gtf.write_text("chr1\tsrc\tgene\t1\t4\t.\t+\t.\tgene_id \"g1\";\n", encoding="utf-8")
+    args.fasta = str(fasta)
+    args.gtf = str(gtf)
+    _mock_env(monkeypatch)
+
+    with pytest.raises(SkillError) as exc:
+        preflight.run_preflight(
+            args,
+            pipeline_source=_PIPELINE_SOURCE,
+            samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+        )
+
+    assert exc.value.error_code == "INVALID_PRESET_CONFIGURATION"
+    assert exc.value.details["field"] == "fasta"
+    assert exc.value.details["schema_pattern"] == r"^\S+\.fn?a(sta)?(\.gz)?$"
+
+
+def test_preflight_rejects_email_not_matching_nfcore_schema(tmp_path, monkeypatch):
+    args = _args(tmp_path)
+    args.email = "bad address@example.org"
+    _mock_env(monkeypatch)
+
+    with pytest.raises(SkillError) as exc:
+        preflight.run_preflight(
+            args,
+            pipeline_source=_PIPELINE_SOURCE,
+            samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+        )
+
+    assert exc.value.error_code == "INVALID_PRESET_CONFIGURATION"
+    assert exc.value.details["field"] == "email"
+
+
+def test_standard_preset_requires_explicit_non_auto_protocol(tmp_path, monkeypatch):
+    args = _args(tmp_path)
+    args.preset = "standard"
+    args.protocol = None
+    _mock_env(monkeypatch)
+    with pytest.raises(SkillError) as exc:
+        preflight.run_preflight(
+            args,
+            pipeline_source=_PIPELINE_SOURCE,
+            samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+        )
+    assert exc.value.error_code == "INVALID_PRESET_CONFIGURATION"
+    assert exc.value.details["protocol"] == "auto"
+
+
+def test_standard_simpleaf_rejects_smartseq_protocol(tmp_path, monkeypatch):
+    args = _args(tmp_path)
+    args.preset = "standard"
+    args.protocol = "smartseq"
+    _mock_env(monkeypatch)
+
+    with pytest.raises(SkillError) as exc:
+        preflight.run_preflight(
+            args,
+            pipeline_source=_PIPELINE_SOURCE,
+            samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+        )
+
+    assert exc.value.error_code == "INVALID_PRESET_CONFIGURATION"
+    assert exc.value.details == {"preset": "standard", "protocol": "smartseq"}
+
+
+def test_star_accepts_smartseq_protocol_supported_by_upstream(tmp_path, monkeypatch):
+    args = _args(tmp_path)
+    args.preset = "star"
+    args.protocol = "smartseq"
+    Path(args.fasta).write_text(">chr1\nACGT\n", encoding="utf-8")
+    Path(args.gtf).write_text("chr1\tsrc\tgene\t1\t4\t.\t+\t.\tgene_id \"g1\";\n", encoding="utf-8")
+    _mock_env(monkeypatch)
+
+    result = preflight.run_preflight(
+        args,
+        pipeline_source=_PIPELINE_SOURCE,
+        samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+    )
+
+    assert result["ok"] is True
+
+
+def test_cellrangerarc_accepts_explicit_protocol(tmp_path, monkeypatch):
+    """cellrangerarc must not hard-block non-auto protocols — the pipeline only warns and
+    passes them verbatim to the aligner (Utils.groovy:17-18)."""
+    args = _args(tmp_path)
+    args.preset = "cellrangerarc"
+    args.protocol = "10XV3"
+    args.genome = "GRCh38"
+    args.fasta = None
+    args.gtf = None
+    _mock_env(monkeypatch)
+    result = preflight.run_preflight(
+        args,
+        pipeline_source=_PIPELINE_SOURCE,
+        samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+    )
+    assert result["ok"] is True
+
+
+def test_cellrangerarc_accepts_auto_protocol(tmp_path, monkeypatch):
+    """cellrangerarc must accept protocol=auto — this was the only allowed value before
+    F4 fix and must remain valid after the hard-block was removed."""
+    args = _args(tmp_path)
+    args.preset = "cellrangerarc"
+    args.protocol = "auto"
+    args.genome = "GRCh38"
+    args.fasta = None
+    args.gtf = None
+    _mock_env(monkeypatch)
+    result = preflight.run_preflight(
+        args,
+        pipeline_source=_PIPELINE_SOURCE,
+        samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+    )
+    assert result["ok"] is True
+
+
+def test_cellranger_accepts_known_10x_protocol(tmp_path, monkeypatch):
+    """cellranger passes preflight with a standard 10x protocol."""
+    args = _args(tmp_path)
+    args.preset = "cellranger"
+    args.protocol = "10XV3"
+    args.genome = "GRCh38"
+    args.fasta = None
+    args.gtf = None
+    _mock_env(monkeypatch)
+    result = preflight.run_preflight(
+        args,
+        pipeline_source=_PIPELINE_SOURCE,
+        samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+    )
+    assert result["ok"] is True
+
+
+def test_cellranger_accepts_auto_protocol(tmp_path, monkeypatch):
+    """cellranger must accept protocol=auto — the pipeline auto-detects chemistry.
+    This was previously hard-blocked before F2 fix (Utils.groovy:17-18)."""
+    args = _args(tmp_path)
+    args.preset = "cellranger"
+    args.protocol = "auto"
+    args.genome = "GRCh38"
+    args.fasta = None
+    args.gtf = None
+    _mock_env(monkeypatch)
+    result = preflight.run_preflight(
+        args,
+        pipeline_source=_PIPELINE_SOURCE,
+        samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+    )
+    assert result["ok"] is True
+
+
+def test_cellranger_accepts_custom_protocol_string(tmp_path, monkeypatch):
+    """cellranger must not hard-block unrecognized protocols — the pipeline only warns and
+    passes them verbatim to the aligner (Utils.groovy:17-18)."""
+    args = _args(tmp_path)
+    args.preset = "cellranger"
+    args.protocol = "dropseq"
+    args.genome = "GRCh38"
+    args.fasta = None
+    args.gtf = None
+    _mock_env(monkeypatch)
+    result = preflight.run_preflight(
+        args,
+        pipeline_source=_PIPELINE_SOURCE,
+        samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+    )
+    assert result["ok"] is True
+
+
+
+def test_missing_conda_uses_correct_error_code(monkeypatch):
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    with pytest.raises(SkillError) as exc:
+        preflight._check_profile("conda")
+    assert exc.value.error_code == "MISSING_CONDA"
+
+
+def test_missing_singularity_uses_correct_error_code(monkeypatch):
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    with pytest.raises(SkillError) as exc:
+        preflight._check_profile("singularity")
+    assert exc.value.error_code == "MISSING_SINGULARITY"
+
+
+def test_missing_apptainer_uses_correct_error_code(monkeypatch):
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    with pytest.raises(SkillError) as exc:
+        preflight._check_profile("apptainer")
+    assert exc.value.error_code == "MISSING_SINGULARITY"
+
+
+def test_singularity_profile_falls_back_to_apptainer_binary(monkeypatch):
+    """--profile singularity must accept an apptainer binary (they are compatible)."""
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/apptainer" if name == "apptainer" else None)
+    result = preflight._check_profile("singularity")
+    assert result["backend_ready"] is True
+    assert result["backend_path"] == "/usr/bin/apptainer"
+
+
+def test_apptainer_profile_falls_back_to_singularity_binary(monkeypatch):
+    """--profile apptainer must accept a singularity binary (they are compatible)."""
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/singularity" if name == "singularity" else None)
+    result = preflight._check_profile("apptainer")
+    assert result["backend_ready"] is True
+    assert result["backend_path"] == "/usr/bin/singularity"
+
+
+def test_singularity_error_mentions_both_binaries(monkeypatch):
+    """Error details must list both singularity and apptainer so the user knows what to install."""
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    with pytest.raises(SkillError) as exc:
+        preflight._check_profile("singularity")
+    tried = exc.value.details.get("tried", [])
+    assert "singularity" in tried
+    assert "apptainer" in tried
+
+
+def test_output_dir_not_empty_raises(tmp_path, monkeypatch):
+    out = tmp_path / "out"
+    out.mkdir()
+    (out / "result.json").write_text("{}", encoding="utf-8")
+    args = _args(tmp_path)
+    args.output = str(out)
+    fasta = tmp_path / "genome.fa"
+    gtf = tmp_path / "genes.gtf"
+    fasta.write_text(">chr1\nACGT\n", encoding="utf-8")
+    gtf.write_text("chr1\tsrc\tgene\t1\t4\t.\t+\t.\tgene_id \"g1\";\n", encoding="utf-8")
+    args.fasta = str(fasta)
+    args.gtf = str(gtf)
+    _mock_env(monkeypatch)
+    with pytest.raises(SkillError) as exc:
+        preflight.run_preflight(
+            args,
+            pipeline_source=_PIPELINE_SOURCE,
+            samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+        )
+    assert exc.value.error_code == "OUTPUT_DIR_NOT_EMPTY"
+
+
+def test_parse_version_tuple_handles_java_format():
+    assert preflight._parse_version_tuple('openjdk version "17.0.8" 2023-07-18') == (17, 0, 8)
+
+
+def test_parse_version_tuple_handles_nextflow_format():
+    assert preflight._parse_version_tuple("      N E X T F L O W\n      version 25.04.0 build 5940") == (25, 4, 0)
+
+
+def test_parse_version_tuple_returns_empty_for_no_version():
+    assert preflight._parse_version_tuple("no version here at all") == ()
+
+
+def test_unsupported_profile_raises_invalid_profile(monkeypatch):
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/docker")
+    with pytest.raises(SkillError) as exc:
+        preflight._check_profile("unsupported_backend")
+    assert exc.value.error_code == "INVALID_PROFILE"
+
+
+def test_command_output_returns_empty_on_timeout(monkeypatch):
+    import subprocess as sp
+    def _raise(*a, **kw):
+        raise sp.TimeoutExpired(cmd=["java"], timeout=10)
+    monkeypatch.setattr(sp, "run", _raise)
+    assert preflight._command_output(["java", "-version"]) == ""
+
+
+def test_genome_shortcut_satisfies_reference_requirement(tmp_path, monkeypatch):
+    """--genome (iGenomes shortcut) must satisfy the reference requirement for any preset."""
+    args = _args(tmp_path)
+    args.genome = "GRCh38"
+    args.fasta = None
+    args.gtf = None
+    _mock_env(monkeypatch)
+    result = preflight.run_preflight(
+        args,
+        pipeline_source=_PIPELINE_SOURCE,
+        samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+    )
+    assert result["ok"] is True
+
+
+def test_cellrangerarc_preset_accepted_by_preflight(tmp_path, monkeypatch):
+    """cellrangerarc passes preflight when its reference and ARC-specific files are provided."""
+    args = _args(tmp_path)
+    args.preset = "cellrangerarc"
+    args.protocol = None
+    args.genome = "GRCh38"
+    args.fasta = None
+    args.gtf = None
+    arc_config = tmp_path / "arc_config.json"
+    motifs = tmp_path / "motifs.pfm"
+    arc_config.write_text("{}", encoding="utf-8")
+    motifs.write_text("MOTIF\n", encoding="utf-8")
+    args.cellrangerarc_config = str(arc_config)
+    args.motifs = str(motifs)
+    args.cellrangerarc_reference = "GRCh38-2024-A"
+    _mock_env(monkeypatch)
+    result = preflight.run_preflight(
+        args,
+        pipeline_source=_PIPELINE_SOURCE,
+        samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+    )
+    assert result["ok"] is True
+
+
+def test_cellrangermulti_preset_accepted_by_preflight(tmp_path, monkeypatch):
+    """cellrangermulti must be a recognised preset that passes preflight when reference is provided."""
+    args = _args(tmp_path)
+    args.preset = "cellrangermulti"
+    args.genome = "GRCh38"
+    args.fasta = None
+    args.gtf = None
+    barcodes = tmp_path / "multi_barcodes.csv"
+    barcodes.write_text("sample,barcode\n", encoding="utf-8")
+    args.cellranger_multi_barcodes = str(barcodes)
+    _mock_env(monkeypatch)
+    result = preflight.run_preflight(
+        args,
+        pipeline_source=_PIPELINE_SOURCE,
+        samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+    )
+    assert result["ok"] is True
+
+
+def test_cellrangerarc_reference_alone_does_not_satisfy_requirement(tmp_path, monkeypatch):
+    """cellrangerarc_reference is symbolic metadata, not a reference/index by itself."""
+    args = _args(tmp_path)
+    args.preset = "cellrangerarc"
+    args.protocol = None
+    args.genome = None
+    args.fasta = None
+    args.gtf = None
+    args.cellrangerarc_reference = "GRCh38-2024-A"
+    arc_config = tmp_path / "arc_config.json"
+    motifs = tmp_path / "motifs.pfm"
+    arc_config.write_text("{}", encoding="utf-8")
+    motifs.write_text("MOTIF\n", encoding="utf-8")
+    args.cellrangerarc_config = str(arc_config)
+    args.motifs = str(motifs)
+    _mock_env(monkeypatch)
+    with pytest.raises(SkillError) as exc:
+        preflight.run_preflight(
+            args,
+            pipeline_source=_PIPELINE_SOURCE,
+            samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+        )
+    assert exc.value.error_code == "MISSING_REFERENCE"
+
+
+def test_cellrangerarc_missing_config_fails_preflight(tmp_path, monkeypatch):
+    """ARC-specific files must be validated before launching Nextflow."""
+    args = _args(tmp_path)
+    args.preset = "cellrangerarc"
+    args.protocol = None
+    args.genome = "GRCh38"
+    args.fasta = None
+    args.gtf = None
+    args.cellrangerarc_reference = "GRCh38-2024-A"
+    motifs = tmp_path / "motifs.pfm"
+    motifs.write_text("MOTIF\n", encoding="utf-8")
+    args.motifs = str(motifs)
+    _mock_env(monkeypatch)
+    with pytest.raises(SkillError) as exc:
+        preflight.run_preflight(
+            args,
+            pipeline_source=_PIPELINE_SOURCE,
+            samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+        )
+    assert exc.value.error_code == "INVALID_PRESET_CONFIGURATION"
+    assert exc.value.details["missing_field"] == "cellrangerarc_config"
+
+
+def test_cellrangerarc_missing_reference_name_fails_preflight(tmp_path, monkeypatch):
+    """ARC build mode needs the symbolic reference name used by the ARC config."""
+    args = _args(tmp_path)
+    args.preset = "cellrangerarc"
+    args.protocol = None
+    args.genome = "GRCh38"
+    args.fasta = None
+    args.gtf = None
+    arc_config = tmp_path / "arc_config.json"
+    motifs = tmp_path / "motifs.pfm"
+    arc_config.write_text("{}", encoding="utf-8")
+    motifs.write_text("MOTIF\n", encoding="utf-8")
+    args.cellrangerarc_config = str(arc_config)
+    args.motifs = str(motifs)
+    _mock_env(monkeypatch)
+    with pytest.raises(SkillError) as exc:
+        preflight.run_preflight(
+            args,
+            pipeline_source=_PIPELINE_SOURCE,
+            samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+        )
+    assert exc.value.error_code == "INVALID_PRESET_CONFIGURATION"
+    assert exc.value.details["missing_field"] == "cellrangerarc_reference"
+
+
+def test_cellrangerarc_motifs_are_optional_when_building_reference(tmp_path, monkeypatch):
+    """nf-core/scrnaseq treats motifs as optional for CellRanger ARC mkref."""
+    args = _args(tmp_path)
+    args.preset = "cellrangerarc"
+    args.protocol = None
+    args.genome = "GRCh38"
+    args.fasta = None
+    args.gtf = None
+    args.cellrangerarc_reference = "GRCh38-2024-A"
+    arc_config = tmp_path / "arc_config.json"
+    arc_config.write_text("{}", encoding="utf-8")
+    args.cellrangerarc_config = str(arc_config)
+    # motifs intentionally omitted
+    _mock_env(monkeypatch)
+    result = preflight.run_preflight(
+        args,
+        pipeline_source=_PIPELINE_SOURCE,
+        samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+    )
+    assert result["ok"] is True
+
+
+def test_cellrangerarc_prebuilt_index_skips_build_files(tmp_path, monkeypatch):
+    """A prebuilt ARC/CellRanger index should not require motifs/config build inputs."""
+    args = _args(tmp_path)
+    args.preset = "cellrangerarc"
+    args.protocol = None
+    args.fasta = None
+    args.gtf = None
+    index = tmp_path / "cellranger_arc_index"
+    index.mkdir()
+    args.cellranger_index = str(index)
+    _mock_env(monkeypatch)
+    result = preflight.run_preflight(
+        args,
+        pipeline_source=_PIPELINE_SOURCE,
+        samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+    )
+    assert result["ok"] is True
+
+
+def test_cellrangermulti_without_multiplexed_cmo_barcodes_passes_preflight(tmp_path, monkeypatch):
+    args = _args(tmp_path)
+    args.preset = "cellrangermulti"
+    args.genome = "GRCh38"
+    args.fasta = None
+    args.gtf = None
+    _mock_env(monkeypatch)
+    result = preflight.run_preflight(
+        args,
+        pipeline_source=_PIPELINE_SOURCE,
+        samplesheet_summary={"sample_count": 1, "unknown_columns": [], "feature_types": ["gex", "vdj"]},
+    )
+    assert result["ok"] is True
+
+
+def test_cellrangermulti_cmo_requires_barcodes(tmp_path, monkeypatch):
+    args = _args(tmp_path)
+    args.preset = "cellrangermulti"
+    args.genome = "GRCh38"
+    args.fasta = None
+    args.gtf = None
+    _mock_env(monkeypatch)
+    with pytest.raises(SkillError) as exc:
+        preflight.run_preflight(
+            args,
+            pipeline_source=_PIPELINE_SOURCE,
+            samplesheet_summary={"sample_count": 1, "unknown_columns": [], "feature_types": ["cmo"]},
+        )
+    assert exc.value.error_code == "INVALID_PRESET_CONFIGURATION"
+    assert exc.value.details["missing_field"] == "cellranger_multi_barcodes"
+
+
+def test_cellrangermulti_antibody_capture_requires_feature_barcode_reference(tmp_path, monkeypatch):
+    args = _args(tmp_path)
+    args.preset = "cellrangermulti"
+    args.genome = "GRCh38"
+    args.fasta = None
+    args.gtf = None
+    _mock_env(monkeypatch)
+    with pytest.raises(SkillError) as exc:
+        preflight.run_preflight(
+            args,
+            pipeline_source=_PIPELINE_SOURCE,
+            samplesheet_summary={"sample_count": 1, "unknown_columns": [], "feature_types": ["ab"]},
+        )
+    assert exc.value.error_code == "INVALID_PRESET_CONFIGURATION"
+    assert exc.value.details["missing_field"] == "fb_reference"
+
+
+def test_cellrangermulti_vdj_rows_reject_skip_vdjref_without_prebuilt_index(tmp_path, monkeypatch):
+    args = _args(tmp_path)
+    args.preset = "cellrangermulti"
+    args.genome = "GRCh38"
+    args.fasta = None
+    args.gtf = None
+    args.skip_cellrangermulti_vdjref = True
+    _mock_env(monkeypatch)
+
+    with pytest.raises(SkillError) as exc:
+        preflight.run_preflight(
+            args,
+            pipeline_source=_PIPELINE_SOURCE,
+            samplesheet_summary={"sample_count": 1, "unknown_columns": [], "feature_types": ["gex", "vdj"]},
+        )
+
+    assert exc.value.error_code == "INVALID_PRESET_CONFIGURATION"
+    assert exc.value.details["feature_type"] == "vdj"
+    assert exc.value.details["missing_field"] == "cellranger_vdj_index"
+
+
+def test_cellrangermulti_rejects_cmo_and_ffpe_probe_set_together(tmp_path, monkeypatch):
+    args = _args(tmp_path)
+    args.preset = "cellrangermulti"
+    args.genome = "GRCh38"
+    args.fasta = None
+    args.gtf = None
+    probe_set = tmp_path / "probe_set.csv"
+    barcodes = tmp_path / "multi_barcodes.csv"
+    probe_set.write_text("gene_id\n", encoding="utf-8")
+    barcodes.write_text("sample,barcode\n", encoding="utf-8")
+    args.gex_frna_probe_set = str(probe_set)
+    args.cellranger_multi_barcodes = str(barcodes)
+    _mock_env(monkeypatch)
+
+    with pytest.raises(SkillError) as exc:
+        preflight.run_preflight(
+            args,
+            pipeline_source=_PIPELINE_SOURCE,
+            samplesheet_summary={"sample_count": 1, "unknown_columns": [], "feature_types": ["gex", "cmo"]},
+        )
+
+    assert exc.value.error_code == "INVALID_PRESET_CONFIGURATION"
+    assert exc.value.details["active_modes"] == ["cmo", "ffpe"]
+
+
+def test_cellrangermulti_ffpe_probe_set_requires_barcodes_samplesheet(tmp_path, monkeypatch):
+    args = _args(tmp_path)
+    args.preset = "cellrangermulti"
+    args.genome = "GRCh38"
+    args.fasta = None
+    args.gtf = None
+    probe_set = tmp_path / "probe_set.csv"
+    probe_set.write_text("gene_id\n", encoding="utf-8")
+    args.gex_frna_probe_set = str(probe_set)
+    _mock_env(monkeypatch)
+
+    with pytest.raises(SkillError) as exc:
+        preflight.run_preflight(
+            args,
+            pipeline_source=_PIPELINE_SOURCE,
+            samplesheet_summary={"sample_count": 1, "unknown_columns": [], "feature_types": ["gex"]},
+        )
+
+    assert exc.value.error_code == "INVALID_PRESET_CONFIGURATION"
+    assert exc.value.details["missing_field"] == "cellranger_multi_barcodes"
+    assert exc.value.details["field"] == "gex_frna_probe_set"
+
+
+def test_genome_and_fasta_mutually_exclusive(tmp_path, monkeypatch):
+    """--genome and --fasta together must raise CONFLICTING_REFERENCES before Nextflow runs."""
+    args = _args(tmp_path)
+    args.genome = "GRCh38"
+    fasta = tmp_path / "genome.fa"
+    fasta.write_text(">chr1\nACGT\n", encoding="utf-8")
+    args.fasta = str(fasta)
+    _mock_env(monkeypatch)
+    with pytest.raises(SkillError) as exc:
+        preflight.run_preflight(
+            args,
+            pipeline_source=_PIPELINE_SOURCE,
+            samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+        )
+    assert exc.value.error_code == "CONFLICTING_REFERENCES"
+
+
+def test_docker_info_timeout_raises_docker_not_running(monkeypatch):
+    import shutil
+    import subprocess as sp
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/docker" if name == "docker" else None)
+    def _raise(*a, **kw):
+        raise sp.TimeoutExpired(cmd=["docker"], timeout=30)
+    monkeypatch.setattr(sp, "run", _raise)
+    with pytest.raises(SkillError) as exc:
+        preflight._check_profile("docker")
+    assert exc.value.error_code == "DOCKER_NOT_RUNNING"
+
+
+def test_check_output_dir_available_allows_params_yaml(tmp_path):
+    """reproducibility/params.yaml must not trigger OUTPUT_DIR_NOT_EMPTY."""
+    from preflight import check_output_dir_available
+    repro = tmp_path / "reproducibility"
+    repro.mkdir()
+    (repro / "params.yaml").write_text("aligner: star\n", encoding="utf-8")
+    check_output_dir_available(tmp_path, resume=False)
+
+
+def test_check_output_dir_available_allows_demo_samplesheet(tmp_path):
+    """reproducibility/samplesheet.demo.csv must not trigger OUTPUT_DIR_NOT_EMPTY."""
+    from preflight import check_output_dir_available
+    repro = tmp_path / "reproducibility"
+    repro.mkdir()
+    (repro / "samplesheet.demo.csv").write_text("sample,fastq_1\n", encoding="utf-8")
+    check_output_dir_available(tmp_path, resume=False)
+
+
+# ---------------------------------------------------------------------------
+# _prompt_for_genome
+# ---------------------------------------------------------------------------
+
+def test_common_genomes_is_nonempty_sequence():
+    from schemas import COMMON_GENOMES
+    assert len(COMMON_GENOMES) > 0
+    assert all(isinstance(g, str) and g for g in COMMON_GENOMES)
+
+
+def test_prompt_for_genome_returns_selection_by_number(monkeypatch):
+    """User entering a valid index returns the corresponding genome string."""
+    from preflight import _prompt_for_genome
+    from schemas import COMMON_GENOMES
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "1")
+    result = _prompt_for_genome()
+    assert result == COMMON_GENOMES[0]
+
+
+def test_prompt_for_genome_returns_selection_by_name(monkeypatch):
+    """User entering a genome name directly returns that name."""
+    from preflight import _prompt_for_genome
+    from schemas import COMMON_GENOMES
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    target = COMMON_GENOMES[0]
+    monkeypatch.setattr("builtins.input", lambda _prompt="": target)
+    result = _prompt_for_genome()
+    assert result == target
+
+
+def test_prompt_for_genome_returns_none_in_noninteractive(monkeypatch):
+    """When stdin is not a TTY the prompt returns None rather than blocking."""
+    from preflight import _prompt_for_genome
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    result = _prompt_for_genome()
+    assert result is None
+
+
+def test_prompt_for_genome_returns_none_on_empty_input(monkeypatch):
+    """Pressing Enter (empty input) returns None so the caller can raise MISSING_REFERENCE."""
+    from preflight import _prompt_for_genome
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "")
+    result = _prompt_for_genome()
+    assert result is None
+
+
+def test_prompt_for_genome_returns_none_on_invalid_number(monkeypatch):
+    """An out-of-range number returns None so the caller can raise MISSING_REFERENCE."""
+    from preflight import _prompt_for_genome
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "9999")
+    result = _prompt_for_genome()
+    assert result is None
+
+
+def test_cellrangermulti_accepts_custom_protocol_string(tmp_path, monkeypatch):
+    """cellrangermulti internally uses the cellranger protocol map (Utils.groovy:12).
+    Like cellranger after F2 fix, it must accept any protocol string and delegate
+    validation to the pipeline."""
+    args = _args(tmp_path)
+    args.preset = "cellrangermulti"
+    args.protocol = "dropseq"
+    args.genome = "GRCh38"
+    args.fasta = None
+    args.gtf = None
+    _mock_env(monkeypatch)
+    result = preflight.run_preflight(
+        args,
+        pipeline_source=_PIPELINE_SOURCE,
+        samplesheet_summary={"sample_count": 1, "unknown_columns": []},
+    )
+    assert result["ok"] is True
+
+
+# ── mamba profile ─────────────────────────────────────────────────────────────
+
+def test_mamba_profile_accepted_when_mamba_installed(monkeypatch):
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/mamba" if name == "mamba" else None)
+    result = preflight._check_profile("mamba")
+    assert result["backend_ready"] is True
+    assert result["backend_path"] == "/usr/bin/mamba"
+
+
+def test_mamba_profile_falls_back_to_conda_binary(monkeypatch):
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/conda" if name == "conda" else None)
+    result = preflight._check_profile("mamba")
+    assert result["backend_ready"] is True
+    assert result["backend_path"] == "/usr/bin/conda"
+
+
+def test_missing_mamba_uses_missing_conda_error(monkeypatch):
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    with pytest.raises(SkillError) as exc:
+        preflight._check_profile("mamba")
+    assert exc.value.error_code == "MISSING_CONDA"
+
+
+# ── podman profile ────────────────────────────────────────────────────────────
+
+def test_missing_podman_raises_missing_podman_error(monkeypatch):
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    with pytest.raises(SkillError) as exc:
+        preflight._check_profile("podman")
+    assert exc.value.error_code == "MISSING_PODMAN"
+
+
+def test_podman_not_running_raises_podman_not_running(monkeypatch):
+    import shutil
+    import subprocess as sp
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/podman" if name == "podman" else None)
+    def _raise(*a, **kw):
+        raise sp.TimeoutExpired(cmd=["podman"], timeout=30)
+    monkeypatch.setattr(sp, "run", _raise)
+    with pytest.raises(SkillError) as exc:
+        preflight._check_profile("podman")
+    assert exc.value.error_code == "PODMAN_NOT_RUNNING"
+
+
+def test_podman_profile_accepted_when_running(monkeypatch):
+    import shutil
+    import subprocess as sp
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/podman" if name == "podman" else None)
+    mock_result = sp.CompletedProcess(args=["podman", "info"], returncode=0, stdout="", stderr="")
+    monkeypatch.setattr(sp, "run", lambda *a, **kw: mock_result)
+    result = preflight._check_profile("podman")
+    assert result["backend_ready"] is True
+    assert result["backend_path"] == "/usr/bin/podman"
+
+
+# ── HPC profiles (shifter, charliecloud) ─────────────────────────────────────
+
+def test_missing_shifter_raises_missing_hpc_runtime(monkeypatch):
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    with pytest.raises(SkillError) as exc:
+        preflight._check_profile("shifter")
+    assert exc.value.error_code == "MISSING_HPC_RUNTIME"
+
+
+def test_shifter_profile_accepted_when_installed(monkeypatch):
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/shifter" if name == "shifter" else None)
+    result = preflight._check_profile("shifter")
+    assert result["backend_ready"] is True
+    assert result["backend_path"] == "/usr/bin/shifter"
+
+
+def test_missing_charliecloud_raises_missing_hpc_runtime(monkeypatch):
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    with pytest.raises(SkillError) as exc:
+        preflight._check_profile("charliecloud")
+    assert exc.value.error_code == "MISSING_HPC_RUNTIME"
+
+
+def test_charliecloud_profile_accepted_when_ch_run_installed(monkeypatch):
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/ch-run" if name == "ch-run" else None)
+    result = preflight._check_profile("charliecloud")
+    assert result["backend_ready"] is True
+    assert result["backend_path"] == "/usr/bin/ch-run"
+
+
+# ── macOS + Docker + /tmp warning ─────────────────────────────────────────────
+
+def test_macos_docker_tmp_emits_warning(monkeypatch, capsys):
+    monkeypatch.setattr(preflight.sys, "platform", "darwin")
+    preflight._warn_if_macos_docker_tmp("docker", Path("/tmp/some_run"))
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.err
+    assert "/tmp" in captured.err
+
+
+def test_macos_docker_private_tmp_emits_warning(monkeypatch, capsys):
+    monkeypatch.setattr(preflight.sys, "platform", "darwin")
+    preflight._warn_if_macos_docker_tmp("docker", Path("/private/tmp/some_run"))
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.err
+
+
+def test_macos_docker_home_no_warning(monkeypatch, capsys):
+    monkeypatch.setattr(preflight.sys, "platform", "darwin")
+    preflight._warn_if_macos_docker_tmp("docker", Path("/Users/someone/my_run"))
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+def test_linux_docker_tmp_no_warning(monkeypatch, capsys):
+    monkeypatch.setattr(preflight.sys, "platform", "linux")
+    preflight._warn_if_macos_docker_tmp("docker", Path("/tmp/some_run"))
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
+def test_macos_singularity_tmp_no_warning(monkeypatch, capsys):
+    monkeypatch.setattr(preflight.sys, "platform", "darwin")
+    preflight._warn_if_macos_docker_tmp("singularity", Path("/tmp/some_run"))
+    captured = capsys.readouterr()
+    assert captured.err == ""

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_provenance.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_provenance.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from unittest.mock import patch
+
+from provenance import write_provenance_bundle, write_reproducibility_checksums
+
+
+def test_write_reproducibility_checksums_normalises_types(tmp_path):
+    """All paths in the checksum list must be Path objects before write_checksums is called."""
+    samplesheet = tmp_path / "samplesheet.csv"
+    params = tmp_path / "params.yaml"
+    stdout = tmp_path / "stdout.txt"
+    stderr = tmp_path / "stderr.txt"
+    for f in (samplesheet, params, stdout, stderr):
+        f.write_text("x", encoding="utf-8")
+
+    collected: list = []
+
+    def fake_write_checksums(paths, output_dir, *, anchor):
+        collected.extend(paths)
+        return output_dir / "checksums.sha256"
+
+    with patch("provenance.write_checksums", fake_write_checksums):
+        write_reproducibility_checksums(
+            tmp_path,
+            normalized_samplesheet=samplesheet,
+            params_path=params,
+            preflight_result={"references": {}},
+            parsed_outputs={"h5ad_candidates": [], "multiqc_report": ""},
+            execution_result={
+                "stdout_path": str(stdout),
+                "stderr_path": str(stderr),
+            },
+        )
+
+    assert all(isinstance(p, Path) for p in collected), \
+        f"All checksum paths must be Path objects, got: {[type(p) for p in collected]}"
+
+
+def test_write_provenance_bundle(tmp_path):
+    output_dir = tmp_path
+    params_path = output_dir / "reproducibility" / "params.yaml"
+    params_path.parent.mkdir(parents=True)
+    params_path.write_text("{}", encoding="utf-8")
+    normalized = output_dir / "reproducibility" / "samplesheet.valid.csv"
+    normalized.write_text("sample,fastq_1,fastq_2\n", encoding="utf-8")
+    stdout = output_dir / "logs" / "stdout.txt"
+    stderr = output_dir / "logs" / "stderr.txt"
+    stdout.parent.mkdir(parents=True)
+    stdout.write_text("", encoding="utf-8")
+    stderr.write_text("", encoding="utf-8")
+    preferred = output_dir / "upstream" / "results" / "combined_filtered_matrix.h5ad"
+    preferred.parent.mkdir(parents=True)
+    preferred.write_text("h5ad", encoding="utf-8")
+    args = Namespace(demo=False, check=False, preset="star", profile="docker", pipeline_version="4.1.0", resume=False)
+    provenance_dir, manifest_path = write_provenance_bundle(
+        output_dir,
+        args=args,
+        pipeline_source={"source_kind": "local_checkout", "source_ref": "scrnaseq-checkout", "resolved_version": "abc123", "branch": "main", "dirty": False},
+        preflight_result={"java": {"version": "17.0.8"}, "nextflow": {"version": "25.04.0"}, "references": {}, "profile": {"profile": "docker"}},
+        params_path=params_path,
+        params_payload={"aligner": "star"},
+        normalized_samplesheet=normalized,
+        samplesheet_summary={"sample_count": 1, "fastq_paths": [], "unknown_columns": []},
+        parsed_outputs={"preferred_h5ad": str(preferred), "multiqc_report": "", "pipeline_info_dir": "", "h5ad_candidates": [str(preferred)], "rds_candidates": [], "handoff_available": True},
+        execution_result={"stdout_path": str(stdout), "stderr_path": str(stderr)},
+        command_str="nextflow run ...",
+    )
+    assert (provenance_dir / "runtime.json").exists()
+    assert manifest_path.exists()
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    runtime = json.loads((provenance_dir / "runtime.json").read_text(encoding="utf-8"))
+    assert manifest["preset"] == "star"
+    assert manifest["profile"] == "docker"
+    assert manifest["params_checksum"]
+    assert "pipeline_source" in manifest
+    assert manifest["pipeline_source"]["source_kind"] == "local_checkout"
+    assert manifest["pipeline_source"]["resolved_version"] == "abc123"
+    assert runtime["work_dir"] == str(output_dir / "upstream" / "work")
+    assert manifest["java_version"] == "17.0.8"
+    assert manifest["nextflow_version"] == "25.04.0"
+    assert manifest["python_version"] == runtime["python_version"]
+    assert manifest["environment_yml_mode"] == "install_recipe"
+
+
+def test_build_upstream_payload_uses_schema_constant():
+    from provenance import build_upstream_payload
+    from schemas import DEFAULT_REMOTE_PIPELINE
+    source = {
+        "source_kind": "remote_repo",
+        "source_ref": "nf-core/scrnaseq",
+        "resolved_version": "4.1.0",
+        "branch": "",
+        "dirty": False,
+    }
+    payload = build_upstream_payload(source)
+    assert payload["pipeline"] == DEFAULT_REMOTE_PIPELINE
+
+
+def test_write_reproducibility_environment_uses_minimum_versions(tmp_path):
+    """environment.yml must pin schema minimums, not detected runtime versions."""
+    from provenance import write_reproducibility_environment
+    from schemas import JAVA_MIN_VERSION, NEXTFLOW_MIN_VERSION
+
+    captured: dict = {}
+
+    def fake_write_env(output_dir, *, env_name, pip_deps, conda_deps, python_version):
+        captured["conda_deps"] = conda_deps
+
+    with patch("provenance.write_environment_yml", fake_write_env):
+        write_reproducibility_environment(
+            tmp_path,
+            preflight_result={
+                "java": {"version": "999.0.0"},
+                "nextflow": {"version": "999.9.9"},
+            },
+        )
+
+    expected_java = f"openjdk>={JAVA_MIN_VERSION}"
+    expected_nf = f"nextflow>={'.'.join(map(str, NEXTFLOW_MIN_VERSION))}"
+    assert expected_java in captured["conda_deps"]
+    assert expected_nf in captured["conda_deps"]

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_remap_paths.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_remap_paths.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import csv
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from remap_paths import cmd_remap, cmd_verify, find_samplesheet, remap_csv, verify_paths
+
+_FASTQ_HEADER = "sample,fastq_1,fastq_2,expected_cells,seq_center\n"
+
+
+def _write_samplesheet(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["sample", "fastq_1", "fastq_2", "expected_cells", "seq_center"])
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+# ── find_samplesheet ──────────────────────────────────────────────────────────
+
+def test_find_samplesheet_returns_valid_csv_when_present(tmp_path):
+    ss = tmp_path / "samplesheet.valid.csv"
+    ss.write_text(_FASTQ_HEADER, encoding="utf-8")
+    result = find_samplesheet(bundle_dir=tmp_path)
+    assert result == ss
+
+
+def test_find_samplesheet_returns_demo_csv_when_no_valid(tmp_path):
+    ss = tmp_path / "samplesheet.demo.csv"
+    ss.write_text(_FASTQ_HEADER, encoding="utf-8")
+    result = find_samplesheet(bundle_dir=tmp_path)
+    assert result == ss
+
+
+def test_find_samplesheet_prefers_valid_over_demo(tmp_path):
+    valid = tmp_path / "samplesheet.valid.csv"
+    demo = tmp_path / "samplesheet.demo.csv"
+    valid.write_text(_FASTQ_HEADER, encoding="utf-8")
+    demo.write_text(_FASTQ_HEADER, encoding="utf-8")
+    result = find_samplesheet(bundle_dir=tmp_path)
+    assert result == valid
+
+
+def test_find_samplesheet_returns_none_when_no_csv(tmp_path):
+    assert find_samplesheet(bundle_dir=tmp_path) is None
+
+
+# ── remap_csv ─────────────────────────────────────────────────────────────────
+
+def test_remap_csv_replaces_matching_prefix(tmp_path):
+    ss = tmp_path / "samplesheet.valid.csv"
+    _write_samplesheet(ss, [
+        {"sample": "S1", "fastq_1": "/old/data/S1_R1.fastq.gz",
+         "fastq_2": "/old/data/S1_R2.fastq.gz", "expected_cells": "", "seq_center": ""},
+    ])
+    changes = remap_csv(ss, "/old/data", "/new/data", dry_run=False)
+    assert len(changes) == 2
+    assert changes[0] == ("fastq_1", "/old/data/S1_R1.fastq.gz", "/new/data/S1_R1.fastq.gz")
+    assert changes[1] == ("fastq_2", "/old/data/S1_R2.fastq.gz", "/new/data/S1_R2.fastq.gz")
+    rows = list(csv.DictReader(ss.read_text(encoding="utf-8").splitlines()))
+    assert rows[0]["fastq_1"] == "/new/data/S1_R1.fastq.gz"
+    assert rows[0]["fastq_2"] == "/new/data/S1_R2.fastq.gz"
+
+
+def test_remap_csv_dry_run_does_not_modify_file(tmp_path):
+    ss = tmp_path / "samplesheet.valid.csv"
+    original = "/old/data/S1_R1.fastq.gz,/old/data/S1_R2.fastq.gz"
+    _write_samplesheet(ss, [
+        {"sample": "S1", "fastq_1": "/old/data/S1_R1.fastq.gz",
+         "fastq_2": "/old/data/S1_R2.fastq.gz", "expected_cells": "", "seq_center": ""},
+    ])
+    original_text = ss.read_text(encoding="utf-8")
+    changes = remap_csv(ss, "/old/data", "/new/data", dry_run=True)
+    assert len(changes) == 2
+    assert ss.read_text(encoding="utf-8") == original_text
+    assert not ss.with_suffix(".bak").exists()
+
+
+def test_remap_csv_creates_backup_when_modifying(tmp_path):
+    ss = tmp_path / "samplesheet.valid.csv"
+    _write_samplesheet(ss, [
+        {"sample": "S1", "fastq_1": "/old/S1_R1.fastq.gz",
+         "fastq_2": "/old/S1_R2.fastq.gz", "expected_cells": "", "seq_center": ""},
+    ])
+    remap_csv(ss, "/old", "/new", dry_run=False)
+    assert ss.with_suffix(".bak").exists()
+
+
+def test_remap_csv_returns_empty_when_no_match(tmp_path):
+    ss = tmp_path / "samplesheet.valid.csv"
+    _write_samplesheet(ss, [
+        {"sample": "S1", "fastq_1": "/different/S1_R1.fastq.gz",
+         "fastq_2": "/different/S1_R2.fastq.gz", "expected_cells": "", "seq_center": ""},
+    ])
+    changes = remap_csv(ss, "/old/data", "/new/data", dry_run=False)
+    assert changes == []
+
+
+def test_remap_csv_handles_multiple_samples(tmp_path):
+    ss = tmp_path / "samplesheet.valid.csv"
+    _write_samplesheet(ss, [
+        {"sample": "S1", "fastq_1": "/mnt/S1_R1.fastq.gz",
+         "fastq_2": "/mnt/S1_R2.fastq.gz", "expected_cells": "", "seq_center": ""},
+        {"sample": "S2", "fastq_1": "/mnt/S2_R1.fastq.gz",
+         "fastq_2": "/mnt/S2_R2.fastq.gz", "expected_cells": "", "seq_center": ""},
+    ])
+    changes = remap_csv(ss, "/mnt", "/data", dry_run=False)
+    assert len(changes) == 4
+    rows = list(csv.DictReader(ss.read_text(encoding="utf-8").splitlines()))
+    assert rows[0]["fastq_1"] == "/data/S1_R1.fastq.gz"
+    assert rows[1]["fastq_2"] == "/data/S2_R2.fastq.gz"
+
+
+def test_remap_csv_only_replaces_prefix_not_middle(tmp_path):
+    ss = tmp_path / "samplesheet.valid.csv"
+    _write_samplesheet(ss, [
+        {"sample": "S1", "fastq_1": "/data/old/S1_R1.fastq.gz",
+         "fastq_2": "/data/old/S1_R2.fastq.gz", "expected_cells": "", "seq_center": ""},
+    ])
+    changes = remap_csv(ss, "/old", "/new", dry_run=False)
+    assert changes == [], "Should not replace /old in the middle of the path"
+
+
+# ── verify_paths ──────────────────────────────────────────────────────────────
+
+def test_verify_paths_returns_empty_when_all_exist(tmp_path):
+    r1 = tmp_path / "S1_R1.fastq.gz"
+    r2 = tmp_path / "S1_R2.fastq.gz"
+    r1.write_bytes(b"")
+    r2.write_bytes(b"")
+    ss = tmp_path / "samplesheet.valid.csv"
+    _write_samplesheet(ss, [
+        {"sample": "S1", "fastq_1": str(r1), "fastq_2": str(r2),
+         "expected_cells": "", "seq_center": ""},
+    ])
+    assert verify_paths(ss) == []
+
+
+def test_verify_paths_returns_missing_paths(tmp_path):
+    ss = tmp_path / "samplesheet.valid.csv"
+    _write_samplesheet(ss, [
+        {"sample": "S1", "fastq_1": "/nonexistent/R1.fastq.gz",
+         "fastq_2": "/nonexistent/R2.fastq.gz", "expected_cells": "", "seq_center": ""},
+    ])
+    missing = verify_paths(ss)
+    assert len(missing) == 2
+    assert "/nonexistent/R1.fastq.gz" in missing
+    assert "/nonexistent/R2.fastq.gz" in missing
+
+
+def test_verify_paths_ignores_empty_fastq_columns(tmp_path):
+    ss = tmp_path / "samplesheet.valid.csv"
+    _write_samplesheet(ss, [
+        {"sample": "S1", "fastq_1": "", "fastq_2": "", "expected_cells": "", "seq_center": ""},
+    ])
+    assert verify_paths(ss) == []
+
+
+# ── cmd_remap (integration) ───────────────────────────────────────────────────
+
+def test_cmd_remap_succeeds_when_paths_are_remapped_to_existing_files(tmp_path):
+    r1 = tmp_path / "fastqs" / "S1_R1.fastq.gz"
+    r2 = tmp_path / "fastqs" / "S1_R2.fastq.gz"
+    r1.parent.mkdir()
+    r1.write_bytes(b"")
+    r2.write_bytes(b"")
+    ss = tmp_path / "samplesheet.valid.csv"
+    _write_samplesheet(ss, [
+        {"sample": "S1", "fastq_1": "/old/fastqs/S1_R1.fastq.gz",
+         "fastq_2": "/old/fastqs/S1_R2.fastq.gz", "expected_cells": "", "seq_center": ""},
+    ])
+    rc = cmd_remap("/old/fastqs", str(tmp_path / "fastqs"), dry_run=False, bundle_dir=tmp_path)
+    assert rc == 0
+    rows = list(csv.DictReader(ss.read_text(encoding="utf-8").splitlines()))
+    assert rows[0]["fastq_1"] == str(tmp_path / "fastqs" / "S1_R1.fastq.gz")
+
+
+def test_cmd_remap_returns_nonzero_when_new_paths_missing(tmp_path):
+    ss = tmp_path / "samplesheet.valid.csv"
+    _write_samplesheet(ss, [
+        {"sample": "S1", "fastq_1": "/old/S1_R1.fastq.gz",
+         "fastq_2": "/old/S1_R2.fastq.gz", "expected_cells": "", "seq_center": ""},
+    ])
+    rc = cmd_remap("/old", "/nonexistent", dry_run=False, bundle_dir=tmp_path)
+    assert rc != 0
+
+
+def test_cmd_remap_dry_run_returns_zero_without_verifying(tmp_path):
+    ss = tmp_path / "samplesheet.valid.csv"
+    _write_samplesheet(ss, [
+        {"sample": "S1", "fastq_1": "/old/S1_R1.fastq.gz",
+         "fastq_2": "/old/S1_R2.fastq.gz", "expected_cells": "", "seq_center": ""},
+    ])
+    rc = cmd_remap("/old", "/nonexistent", dry_run=True, bundle_dir=tmp_path)
+    assert rc == 0
+
+
+def test_cmd_remap_returns_zero_when_no_paths_matched(tmp_path):
+    ss = tmp_path / "samplesheet.valid.csv"
+    _write_samplesheet(ss, [
+        {"sample": "S1", "fastq_1": "/other/S1_R1.fastq.gz",
+         "fastq_2": "/other/S1_R2.fastq.gz", "expected_cells": "", "seq_center": ""},
+    ])
+    rc = cmd_remap("/old", "/new", dry_run=False, bundle_dir=tmp_path)
+    assert rc == 0
+
+
+def test_cmd_remap_returns_nonzero_when_no_samplesheet(tmp_path):
+    rc = cmd_remap("/old", "/new", dry_run=False, bundle_dir=tmp_path)
+    assert rc != 0
+
+
+# ── cmd_verify (integration) ──────────────────────────────────────────────────
+
+def test_cmd_verify_returns_zero_when_all_paths_exist(tmp_path):
+    r1 = tmp_path / "S1_R1.fastq.gz"
+    r2 = tmp_path / "S1_R2.fastq.gz"
+    r1.write_bytes(b"")
+    r2.write_bytes(b"")
+    ss = tmp_path / "samplesheet.valid.csv"
+    _write_samplesheet(ss, [
+        {"sample": "S1", "fastq_1": str(r1), "fastq_2": str(r2),
+         "expected_cells": "", "seq_center": ""},
+    ])
+    rc = cmd_verify(bundle_dir=tmp_path)
+    assert rc == 0
+
+
+def test_cmd_verify_returns_nonzero_when_paths_missing(tmp_path):
+    ss = tmp_path / "samplesheet.valid.csv"
+    _write_samplesheet(ss, [
+        {"sample": "S1", "fastq_1": "/nonexistent/R1.fastq.gz",
+         "fastq_2": "/nonexistent/R2.fastq.gz", "expected_cells": "", "seq_center": ""},
+    ])
+    rc = cmd_verify(bundle_dir=tmp_path)
+    assert rc != 0
+
+
+def test_cmd_verify_returns_nonzero_when_no_samplesheet(tmp_path):
+    rc = cmd_verify(bundle_dir=tmp_path)
+    assert rc != 0
+
+
+# ── find_commands_sh ──────────────────────────────────────────────────────────
+
+def test_find_commands_sh_returns_path_when_exists(tmp_path):
+    from remap_paths import find_commands_sh
+    cs = tmp_path / "commands.sh"
+    cs.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    assert find_commands_sh(bundle_dir=tmp_path) == cs
+
+
+def test_find_commands_sh_returns_none_when_absent(tmp_path):
+    from remap_paths import find_commands_sh
+    assert find_commands_sh(bundle_dir=tmp_path) is None
+
+
+# ── update_commands_output ────────────────────────────────────────────────────
+
+def test_update_commands_output_replaces_output_flag(tmp_path):
+    from remap_paths import update_commands_output
+    cs = tmp_path / "commands.sh"
+    cs.write_text(
+        'python "$SKILL_SCRIPT" \\\n    --output /old/output/dir \\\n    --preset star\n',
+        encoding="utf-8",
+    )
+    update_commands_output(cs, "/new/output/dir")
+    content = cs.read_text(encoding="utf-8")
+    assert "/new/output/dir" in content
+    assert "/old/output/dir" not in content
+
+
+def test_update_commands_output_creates_backup(tmp_path):
+    from remap_paths import update_commands_output
+    cs = tmp_path / "commands.sh"
+    cs.write_text('    --output /old/path \\\n', encoding="utf-8")
+    update_commands_output(cs, "/new/path")
+    assert cs.with_suffix(".sh.bak").exists()
+
+
+def test_update_commands_output_noop_when_no_output_flag(tmp_path):
+    from remap_paths import update_commands_output
+    cs = tmp_path / "commands.sh"
+    original = '#!/usr/bin/env bash\necho hello\n'
+    cs.write_text(original, encoding="utf-8")
+    update_commands_output(cs, "/new/path")
+    assert cs.read_text(encoding="utf-8") == original
+    assert not cs.with_suffix(".sh.bak").exists()
+
+
+# ── CLAWBIO_REPO fallback in commands.sh ─────────────────────────────────────
+
+def test_generated_commands_sh_contains_clawbio_repo_fallback(tmp_path):
+    import argparse
+    import sys as _sys
+    _sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from reporting import write_repro_commands
+    args = argparse.Namespace(
+        input=str(tmp_path / "samplesheet.csv"),
+        output=str(tmp_path / "out"), preset="star", profile="docker",
+        pipeline_version="4.1.0", protocol=None, demo=False, check=False,
+        resume=False, skip_cellbender=False, skip_fastqc=False,
+        skip_emptydrops=False, skip_multiqc=False, star_feature=None,
+        star_ignore_sjdbgtf=False, seq_center=None, simpleaf_umi_resolution=None,
+        kb_workflow=None, kb_t1c=None, kb_t2c=None, fasta=None, gtf=None,
+        transcript_fasta=None, txp2gene=None, simpleaf_index=None,
+        kallisto_index=None, star_index=None, cellranger_index=None,
+        barcode_whitelist=None, expected_cells=None, genome=None,
+        save_reference=False, save_align_intermeds=False,
+        skip_cellranger_renaming=False, motifs=None, cellrangerarc_config=None,
+        cellrangerarc_reference=None, cellranger_vdj_index=None,
+        skip_cellrangermulti_vdjref=False, gex_frna_probe_set=None,
+        gex_target_panel=None, gex_cmo_set=None, fb_reference=None,
+        vdj_inner_enrichment_primers=None, gex_barcode_sample_assignment=None,
+        cellranger_multi_barcodes=None, run_downstream=False,
+        email=None, multiqc_title=None,
+    )
+    write_repro_commands(tmp_path, args=args)
+    content = (tmp_path / "reproducibility" / "commands.sh").read_text(encoding="utf-8")
+    assert "CLAWBIO_REPO" in content

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_reporting.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_reporting.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from reporting import write_check_result, write_report, write_repro_commands, write_result
+
+
+def _make_args(tmp_path: Path, **kwargs) -> argparse.Namespace:
+    defaults = dict(
+        input=str(tmp_path / "samplesheet.csv"),
+        output=str(tmp_path / "out"),
+        preset="star",
+        profile="docker",
+        pipeline_version="3.14.0",
+        protocol=None,
+        skip_cellbender=False,
+        skip_fastqc=False,
+        skip_emptydrops=False,
+        skip_multiqc=False,
+        resume=False,
+        demo=False,
+        check=False,
+        fasta=None,
+        gtf=None,
+        transcript_fasta=None,
+        txp2gene=None,
+        simpleaf_index=None,
+        kallisto_index=None,
+        star_index=None,
+        cellranger_index=None,
+        barcode_whitelist=None,
+        expected_cells=None,
+        star_feature=None,
+        star_ignore_sjdbgtf=False,
+        seq_center=None,
+        simpleaf_umi_resolution=None,
+        kb_workflow=None,
+        kb_t1c=None,
+        kb_t2c=None,
+        skip_cellranger_renaming=False,
+        motifs=None,
+        cellrangerarc_config=None,
+        cellrangerarc_reference=None,
+        cellranger_vdj_index=None,
+        skip_cellrangermulti_vdjref=False,
+        gex_frna_probe_set=None,
+        gex_target_panel=None,
+        gex_cmo_set=None,
+        fb_reference=None,
+        vdj_inner_enrichment_primers=None,
+        gex_barcode_sample_assignment=None,
+        cellranger_multi_barcodes=None,
+        genome=None,
+        save_reference=False,
+        save_align_intermeds=False,
+        run_downstream=False,
+        email=None,
+        multiqc_title=None,
+    )
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def _pipeline_source() -> dict:
+    return {
+        "source_kind": "remote_repo",
+        "source_ref": "nf-core/scrnaseq",
+        "resolved_version": "3.14.0",
+        "branch": "",
+        "dirty": False,
+    }
+
+
+def _preflight_result() -> dict:
+    return {
+        "ok": True,
+        "java": {"version": "21.0.0", "path": "/usr/bin/java"},
+        "nextflow": {"version": "25.4.0", "path": "/usr/bin/nextflow"},
+        "profile": {"profile": "docker", "backend_path": "/usr/bin/docker", "backend_ready": True},
+        "pipeline_source": _pipeline_source(),
+        "references": {},
+        "samplesheet": {"sample_count": 2, "unknown_columns": []},
+    }
+
+
+def _parsed_outputs(preferred_h5ad: str = "") -> dict:
+    return {
+        "preferred_h5ad": preferred_h5ad,
+        "multiqc_report": "",
+        "pipeline_info_dir": "",
+        "aligner_effective": "star",
+        "cellbender_used": False,
+        "handoff_available": bool(preferred_h5ad),
+        "samples_detected": ["sampleA", "sampleB"],
+        "h5ad_candidates": [],
+        "rds_candidates": [],
+    }
+
+
+# ── write_report ──────────────────────────────────────────────────────────────
+
+def test_write_report_creates_report_md(tmp_path):
+    args = _make_args(tmp_path)
+    report_path = write_report(
+        tmp_path,
+        args=args,
+        pipeline_source=_pipeline_source(),
+        preflight_result=_preflight_result(),
+        parsed_outputs=_parsed_outputs(),
+        command_str="nextflow run nf-core/scrnaseq",
+    )
+    assert report_path == tmp_path / "report.md"
+    assert report_path.exists()
+
+
+def test_write_report_contains_preset_and_profile(tmp_path):
+    args = _make_args(tmp_path, preset="cellranger", profile="singularity")
+    write_report(
+        tmp_path,
+        args=args,
+        pipeline_source=_pipeline_source(),
+        preflight_result=_preflight_result(),
+        parsed_outputs=_parsed_outputs(),
+        command_str="nextflow run nf-core/scrnaseq",
+    )
+    content = (tmp_path / "report.md").read_text(encoding="utf-8")
+    assert "cellranger" in content
+    assert "singularity" in content
+
+
+def test_write_report_handoff_with_preferred_h5ad(tmp_path):
+    preferred = "/output/outs/cellbender.h5ad"
+    write_report(
+        tmp_path,
+        args=_make_args(tmp_path),
+        pipeline_source=_pipeline_source(),
+        preflight_result=_preflight_result(),
+        parsed_outputs=_parsed_outputs(preferred_h5ad=preferred),
+        command_str="nextflow run nf-core/scrnaseq",
+    )
+    content = (tmp_path / "report.md").read_text(encoding="utf-8")
+    assert preferred in content
+    assert "scrna" in content
+
+
+def test_write_report_handoff_without_preferred_h5ad(tmp_path):
+    write_report(
+        tmp_path,
+        args=_make_args(tmp_path),
+        pipeline_source=_pipeline_source(),
+        preflight_result=_preflight_result(),
+        parsed_outputs=_parsed_outputs(preferred_h5ad=""),
+        command_str="nextflow run nf-core/scrnaseq",
+    )
+    content = (tmp_path / "report.md").read_text(encoding="utf-8")
+    assert "not available" in content or "No canonical" in content
+
+
+# ── write_repro_commands ──────────────────────────────────────────────────────
+
+def test_write_repro_commands_creates_commands_sh(tmp_path):
+    args = _make_args(tmp_path)
+    write_repro_commands(tmp_path, args=args)
+    assert (tmp_path / "reproducibility" / "commands.sh").exists()
+
+
+def test_write_repro_commands_contains_output_path(tmp_path):
+    args = _make_args(tmp_path, output=str(tmp_path))
+    write_repro_commands(tmp_path, args=args)
+    content = (tmp_path / "reproducibility" / "commands.sh").read_text(encoding="utf-8")
+    # write_repro_commands uses the first (already-resolved) output_dir, not args.output
+    assert tmp_path.as_posix() in content
+
+
+def test_write_repro_commands_paths_have_no_backslashes(tmp_path):
+    args = _make_args(tmp_path)
+    write_repro_commands(tmp_path, args=args)
+    content = (tmp_path / "reproducibility" / "commands.sh").read_text(encoding="utf-8")
+    # Exclude comment lines from the backslash check
+    non_comment_lines = [l for l in content.splitlines() if not l.strip().startswith("#")]
+    for line in non_comment_lines:
+        assert "\\" not in line.replace(" \\", ""), f"Backslash in arg value: {line!r}"
+
+
+def test_write_repro_commands_demo_omits_input(tmp_path):
+    args = _make_args(tmp_path, demo=True)
+    write_repro_commands(tmp_path, args=args)
+    content = (tmp_path / "reproducibility" / "commands.sh").read_text(encoding="utf-8")
+    assert "--demo" in content
+    assert "--input" not in content
+
+
+def test_write_repro_commands_includes_expected_cells_when_set(tmp_path):
+    """--expected-cells must appear in the repro script so replays are identical."""
+    args = _make_args(tmp_path, expected_cells=5000)
+    write_repro_commands(tmp_path, args=args)
+    content = (tmp_path / "reproducibility" / "commands.sh").read_text(encoding="utf-8")
+    assert "--expected-cells" in content
+    assert "5000" in content
+
+
+def test_write_repro_commands_omits_expected_cells_when_none(tmp_path):
+    args = _make_args(tmp_path, expected_cells=None)
+    write_repro_commands(tmp_path, args=args)
+    content = (tmp_path / "reproducibility" / "commands.sh").read_text(encoding="utf-8")
+    assert "--expected-cells" not in content
+
+
+def test_write_repro_commands_uses_canonical_skip_flags_when_set(tmp_path):
+    """Deprecated --skip-emptydrops replays as the canonical --skip-cellbender flag."""
+    args = _make_args(tmp_path, skip_fastqc=True, skip_emptydrops=True, skip_multiqc=True)
+    write_repro_commands(tmp_path, args=args)
+    content = (tmp_path / "reproducibility" / "commands.sh").read_text(encoding="utf-8")
+    assert "--skip-fastqc" in content
+    assert "--skip-cellbender" in content
+    assert "--skip-emptydrops" not in content
+    assert "--skip-multiqc" in content
+
+
+def test_write_repro_commands_omits_skip_flags_when_not_set(tmp_path):
+    args = _make_args(tmp_path, skip_fastqc=False, skip_emptydrops=False, skip_multiqc=False)
+    write_repro_commands(tmp_path, args=args)
+    content = (tmp_path / "reproducibility" / "commands.sh").read_text(encoding="utf-8")
+    assert "--skip-fastqc" not in content
+    assert "--skip-emptydrops" not in content
+    assert "--skip-multiqc" not in content
+
+
+def test_write_repro_commands_includes_aligner_tuning_when_set(tmp_path):
+    """Aligner-specific tuning flags must appear in the repro script for exact replay."""
+    args = _make_args(tmp_path, star_feature="GeneFull", simpleaf_umi_resolution="cr-like-em", kb_workflow="lamanno")
+    write_repro_commands(tmp_path, args=args)
+    content = (tmp_path / "reproducibility" / "commands.sh").read_text(encoding="utf-8")
+    assert "--star-feature" in content
+    assert "GeneFull" in content
+    assert "--simpleaf-umi-resolution" in content
+    assert "cr-like-em" in content
+    assert "--kb-workflow" in content
+    assert "lamanno" in content
+
+
+def test_write_repro_commands_includes_genome_when_set(tmp_path):
+    args = _make_args(tmp_path, genome="GRCh38")
+    write_repro_commands(tmp_path, args=args)
+    content = (tmp_path / "reproducibility" / "commands.sh").read_text(encoding="utf-8")
+    assert "--genome" in content
+    assert "GRCh38" in content
+
+
+def test_write_repro_commands_includes_save_flags_when_set(tmp_path):
+    args = _make_args(tmp_path, save_reference=True, save_align_intermeds=True)
+    write_repro_commands(tmp_path, args=args)
+    content = (tmp_path / "reproducibility" / "commands.sh").read_text(encoding="utf-8")
+    assert "--save-reference" in content
+    assert "--save-align-intermeds" in content
+
+
+def test_write_repro_commands_includes_downstream_opt_in_when_set(tmp_path):
+    args = _make_args(tmp_path, run_downstream=True)
+    write_repro_commands(tmp_path, args=args)
+    content = (tmp_path / "reproducibility" / "commands.sh").read_text(encoding="utf-8")
+    assert "--run-downstream" in content
+
+
+def test_write_repro_commands_includes_starsolo_extras(tmp_path):
+    args = _make_args(tmp_path, star_ignore_sjdbgtf=True, seq_center="CoreLab")
+    write_repro_commands(tmp_path, args=args)
+    content = (tmp_path / "reproducibility" / "commands.sh").read_text(encoding="utf-8")
+    assert "--star-ignore-sjdbgtf" in content
+    assert "--seq-center" in content
+    assert "CoreLab" in content
+
+
+def test_write_repro_commands_includes_cellrangerarc_reference(tmp_path):
+    args = _make_args(tmp_path, cellrangerarc_reference="GRCh38-2024-A")
+    write_repro_commands(tmp_path, args=args)
+    content = (tmp_path / "reproducibility" / "commands.sh").read_text(encoding="utf-8")
+    assert "--cellrangerarc-reference" in content
+    assert "GRCh38-2024-A" in content
+
+
+def test_write_repro_commands_includes_skip_cellranger_renaming(tmp_path):
+    args = _make_args(tmp_path, skip_cellranger_renaming=True)
+    write_repro_commands(tmp_path, args=args)
+    content = (tmp_path / "reproducibility" / "commands.sh").read_text(encoding="utf-8")
+    assert "--skip-cellranger-renaming" in content
+
+
+def test_write_repro_commands_includes_skip_cellrangermulti_vdjref(tmp_path):
+    args = _make_args(tmp_path, skip_cellrangermulti_vdjref=True)
+    write_repro_commands(tmp_path, args=args)
+    content = (tmp_path / "reproducibility" / "commands.sh").read_text(encoding="utf-8")
+    assert "--skip-cellrangermulti-vdjref" in content
+
+
+def test_write_repro_commands_includes_email_and_multiqc_title(tmp_path):
+    args = _make_args(tmp_path, email="lab@example.com", multiqc_title="My QC")
+    write_repro_commands(tmp_path, args=args)
+    content = (tmp_path / "reproducibility" / "commands.sh").read_text(encoding="utf-8")
+    assert "--email" in content
+    assert "lab@example.com" in content
+    assert "--multiqc-title" in content
+    assert "My QC" in content
+
+
+# ── write_result ──────────────────────────────────────────────────────────────
+
+def test_write_result_creates_result_json(tmp_path):
+    args = _make_args(tmp_path)
+    preferred = tmp_path / "preferred.h5ad"
+    result_path = write_result(
+        tmp_path,
+        args=args,
+        pipeline_source=_pipeline_source(),
+        parsed_outputs=_parsed_outputs(preferred_h5ad=str(preferred)),
+        command_str="nextflow run nf-core/scrnaseq",
+    )
+    assert result_path.exists()
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    assert "summary" in payload
+    assert payload["summary"]["preset"] == "star"
+    assert payload["summary"]["profile"] == "docker"
+    assert payload["summary"]["output_artifacts"]["preferred_h5ad"] == str(preferred)
+    assert payload["data"]["output_artifacts"] == payload["summary"]["output_artifacts"]
+
+
+# ── write_check_result ────────────────────────────────────────────────────────
+
+def test_write_check_result_creates_check_result_json(tmp_path):
+    payload = {"ok": True, "skill": "nfcore-scrnaseq-pipeline", "preflight": {}}
+    path = write_check_result(tmp_path, payload)
+    assert path == tmp_path / "check_result.json"
+    assert path.exists()
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    assert loaded["ok"] is True
+
+
+def test_check_result_json_not_counted_as_materialized_entry(tmp_path):
+    """check_result.json must not block a subsequent full run (_check_output_dir ignores it)."""
+    import sys
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from preflight import _check_output_dir
+    (tmp_path / "check_result.json").write_text('{"ok": true}', encoding="utf-8")
+    _check_output_dir(tmp_path, resume=False)
+
+
+def test_check_output_dir_rejects_existing_file(tmp_path):
+    from preflight import _check_output_dir
+
+    output_file = tmp_path / "not_a_directory"
+    output_file.write_text("x", encoding="utf-8")
+    with pytest.raises(Exception) as exc:
+        _check_output_dir(output_file, resume=False)
+    assert getattr(exc.value, "error_code", "") == "OUTPUT_DIR_NOT_WRITABLE"
+
+
+def test_write_repro_commands_creates_remap_script(tmp_path):
+    args = _make_args(tmp_path)
+    write_repro_commands(tmp_path, args=args)
+    assert (tmp_path / "reproducibility" / "remap_paths.py").exists()
+
+
+def test_remap_script_is_executable_python(tmp_path):
+    args = _make_args(tmp_path)
+    write_repro_commands(tmp_path, args=args)
+    content = (tmp_path / "reproducibility" / "remap_paths.py").read_text(encoding="utf-8")
+    assert "#!/usr/bin/env python3" in content
+    assert "remap_csv" in content
+    assert "verify_paths" in content
+
+
+def test_write_repro_commands_portability_notice_in_commands_sh(tmp_path):
+    args = _make_args(tmp_path, demo=False)
+    write_repro_commands(tmp_path, args=args)
+    content = (tmp_path / "reproducibility" / "commands.sh").read_text(encoding="utf-8")
+    assert "remap_paths.py" in content
+    assert "portab" in content.lower() or "absolute" in content.lower() or "FASTQ" in content
+
+
+def test_write_repro_commands_demo_skips_portability_notice(tmp_path):
+    args = _make_args(tmp_path, demo=True)
+    write_repro_commands(tmp_path, args=args)
+    content = (tmp_path / "reproducibility" / "commands.sh").read_text(encoding="utf-8")
+    assert "remap_paths.py" not in content
+
+
+def test_handoff_lines_use_absolute_clawbio_path():
+    import sys as _sys
+    _sys.path.insert(0, str(__import__("pathlib").Path(__file__).resolve().parent.parent))
+    from reporting import _build_handoff_lines
+    from schemas import SKILL_DIR
+    expected_script = (SKILL_DIR.parent.parent / "clawbio.py").as_posix()
+    lines = _build_handoff_lines("/data/combined_filtered_matrix.h5ad")
+    handoff_line = next((l for l in lines if "clawbio.py" in l), None)
+    assert handoff_line is not None, "No handoff line found"
+    assert expected_script in handoff_line, \
+        f"Expected absolute path {expected_script!r} in line: {handoff_line!r}"

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_resume_policy.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_resume_policy.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import json
+from argparse import Namespace
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import preflight
+from errors import SkillError
+
+
+_LOCAL_SOURCE = {"source_kind": "local_checkout", "source_ref": "scrnaseq-checkout", "resolved_version": "abc123", "branch": "main", "dirty": False}
+_SS = {"sample_count": 1, "unknown_columns": []}
+
+
+def test_resume_requires_manifest(tmp_path, monkeypatch):
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+    fasta = tmp_path / "genome.fa"
+    gtf = tmp_path / "genes.gtf"
+    fasta.write_text(">chr1\nACGT\n", encoding="utf-8")
+    gtf.write_text("chr1\tsrc\tgene\t1\t4\t.\t+\t.\tgene_id \"g1\";\n", encoding="utf-8")
+    _mock_preflight_infra(monkeypatch)
+    with pytest.raises(SkillError) as exc:
+        preflight.run_preflight(
+            _make_resume_args(output_dir, fasta, gtf),
+            pipeline_source=_LOCAL_SOURCE,
+            samplesheet_summary=_SS,
+        )
+    assert exc.value.error_code == "INVALID_RESUME_STATE"
+
+
+def _make_resume_args(output_dir, fasta, gtf, *, preset="star", profile="docker"):
+    return Namespace(
+        output=str(output_dir),
+        resume=True,
+        preset=preset,
+        protocol="10XV3",
+        profile=profile,
+        demo=False,
+        fasta=str(fasta),
+        gtf=str(gtf),
+        transcript_fasta=None,
+        txp2gene=None,
+        simpleaf_index=None,
+        kallisto_index=None,
+        star_index=None,
+        cellranger_index=None,
+        barcode_whitelist=None,
+        genome=None,
+        cellrangerarc_reference=None,
+        kb_t1c=None, kb_t2c=None,
+        motifs=None, cellrangerarc_config=None,
+        cellranger_vdj_index=None,
+        gex_frna_probe_set=None, gex_target_panel=None,
+        gex_cmo_set=None, fb_reference=None,
+        vdj_inner_enrichment_primers=None,
+        gex_barcode_sample_assignment=None,
+        cellranger_multi_barcodes=None,
+    )
+
+
+def _mock_preflight_infra(monkeypatch):
+    monkeypatch.setattr(preflight, "_check_java", lambda: {"path": "/usr/bin/java", "version": "17.0.8"})
+    monkeypatch.setattr(preflight, "_check_nextflow", lambda: {"path": "/usr/bin/nextflow", "version": "25.04.0"})
+    monkeypatch.setattr(preflight, "_check_profile", lambda profile: {"profile": profile, "backend_path": "/usr/bin/docker", "backend_ready": True})
+
+
+def _write_manifest(output_dir, *, preset="star", profile="docker", source_kind="local_checkout", version="abc123"):
+    (output_dir / "reproducibility").mkdir(parents=True, exist_ok=True)
+    (output_dir / "reproducibility" / "manifest.json").write_text(
+        json.dumps({"preset": preset, "profile": profile, "pipeline_source": {"source_kind": source_kind, "resolved_version": version}}),
+        encoding="utf-8",
+    )
+
+
+def test_resume_allows_manifest(tmp_path, monkeypatch):
+    output_dir = tmp_path / "out"
+    _write_manifest(output_dir)
+    fasta = tmp_path / "genome.fa"
+    gtf = tmp_path / "genes.gtf"
+    fasta.write_text(">chr1\nACGT\n", encoding="utf-8")
+    gtf.write_text("chr1\tsrc\tgene\t1\t4\t.\t+\t.\tgene_id \"g1\";\n", encoding="utf-8")
+    _mock_preflight_infra(monkeypatch)
+    result = preflight.run_preflight(
+        _make_resume_args(output_dir, fasta, gtf),
+        pipeline_source=_LOCAL_SOURCE,
+        samplesheet_summary=_SS,
+    )
+    assert result["ok"] is True
+
+
+def test_resume_preset_mismatch_raises(tmp_path, monkeypatch):
+    """Resume with a different preset must raise INVALID_RESUME_STATE."""
+    output_dir = tmp_path / "out"
+    _write_manifest(output_dir, preset="kallisto")  # previous run used kallisto
+    fasta = tmp_path / "genome.fa"
+    gtf = tmp_path / "genes.gtf"
+    fasta.write_text(">chr1\nACGT\n", encoding="utf-8")
+    gtf.write_text("chr1\tsrc\tgene\t1\t4\t.\t+\t.\tgene_id \"g1\";\n", encoding="utf-8")
+    _mock_preflight_infra(monkeypatch)
+    with pytest.raises(SkillError) as exc:
+        preflight.run_preflight(
+            _make_resume_args(output_dir, fasta, gtf, preset="star"),  # now requesting star
+            pipeline_source=_LOCAL_SOURCE,
+            samplesheet_summary=_SS,
+        )
+    assert exc.value.error_code == "INVALID_RESUME_STATE"
+
+
+def test_resume_profile_mismatch_raises(tmp_path, monkeypatch):
+    """Resume with a different profile must raise INVALID_RESUME_STATE."""
+    output_dir = tmp_path / "out"
+    _write_manifest(output_dir, profile="conda")  # previous run used conda
+    fasta = tmp_path / "genome.fa"
+    gtf = tmp_path / "genes.gtf"
+    fasta.write_text(">chr1\nACGT\n", encoding="utf-8")
+    gtf.write_text("chr1\tsrc\tgene\t1\t4\t.\t+\t.\tgene_id \"g1\";\n", encoding="utf-8")
+    _mock_preflight_infra(monkeypatch)
+    with pytest.raises(SkillError) as exc:
+        preflight.run_preflight(
+            _make_resume_args(output_dir, fasta, gtf, profile="docker"),  # now requesting docker
+            pipeline_source=_LOCAL_SOURCE,
+            samplesheet_summary=_SS,
+        )
+    assert exc.value.error_code == "INVALID_RESUME_STATE"
+
+
+def test_resume_source_kind_mismatch_raises(tmp_path, monkeypatch):
+    """Resume when source_kind changed (local → remote) must raise INVALID_RESUME_STATE."""
+    output_dir = tmp_path / "out"
+    _write_manifest(output_dir, source_kind="local_checkout", version="abc123")
+    fasta = tmp_path / "genome.fa"
+    gtf = tmp_path / "genes.gtf"
+    fasta.write_text(">chr1\nACGT\n", encoding="utf-8")
+    gtf.write_text("chr1\tsrc\tgene\t1\t4\t.\t+\t.\tgene_id \"g1\";\n", encoding="utf-8")
+    _mock_preflight_infra(monkeypatch)
+    remote_source = {"source_kind": "remote_repo", "source_ref": "nf-core/scrnaseq", "resolved_version": "4.1.0", "branch": "", "dirty": False}
+    with pytest.raises(SkillError) as exc:
+        preflight.run_preflight(
+            _make_resume_args(output_dir, fasta, gtf),
+            pipeline_source=remote_source,  # different source_kind
+            samplesheet_summary=_SS,
+        )
+    assert exc.value.error_code == "INVALID_RESUME_STATE"

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_samplesheet_builder.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_samplesheet_builder.py
@@ -1,0 +1,693 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from errors import ErrorCode, SkillError
+from samplesheet_builder import (
+    _looks_like_fastq_path,
+    validate_and_normalize_samplesheet,
+)
+
+
+def _touch_fastq(path: Path) -> None:
+    path.write_text("x", encoding="utf-8")
+
+
+def test_validate_and_normalize_samplesheet(tmp_path):
+    r1 = tmp_path / "a_R1.fastq.gz"
+    r2 = tmp_path / "a_R2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        f"sample,fastq_1,fastq_2,expected_cells\nsampleA,{r1},{r2},1000\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "normalized.csv"
+    result = validate_and_normalize_samplesheet(src, out)
+    assert result["sample_count"] == 1
+    assert out.exists()
+
+
+def test_validate_and_normalize_samplesheet_rejects_missing_fastq(tmp_path):
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        "sample,fastq_1,fastq_2\nsampleA,missing_R1.fastq.gz,missing_R2.fastq.gz\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "normalized.csv")
+    assert exc.value.error_code == "MISSING_FASTQ"
+
+
+def test_validate_rejects_fastq_basename_with_space(tmp_path):
+    r1 = tmp_path / "sample A_R1.fastq.gz"
+    r2 = tmp_path / "sampleA_R2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        f"sample,fastq_1,fastq_2\nsampleA,{r1},{r2}\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "normalized.csv")
+    assert exc.value.error_code == "INVALID_FASTQ"
+    assert exc.value.details["column"] == "fastq_1"
+
+
+def test_validate_accepts_upstream_sample_name_with_non_whitespace_symbols(tmp_path):
+    r1 = tmp_path / "sample_R1.fastq.gz"
+    r2 = tmp_path / "sample_R2.fastq.gz"
+    _touch_fastq(r1)
+    _touch_fastq(r2)
+    src = tmp_path / "samplesheet.csv"
+    out = tmp_path / "normalized.csv"
+    src.write_text(
+        f"sample,fastq_1,fastq_2\nsample+alpha:1,{r1},{r2}\n",
+        encoding="utf-8",
+    )
+
+    summary = validate_and_normalize_samplesheet(src, out, preset="star")
+
+    rows = list(csv.DictReader(out.open(encoding="utf-8")))
+    assert summary["sample_names"] == ["sample+alpha:1"]
+    assert rows[0]["sample"] == "sample+alpha:1"
+
+
+def test_validate_rejects_fastq_extension_case_not_matching_nfcore_schema(tmp_path):
+    r1 = tmp_path / "sample_R1.FASTQ.GZ"
+    r2 = tmp_path / "sample_R2.fastq.gz"
+    _touch_fastq(r1)
+    _touch_fastq(r2)
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(f"sample,fastq_1,fastq_2\nsampleA,{r1},{r2}\n", encoding="utf-8")
+
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "normalized.csv", preset="star")
+
+    assert exc.value.error_code == ErrorCode.INVALID_FASTQ
+    assert exc.value.details["filename"] == "sample_R1.FASTQ.GZ"
+
+
+def test_validate_allows_parent_directory_with_space(tmp_path):
+    reads_dir = tmp_path / "reads with space"
+    reads_dir.mkdir()
+    r1 = reads_dir / "sampleA_R1.fastq.gz"
+    r2 = reads_dir / "sampleA_R2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        f"sample,fastq_1,fastq_2\nsampleA,{r1},{r2}\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "normalized.csv"
+    result = validate_and_normalize_samplesheet(src, out)
+    assert result["sample_count"] == 1
+
+
+def test_validate_rejects_fastq_barcode_basename_with_space_for_arc(tmp_path):
+    r1 = tmp_path / "sampleA_R1.fastq.gz"
+    r2 = tmp_path / "sampleA_R2.fastq.gz"
+    barcode = tmp_path / "sample A_I2.fastq.gz"
+    for path in (r1, r2, barcode):
+        path.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        f"sample,fastq_1,fastq_2,sample_type,fastq_barcode\nsampleA,{r1},{r2},atac,{barcode}\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "normalized.csv", preset="cellrangerarc")
+    assert exc.value.error_code == "INVALID_FASTQ"
+    assert exc.value.details["column"] == "fastq_barcode"
+
+
+def test_validate_rejects_required_columns_out_of_order(tmp_path):
+    r1 = tmp_path / "a_R1.fastq.gz"
+    r2 = tmp_path / "a_R2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        f"fastq_1,sample,fastq_2\n{r1},sampleA,{r2}\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "normalized.csv")
+    assert exc.value.error_code == "INVALID_SAMPLESHEET"
+    assert exc.value.details["expected_first_columns"] == ["sample", "fastq_1", "fastq_2"]
+
+
+def test_validate_normalizes_sample_name_spaces_to_underscores(tmp_path):
+    r1 = tmp_path / "a_R1.fastq.gz"
+    r2 = tmp_path / "a_R2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        f"sample,fastq_1,fastq_2\nsample A,{r1},{r2}\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "normalized.csv"
+    result = validate_and_normalize_samplesheet(src, out)
+
+    import csv as _csv
+    row = next(_csv.DictReader(out.open(encoding="utf-8")))
+    assert row["sample"] == "sample_A"
+    assert result["sample_names"] == ["sample_A"]
+
+
+def test_validate_normalizes_sample_name_whitespace_runs_to_single_underscore(tmp_path):
+    r1 = tmp_path / "a_R1.fastq.gz"
+    r2 = tmp_path / "a_R2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        f"sample,fastq_1,fastq_2\nsample\t  A,{r1},{r2}\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "normalized.csv"
+    result = validate_and_normalize_samplesheet(src, out)
+
+    import csv as _csv
+    row = next(_csv.DictReader(out.open(encoding="utf-8")))
+    assert row["sample"] == "sample_A"
+    assert result["sample_names"] == ["sample_A"]
+
+
+def test_validate_rejects_sample_names_that_collide_after_space_normalization(tmp_path):
+    r1a = tmp_path / "a_R1.fastq.gz"
+    r2a = tmp_path / "a_R2.fastq.gz"
+    r1b = tmp_path / "b_R1.fastq.gz"
+    r2b = tmp_path / "b_R2.fastq.gz"
+    for path in (r1a, r2a, r1b, r2b):
+        path.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        f"sample,fastq_1,fastq_2\nsample A,{r1a},{r2a}\nsample_A,{r1b},{r2b}\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "normalized.csv")
+    assert exc.value.error_code == "INVALID_SAMPLESHEET"
+    assert exc.value.details["normalized_sample"] == "sample_A"
+
+
+def test_validate_rejects_sample_names_that_collide_after_whitespace_normalization(tmp_path):
+    r1a = tmp_path / "a_R1.fastq.gz"
+    r2a = tmp_path / "a_R2.fastq.gz"
+    r1b = tmp_path / "b_R1.fastq.gz"
+    r2b = tmp_path / "b_R2.fastq.gz"
+    for path in (r1a, r2a, r1b, r2b):
+        path.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        f"sample,fastq_1,fastq_2\nsample\tA,{r1a},{r2a}\nsample_A,{r1b},{r2b}\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "normalized.csv")
+    assert exc.value.error_code == "INVALID_SAMPLESHEET"
+    assert exc.value.details["normalized_sample"] == "sample_A"
+
+
+def test_validate_accepts_upstream_sample_name_with_special_chars(tmp_path):
+    r1 = tmp_path / "a_R1.fastq.gz"
+    r2 = tmp_path / "a_R2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        f"sample,fastq_1,fastq_2\nsample@bad!,{r1},{r2}\n",
+        encoding="utf-8",
+    )
+    result = validate_and_normalize_samplesheet(src, tmp_path / "normalized.csv")
+    assert result["sample_names"] == ["sample@bad!"]
+
+
+def test_validate_accepts_valid_sample_name_formats(tmp_path):
+    r1 = tmp_path / "a_R1.fastq.gz"
+    r2 = tmp_path / "a_R2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    for valid_name in ("sample1", "Sample_A", "sample.1", "sample-1"):
+        src = tmp_path / "samplesheet.csv"
+        src.write_text(
+            f"sample,fastq_1,fastq_2\n{valid_name},{r1},{r2}\n",
+            encoding="utf-8",
+        )
+        result = validate_and_normalize_samplesheet(src, tmp_path / "normalized.csv")
+        assert result["sample_count"] == 1
+
+
+def test_normalized_csv_writes_absolute_posix_paths(tmp_path):
+    """FASTQ paths in the normalized CSV must be absolute and use forward slashes."""
+    r1 = tmp_path / "reads" / "s_R1.fastq.gz"
+    r2 = tmp_path / "reads" / "s_R2.fastq.gz"
+    r1.parent.mkdir()
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(f"sample,fastq_1,fastq_2\nsampleA,{r1},{r2}\n", encoding="utf-8")
+    out = tmp_path / "norm.csv"
+    validate_and_normalize_samplesheet(src, out)
+    import csv as _csv
+    rows = list(_csv.DictReader(out.open(encoding="utf-8")))
+    assert Path(rows[0]["fastq_1"]).is_absolute()
+    assert "\\" not in rows[0]["fastq_1"]
+    assert "\\" not in rows[0]["fastq_2"]
+
+
+def test_relative_fastq_path_resolved_against_csv_directory(tmp_path):
+    """A relative FASTQ path should be resolved against the CSV's directory, not CWD."""
+    reads_dir = tmp_path / "data"
+    reads_dir.mkdir()
+    r1 = reads_dir / "s_R1.fastq.gz"
+    r2 = reads_dir / "s_R2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    # Write relative paths (relative to the CSV's location = tmp_path)
+    src = tmp_path / "samplesheet.csv"
+    src.write_text("sample,fastq_1,fastq_2\nsampleA,data/s_R1.fastq.gz,data/s_R2.fastq.gz\n", encoding="utf-8")
+    out = tmp_path / "norm.csv"
+    result = validate_and_normalize_samplesheet(src, out)
+    assert result["sample_count"] == 1
+    import csv as _csv
+    rows = list(_csv.DictReader(out.open(encoding="utf-8")))
+    assert rows[0]["fastq_1"] == r1.resolve().as_posix()
+
+
+def test_exact_duplicate_fastq_rows_rejected(tmp_path):
+    r1 = tmp_path / "r1.fastq.gz"
+    r2 = tmp_path / "r2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        f"sample,fastq_1,fastq_2\nsampleA,{r1},{r2}\nsampleA,{r1},{r2}\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "norm.csv")
+    assert exc.value.error_code == "INVALID_SAMPLESHEET"
+    assert "duplicate" in exc.value.message.lower() or "duplicate" in str(exc.value.details).lower()
+
+
+def test_repeated_sample_names_allowed_for_distinct_fastqs(tmp_path):
+    r1a = tmp_path / "lane1_R1.fastq.gz"
+    r2a = tmp_path / "lane1_R2.fastq.gz"
+    r1b = tmp_path / "lane2_R1.fastq.gz"
+    r2b = tmp_path / "lane2_R2.fastq.gz"
+    for path in (r1a, r2a, r1b, r2b):
+        path.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        f"sample,fastq_1,fastq_2\nsampleA,{r1a},{r2a}\nsampleA,{r1b},{r2b}\n",
+        encoding="utf-8",
+    )
+    result = validate_and_normalize_samplesheet(src, tmp_path / "norm.csv")
+    assert result["sample_count"] == 2
+
+
+def test_repeated_sample_requires_consistent_expected_cells(tmp_path):
+    r1a = tmp_path / "lane1_R1.fastq.gz"
+    r2a = tmp_path / "lane1_R2.fastq.gz"
+    r1b = tmp_path / "lane2_R1.fastq.gz"
+    r2b = tmp_path / "lane2_R2.fastq.gz"
+    for path in (r1a, r2a, r1b, r2b):
+        path.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        "sample,fastq_1,fastq_2,expected_cells\n"
+        f"sampleA,{r1a},{r2a},1000\n"
+        f"sampleA,{r1b},{r2b},2000\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "norm.csv")
+
+    assert exc.value.error_code == "INVALID_SAMPLESHEET"
+    assert exc.value.details["column"] == "expected_cells"
+    assert exc.value.details["sample"] == "sampleA"
+
+
+def test_repeated_sample_requires_consistent_seq_center(tmp_path):
+    r1a = tmp_path / "lane1_R1.fastq.gz"
+    r2a = tmp_path / "lane1_R2.fastq.gz"
+    r1b = tmp_path / "lane2_R1.fastq.gz"
+    r2b = tmp_path / "lane2_R2.fastq.gz"
+    for path in (r1a, r2a, r1b, r2b):
+        path.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        "sample,fastq_1,fastq_2,seq_center\n"
+        f"sampleA,{r1a},{r2a},CoreA\n"
+        f"sampleA,{r1b},{r2b},CoreB\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "norm.csv")
+
+    assert exc.value.error_code == "INVALID_SAMPLESHEET"
+    assert exc.value.details["column"] == "seq_center"
+    assert exc.value.details["sample"] == "sampleA"
+
+
+def test_repeated_sample_allows_matching_metadata(tmp_path):
+    r1a = tmp_path / "lane1_R1.fastq.gz"
+    r2a = tmp_path / "lane1_R2.fastq.gz"
+    r1b = tmp_path / "lane2_R1.fastq.gz"
+    r2b = tmp_path / "lane2_R2.fastq.gz"
+    for path in (r1a, r2a, r1b, r2b):
+        path.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        "sample,fastq_1,fastq_2,expected_cells,seq_center\n"
+        f"sampleA,{r1a},{r2a},1000,CoreA\n"
+        f"sampleA,{r1b},{r2b},1000,CoreA\n",
+        encoding="utf-8",
+    )
+
+    result = validate_and_normalize_samplesheet(src, tmp_path / "norm.csv")
+
+    assert result["sample_count"] == 2
+
+
+def test_expected_cells_zero_rejected(tmp_path):
+    r1 = tmp_path / "r1.fastq.gz"
+    r2 = tmp_path / "r2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(f"sample,fastq_1,fastq_2,expected_cells\nsampleA,{r1},{r2},0\n", encoding="utf-8")
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "norm.csv")
+    assert exc.value.error_code == "INVALID_SAMPLESHEET"
+
+
+def test_expected_cells_negative_rejected(tmp_path):
+    r1 = tmp_path / "r1.fastq.gz"
+    r2 = tmp_path / "r2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(f"sample,fastq_1,fastq_2,expected_cells\nsampleA,{r1},{r2},-500\n", encoding="utf-8")
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "norm.csv")
+    assert exc.value.error_code == "INVALID_SAMPLESHEET"
+
+
+def test_missing_fastq_2_rejected(tmp_path):
+    """A row with fastq_1 but empty fastq_2 must raise INVALID_SAMPLESHEET."""
+    r1 = tmp_path / "r1.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(f"sample,fastq_1,fastq_2\nsampleA,{r1},\n", encoding="utf-8")
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "norm.csv")
+    assert exc.value.error_code == "INVALID_SAMPLESHEET"
+
+
+def test_bom_prefixed_samplesheet_accepted(tmp_path):
+    """UTF-8 BOM (Excel export) must not cause a MISSING_COLUMNS error."""
+    r1 = tmp_path / "r1.fastq.gz"
+    r2 = tmp_path / "r2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    # Write BOM + CSV header explicitly
+    src.write_bytes(
+        "﻿sample,fastq_1,fastq_2\n".encode("utf-8")
+        + f"sampleA,{r1},{r2}\n".encode("utf-8")
+    )
+    result = validate_and_normalize_samplesheet(src, tmp_path / "norm.csv")
+    assert result["sample_count"] == 1
+
+
+def test_unknown_columns_reported(tmp_path):
+    """Extra columns in the samplesheet must be surfaced in the result dict."""
+    r1 = tmp_path / "r1.fastq.gz"
+    r2 = tmp_path / "r2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(f"sample,fastq_1,fastq_2,library_type\nsampleA,{r1},{r2},GEX\n", encoding="utf-8")
+    result = validate_and_normalize_samplesheet(src, tmp_path / "norm.csv")
+    assert "library_type" in result["unknown_columns"]
+
+
+def test_unknown_columns_preserved_in_normalized_samplesheet(tmp_path):
+    r1 = tmp_path / "sampleA_gex_S1_L001_R1_001.fastq.gz"
+    r2 = tmp_path / "sampleA_gex_S1_L001_R2_001.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        f"sample,fastq_1,fastq_2,sample_type,fastq_barcode,feature_type\n"
+        f"sampleA,{r1},{r2},gex,SI-GA-A1,gex\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "norm.csv"
+    validate_and_normalize_samplesheet(src, out, preset="cellrangerarc")
+    import csv as _csv
+    row = next(_csv.DictReader(out.open(encoding="utf-8")))
+    assert row["sample_type"] == "gex"
+    assert row["fastq_barcode"] == "SI-GA-A1"
+    assert row["feature_type"] == "gex"
+
+
+def test_cellrangerarc_requires_sample_type_and_fastq_barcode_columns(tmp_path):
+    r1 = tmp_path / "r1.fastq.gz"
+    r2 = tmp_path / "r2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(f"sample,fastq_1,fastq_2\nsampleA,{r1},{r2}\n", encoding="utf-8")
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "norm.csv", preset="cellrangerarc")
+    assert exc.value.error_code == "INVALID_SAMPLESHEET"
+    assert exc.value.details["missing_columns"] == ["sample_type", "fastq_barcode"]
+
+
+def test_cellrangerarc_rejects_invalid_sample_type(tmp_path):
+    r1 = tmp_path / "r1.fastq.gz"
+    r2 = tmp_path / "r2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        f"sample,fastq_1,fastq_2,sample_type,fastq_barcode\nsampleA,{r1},{r2},rna,\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "norm.csv", preset="cellrangerarc")
+    assert exc.value.error_code == "INVALID_SAMPLESHEET"
+    assert exc.value.details["sample_type"] == "rna"
+
+
+def test_cellrangermulti_requires_feature_type_column(tmp_path):
+    r1 = tmp_path / "r1.fastq.gz"
+    r2 = tmp_path / "r2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(f"sample,fastq_1,fastq_2\nsampleA,{r1},{r2}\n", encoding="utf-8")
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "norm.csv", preset="cellrangermulti")
+    assert exc.value.error_code == "INVALID_SAMPLESHEET"
+    assert exc.value.details["missing_columns"] == ["feature_type"]
+
+
+def test_cellrangermulti_rejects_invalid_feature_type(tmp_path):
+    r1 = tmp_path / "r1.fastq.gz"
+    r2 = tmp_path / "r2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        f"sample,fastq_1,fastq_2,feature_type\nsampleA,{r1},{r2},beam\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "norm.csv", preset="cellrangermulti")
+    assert exc.value.error_code == "INVALID_SAMPLESHEET"
+    assert exc.value.details["feature_type"] == "beam"
+
+
+def test_fastq_barcode_relative_path_is_normalized_for_arc(tmp_path):
+    reads = tmp_path / "reads"
+    reads.mkdir()
+    r1 = reads / "sampleA_gex_S1_L001_R1_001.fastq.gz"
+    r2 = reads / "sampleA_gex_S1_L001_R2_001.fastq.gz"
+    barcode = reads / "sampleA_atac_S1_L001_I2_001.fastq.gz"
+    for path in (r1, r2, barcode):
+        path.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        "sample,fastq_1,fastq_2,sample_type,fastq_barcode\n"
+        "sampleA,reads/sampleA_gex_S1_L001_R1_001.fastq.gz,"
+        "reads/sampleA_gex_S1_L001_R2_001.fastq.gz,gex,reads/sampleA_atac_S1_L001_I2_001.fastq.gz\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "norm.csv"
+    validate_and_normalize_samplesheet(src, out, preset="cellrangerarc")
+    import csv as _csv
+    row = next(_csv.DictReader(out.open(encoding="utf-8")))
+    assert row["fastq_barcode"] == barcode.resolve().as_posix()
+
+
+def test_arc_atac_row_requires_fastq_barcode(tmp_path):
+    r1 = tmp_path / "gex_R1.fastq.gz"
+    r2 = tmp_path / "gex_R2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        f"sample,fastq_1,fastq_2,sample_type,fastq_barcode\nsampleA,{r1},{r2},atac,\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "norm.csv", preset="cellrangerarc")
+    assert exc.value.error_code == "INVALID_SAMPLESHEET"
+    assert exc.value.details["column"] == "fastq_barcode"
+
+
+def test_arc_atac_row_rejects_symbolic_fastq_barcode(tmp_path):
+    r1 = tmp_path / "gex_R1.fastq.gz"
+    r2 = tmp_path / "gex_R2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        f"sample,fastq_1,fastq_2,sample_type,fastq_barcode\nsampleA,{r1},{r2},atac,SI-GA-A1\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "norm.csv", preset="cellrangerarc")
+    assert exc.value.error_code == "MISSING_FASTQ"
+    assert exc.value.details["column"] == "fastq_barcode"
+
+
+def test_invalid_fastq_extension_rejected(tmp_path):
+    r1 = tmp_path / "r1.txt"
+    r2 = tmp_path / "r2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(f"sample,fastq_1,fastq_2\nsampleA,{r1},{r2}\n", encoding="utf-8")
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "norm.csv")
+    assert exc.value.error_code == "INVALID_FASTQ"
+
+
+def test_looks_like_fastq_rejects_path_with_slash_but_no_fastq_suffix():
+    assert not _looks_like_fastq_path("/some/path/to/file.bam")
+    assert not _looks_like_fastq_path("some/relative/path")
+    assert not _looks_like_fastq_path("SI-GA-A1")
+
+
+def test_looks_like_fastq_accepts_fastq_extensions():
+    assert _looks_like_fastq_path("/data/sample_R1.fastq.gz")
+    assert _looks_like_fastq_path("relative/sample.fq.gz")
+    assert _looks_like_fastq_path("sample_1.fastq.gz")
+
+
+def test_sample_name_accepts_leading_dot_allowed_by_nfcore_schema(tmp_path):
+    r1 = tmp_path / "r1.fastq.gz"
+    r2 = tmp_path / "r2.fastq.gz"
+    r1.write_text("x", encoding="utf-8")
+    r2.write_text("x", encoding="utf-8")
+    ss = tmp_path / "samplesheet.csv"
+    ss.write_text(f"sample,fastq_1,fastq_2\n.hidden,{r1},{r2}\n", encoding="utf-8")
+    out = tmp_path / "out.csv"
+    result = validate_and_normalize_samplesheet(ss, out)
+    assert result["sample_names"] == [".hidden"]
+
+
+def test_cellranger_rejects_fastq_pair_that_differs_by_more_than_read_marker(tmp_path):
+    r1 = tmp_path / "sampleA_S1_L001_R1_001.fastq.gz"
+    r2 = tmp_path / "other_S1_L001_R2_001.fastq.gz"
+    _touch_fastq(r1)
+    _touch_fastq(r2)
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(f"sample,fastq_1,fastq_2\nsampleA,{r1},{r2}\n", encoding="utf-8")
+
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "normalized.csv", preset="cellranger")
+
+    assert exc.value.error_code == ErrorCode.INVALID_SAMPLESHEET
+    assert exc.value.details["preset"] == "cellranger"
+    assert exc.value.details["fastq_1"] == r1.name
+    assert exc.value.details["fastq_2"] == r2.name
+
+
+def test_cellranger_accepts_fastq_pair_that_only_differs_by_r1_r2(tmp_path):
+    r1 = tmp_path / "sampleA_S1_L001_R1_001.fastq.gz"
+    r2 = tmp_path / "sampleA_S1_L001_R2_001.fastq.gz"
+    _touch_fastq(r1)
+    _touch_fastq(r2)
+    src = tmp_path / "samplesheet.csv"
+    out = tmp_path / "normalized.csv"
+    src.write_text(f"sample,fastq_1,fastq_2\nsampleA,{r1},{r2}\n", encoding="utf-8")
+
+    validate_and_normalize_samplesheet(src, out, preset="cellranger")
+
+    rows = list(csv.DictReader(out.open(encoding="utf-8")))
+    assert rows[0]["fastq_1"] == r1.as_posix()
+    assert rows[0]["fastq_2"] == r2.as_posix()
+
+
+def test_cellrangerarc_rejects_fastqs_not_following_10x_arc_naming(tmp_path):
+    r1 = tmp_path / "arc_R1.fastq.gz"
+    r2 = tmp_path / "arc_R2.fastq.gz"
+    barcode = tmp_path / "arc_I2.fastq.gz"
+    _touch_fastq(r1)
+    _touch_fastq(r2)
+    _touch_fastq(barcode)
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        f"sample,fastq_1,fastq_2,fastq_barcode,sample_type\n"
+        f"sampleA,{r1},{r2},{barcode},atac\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SkillError) as exc:
+        validate_and_normalize_samplesheet(src, tmp_path / "normalized.csv", preset="cellrangerarc")
+
+    assert exc.value.error_code == ErrorCode.INVALID_FASTQ
+    assert exc.value.details["preset"] == "cellrangerarc"
+
+
+def test_cellrangerarc_accepts_10x_arc_naming_for_atac_and_gex_rows(tmp_path):
+    atac_r1 = tmp_path / "sampleA_atac_S1_L001_R1_001.fastq.gz"
+    atac_r2 = tmp_path / "sampleA_atac_S1_L001_R2_001.fastq.gz"
+    atac_i2 = tmp_path / "sampleA_atac_S1_L001_I2_001.fastq.gz"
+    gex_r1 = tmp_path / "sampleB_gex_S1_L001_R1_001.fastq.gz"
+    gex_r2 = tmp_path / "sampleB_gex_S1_L001_R2_001.fastq.gz"
+    for path in (atac_r1, atac_r2, atac_i2, gex_r1, gex_r2):
+        _touch_fastq(path)
+    src = tmp_path / "samplesheet.csv"
+    out = tmp_path / "normalized.csv"
+    src.write_text(
+        "sample,fastq_1,fastq_2,fastq_barcode,sample_type\n"
+        f"sampleA,{atac_r1},{atac_r2},{atac_i2},atac\n"
+        f"sampleB,{gex_r1},{gex_r2},,gex\n",
+        encoding="utf-8",
+    )
+
+    validate_and_normalize_samplesheet(src, out, preset="cellrangerarc")
+
+    rows = list(csv.DictReader(out.open(encoding="utf-8")))
+    assert rows[0]["fastq_barcode"] == atac_i2.as_posix()
+    assert rows[1]["sample_type"] == "gex"


### PR DESCRIPTION
## What This PR Adds

A new ClawBio skill — **`nfcore-scrnaseq-wrapper`** (CLI alias: `scrnaseq-pipeline`) — that enables end-to-end upstream single-cell RNA-seq preprocessing from raw FASTQ files using the [nf-core/scrnaseq](https://nf-co.re/scrnaseq) Nextflow pipeline.

This fills the gap at the top of the ClawBio scRNA workflow:

```
[FASTQs] → nfcore-scrnaseq-wrapper → [h5ad] → scrna-orchestrator / scrna-embedding
```

Without it, users had to manually configure Nextflow, guess the right parameters, and figure out where the outputs landed. With it, one command handles everything — from validation to reproducibility bundle.

---

## Skill Overview

**Location:** `skills/nfcore-scrnaseq-wrapper/`  
**CLI alias:** `scrnaseq-pipeline`  
**Version:** 0.1.0  
**Tests:** 293 (all green)

---

## Supported Presets

Each preset maps to a different upstream aligner:

| Preset | Aligner | Best for |
|--------|---------|----------|
| `standard` | simpleaf (alevin-fry) | Default 10x GEX — fast, memory-efficient |
| `star` | STARsolo | Best QC metrics; RNA velocity support |
| `kallisto` | kb-python / BUStools | Pseudo-alignment; fastest option |
| `cellranger` | CellRanger | CellRanger v2/v3 compatibility |
| `cellrangerarc` | CellRanger ARC | Multiome (GEX + ATAC) |
| `cellrangermulti` | CellRanger Multi | GEX + VDJ + feature barcoding |

---

## How It Works

The wrapper executes a strictly ordered 7-step pipeline. Each step gates the next — a failure at any point raises a structured `SkillError` with an `error_code` and a `fix` hint, so users always know exactly what went wrong and how to fix it.

### Step 1 — Samplesheet validation
Parses the user-supplied CSV, resolves all FASTQ paths to absolute POSIX form, normalizes sample name whitespace to underscores, validates FASTQ extensions (`.fastq.gz` / `.fq.gz` only), rejects duplicate rows and inconsistent metadata, and enforces preset-specific column requirements (e.g. `sample_type` + `fastq_barcode` for ARC, `feature_type` for Multi).

### Step 2 — Preflight checks
Verifies Java (≥17), Nextflow (≥25.04.0), and the selected execution backend (`docker`, `singularity`, `conda`, `mamba`, `apptainer`, `podman`, `shifter`, `charliecloud`, `wave`, `gpu`). For Docker, runs `docker info` and gates on the exit code. For `wave` and `gpu`, no binary check is needed — these are Nextflow-native features handled internally. All subprocess calls have a 30-second timeout.

### Step 3 — Pipeline source resolution
Looks for a local sibling `scrnaseq/` checkout first (pinned commit, audit-safe). Falls back to the remote `nf-core/scrnaseq` tag if no local checkout is found.

### Step 4 — Params construction
Translates the chosen preset and CLI flags into a `params.yaml` consumed via `-params-file`. No arbitrary Nextflow flag passthrough — all pipeline configuration flows through the preset system. `igenomes_ignore` is set automatically whenever any explicit reference path is provided (fasta, gtf, any index), suppressing nf-schema DNS validation of the default iGenomes S3 URL. The `--igenomes-base` flag enables local iGenomes mirrors for air-gapped clusters. `--skip-cellbender` and `--skip-emptydrops` are independent flags — each maps to its own upstream parameter.

### Step 5 — Execution
Runs `nextflow run` with stdout and stderr piped directly to log files on disk (never buffered in RAM). On macOS + Docker, automatically writes a Nextflow config with `stageInMode = "copy"` and `--platform linux/amd64` to work around VirtioFS EDEADLK (errno 35) and ARM64 host issues.

### Step 6 — Output parsing
Scans the output tree for MultiQC HTML, `pipeline_info/`, `.h5ad` files, and `.rds` files. Selects a `preferred_h5ad` using a priority order: CellBender-filtered > filtered > raw. Sets `handoff_available = true` only when the preferred h5ad is confirmed on disk.

### Step 7 — Reproducibility bundle + reporting
Writes:
- `reproducibility/params.yaml` — exact pipeline parameters used
- `reproducibility/commands.sh` — self-anchoring portable replay script
- `reproducibility/remap_paths.py` — helper script to remap FASTQ paths and output dir across machines
- `reproducibility/environment.yml` — runtime environment snapshot
- `reproducibility/checksums.sha256` — SHA-256 of every output artifact
- `reproducibility/manifest.json` — run metadata and params checksum
- `reproducibility/samplesheet.valid.csv` — validated, normalized samplesheet
- `reproducibility/macos_docker.config` — macOS+Docker workarounds (written at runtime on macOS)
- `provenance/*.json` — structured provenance for each pipeline stage
- `report.md` — human-readable run summary with next-step handoff commands
- `result.json` — structured result payload for downstream skill chaining

---

## Output Structure

```
output_directory/
├── report.md
├── result.json
├── logs/
│   ├── stdout.txt
│   └── stderr.txt
├── upstream/
│   └── results/          ← nf-core/scrnaseq outputs
├── reproducibility/
│   ├── samplesheet.valid.csv
│   ├── commands.sh
│   ├── remap_paths.py
│   ├── params.yaml
│   ├── environment.yml
│   ├── checksums.sha256
│   └── manifest.json
└── provenance/
    ├── upstream.json
    ├── skill.json
    ├── invocation.json
    ├── inputs.json
    ├── outputs.json
    ├── runtime.json
    └── preflight.json
```

---

## Key Design Decisions

**Why `-params-file` and not direct flags?**  
Prevents arbitrary Nextflow flag injection, makes every run fully auditable, and ensures the exact parameters are always persisted in `params.yaml` before execution starts.

**Why strict preflight?**  
Nextflow gives cryptic errors when Java is missing or Docker isn't running. The wrapper catches these before launching anything and returns structured JSON with a `fix` hint.

**Why a local sibling checkout?**  
Pinned to a specific commit instead of always pulling from GitHub. Faster, audit-safe, and reproducible across air-gapped environments.

**Why a params checksum for `--resume`?**  
Prevents silent resume with incompatible state. If the preset, profile, or any parameter changed since the last run, `INVALID_RESUME_STATE` is raised rather than Nextflow silently continuing with wrong inputs.

---

## Downstream Handoff

After a successful run, `result.json` contains a `preferred_h5ad` path that can be passed directly to downstream skills:

```bash
# Cluster and annotate
python clawbio.py run scrna --input <preferred_h5ad> --output ./analysis

# Latent embedding and batch correction
python clawbio.py run scrna-embedding --input <preferred_h5ad> --output ./embedding
```

Opt-in automatic handoff is also available with `--run-downstream`.

---

## Files Changed

### New skill
| File | Purpose |
|------|---------|
| `skills/nfcore-scrnaseq-wrapper/SKILL.md` | Full skill specification (17/17 conformance checks) |
| `skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py` | Entry point and orchestration |
| `skills/nfcore-scrnaseq-wrapper/schemas.py` | Constants, version pins, supported presets/profiles |
| `skills/nfcore-scrnaseq-wrapper/preflight.py` | Java, Nextflow, backend validation |
| `skills/nfcore-scrnaseq-wrapper/samplesheet_builder.py` | CSV validation and normalization |
| `skills/nfcore-scrnaseq-wrapper/params_builder.py` | `params.yaml` construction |
| `skills/nfcore-scrnaseq-wrapper/command_builder.py` | `nextflow run` command construction |
| `skills/nfcore-scrnaseq-wrapper/pipeline_source.py` | Local vs remote pipeline resolution |
| `skills/nfcore-scrnaseq-wrapper/executor.py` | Subprocess execution with log streaming |
| `skills/nfcore-scrnaseq-wrapper/outputs_parser.py` | Output tree scanning and h5ad selection |
| `skills/nfcore-scrnaseq-wrapper/provenance.py` | Provenance bundle and checksums |
| `skills/nfcore-scrnaseq-wrapper/reporting.py` | `report.md`, `result.json`, `commands.sh` |
| `skills/nfcore-scrnaseq-wrapper/remap_paths.py` | Portability helper — remap FASTQ paths and output dir across machines |
| `skills/nfcore-scrnaseq-wrapper/errors.py` | Structured error codes with fix hints |
| `skills/nfcore-scrnaseq-wrapper/tests/` | 293 tests across all modules |
| `skills/nfcore-scrnaseq-wrapper/demo/README.md` | Demo mode documentation |
| `skills/nfcore-scrnaseq-wrapper/README.md` | Quick-start guide |

### Platform registration
| File | Change |
|------|--------|
| `clawbio.py` | Registers `scrnaseq-pipeline` skill with full flag allowlist |
| `pytest.ini` | Adds skill to test suite; adds `integration` marker |
| `scripts/generate_catalog.py` | Adds skill alias, MVP status, trigger keywords, chaining partners |
| `skills/catalog.json` | Updates generated catalog (skill count: 55 → 56) |

### Documentation
| File | Change |
|------|--------|
| `README.md` | Adds skill to the skills table (positioned before scrna-orchestrator) |
| `CHANGELOG.md` | Adds `[Unreleased]` entry with full feature description |
| `.gitignore` | Adds `.claude/` and `.claire/` |

---

## Testing

```
293 passed in 0.58s
```

All tests are unit/integration tests that run offline (no Nextflow or Docker required). Key test files:

| Test file | What it covers |
|-----------|---------------|
| `test_samplesheet_builder.py` | CSV validation, path normalization, ARC/Multi constraints |
| `test_preflight.py` | Java/Nextflow version parsing, backend detection |
| `test_params_builder.py` | `params.yaml` construction for all presets |
| `test_command_builder.py` | `nextflow run` command assembly |
| `test_outputs_parser.py` | h5ad discovery and priority selection |
| `test_provenance.py` | Reproducibility bundle generation |
| `test_reporting.py` | `report.md`, `result.json`, `commands.sh` |
| `test_remap_paths.py` | Cross-machine path remapping and bundle portability |
| `test_resume_policy.py` | Params checksum verification |
| `test_pipeline_source.py` | Local vs remote pipeline resolution |
| `test_error_codes.py` | Structured error payloads |
| `test_executor.py` | Subprocess execution and timeout handling |
| `test_nfcore_scrnaseq_wrapper.py` | End-to-end integration of all modules |

---

## Validation Against nf-core/scrnaseq Docs

The implementation was validated against the official `nextflow_schema.json` and `assets/schema_input.json` from the nf-core/scrnaseq 4.1.0 repository:

- All aligner enum values match exactly
- All `simpleaf_umi_resolution`, `star_feature`, `kb_workflow`, `protocol` enum values match the pipeline schema (verified against the authoritative `nextflow_schema.json`, not the rendered web docs)
- Samplesheet `sample` pattern (`^\S+$`), `sample_type`, and `feature_type` enums match
- FASTA path pattern (`^\S+\.fn?a(sta)?(\.gz)?$`) enforced in preflight
- `preferred_h5ad` selection order matches actual output naming convention (`combined_{cellbender_filter,filtered,raw}_matrix.h5ad`)
- Nextflow minimum version (`!>=25.04.0`) verified against `nextflow.config` in the pipeline repository