### PR TITLE
Fix runner output path for skill subprocesses

### DIFF
--- a/clawbio.py
+++ b/clawbio.py
@@ -739,7 +739,7 @@ def run_skill(
     if summary_mode:
         out_dir = None
     elif output_dir:
-        out_dir = Path(output_dir)
+        out_dir = Path(output_dir).expanduser().resolve()
     else:
         ts = datetime.now().strftime("%Y%m%d_%H%M%S")
         out_dir = DEFAULT_OUTPUT_ROOT / f"{skill_name}_{ts}"

--- a/clawbio/tests/test_runner.py
+++ b/clawbio/tests/test_runner.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_RUNNER_SPEC = importlib.util.spec_from_file_location("clawbio_runner", PROJECT_ROOT / "clawbio.py")
+clawbio_runner = importlib.util.module_from_spec(_RUNNER_SPEC)
+sys.modules["clawbio_runner"] = clawbio_runner
+assert _RUNNER_SPEC.loader is not None
+_RUNNER_SPEC.loader.exec_module(clawbio_runner)
+
+
+def test_run_skill_passes_absolute_output_to_subprocess(monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+
+    class Proc:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, capture_output, text, timeout, cwd):
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        return Proc()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(clawbio_runner.subprocess, "run", fake_run)
+
+    result = clawbio_runner.run_skill(
+        skill_name="gwas",
+        output_dir="relative_gwas_output",
+        extra_args=["--rsid", "rs861539", "--no-cache"],
+    )
+
+    expected_output = tmp_path / "relative_gwas_output"
+    assert result["success"] is True
+    assert result["output_dir"] == str(expected_output)
+    cmd = captured["cmd"]
+    assert cmd[cmd.index("--output") + 1] == str(expected_output)
+    assert captured["cwd"] == str(PROJECT_ROOT / "skills" / "gwas-lookup")


### PR DESCRIPTION
## Summary

- Fixes a path mismatch where `python clawbio.py run gwas --output output/...` reported the repository-level output path, but the GWAS skill wrote files under `skills/gwas-lookup/output/...`.
- Resolves user-provided output paths to absolute paths before launching skill subprocesses.
- Adds a regression test to ensure relative output paths are passed correctly.

## Skill affected

gwas-lookup / ClawBio runner

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology)
- [ ] Tests included and passing (`pytest -v`)
- [x] Demo data included for reviewers to test
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

Manual verification passed:

```bash
python clawbio.py run gwas --demo --output output/gwas_demo_runner_fix_check --no-cache
python clawbio.py run gwas --rsid rs861539 --output output/gwas_rs861539_fixed_check --no-cache
```

Both commands wrote files under the repository-level output/ directory as expected.

pytest could not be run locally because it is not installed in the current environment:

```bash
/Users/siyoo/miniforge3/bin/python: No module named pytest
```