### PR TITLE
feat: support structured suggested actions

### DIFF
--- a/bot/action_offers.py
+++ b/bot/action_offers.py
@@ -1,0 +1,343 @@
+"""Shared helpers for structured skill-suggested follow-up actions.
+
+Skills may return `suggested_actions[]` in result.json. The chat adapters use
+this module to render those actions, remember them briefly, resolve natural
+follow-up replies, and execute only the stored nested request payload.
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+import re
+import tempfile
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable
+
+DEFAULT_PENDING_ACTION_TTL_SECONDS = 30 * 60
+
+# These are stand-alone confirmation/navigation phrases. They are intentionally
+# separate from numbered choices so "yes" can stay ambiguous when several
+# pending actions exist.
+_AFFIRM_ONLY = {
+    "yes",
+    "y",
+    "yeah",
+    "yep",
+    "ok",
+    "okay",
+    "sure",
+    "please do",
+    "go ahead",
+    "do it",
+    "run it",
+    "please show me",
+    "show me",
+}
+
+_CANCEL_WORDS = {
+    "cancel",
+    "no",
+    "nope",
+    "never mind",
+    "nevermind",
+    "stop",
+    "abort",
+}
+
+_INDEX_CONFIRM_PREFIXES = (
+    "yes",
+    "run",
+    "do",
+    "execute",
+    "show",
+    "please run",
+    "please do",
+    "please show me",
+    "show me",
+)
+_INDEX_CONFIRM_PATTERN = re.compile(
+    r"\s*(?:" + "|".join(re.escape(prefix) for prefix in _INDEX_CONFIRM_PREFIXES) + r")?\s*(\d+)\s*",
+    flags=re.IGNORECASE,
+)
+
+
+def _normalize_text(text: str) -> str:
+    text = text.strip().lower()
+    return re.sub(r"\s+", " ", text)
+
+
+def _token_count(text: str) -> int:
+    return len([part for part in text.split(" ") if part])
+
+
+def looks_like_action_followup(reply_text: str) -> bool:
+    """Return True for short replies that only make sense after an offer."""
+    normalized = _normalize_text(reply_text)
+    if normalized in _AFFIRM_ONLY or normalized in _CANCEL_WORDS:
+        return True
+    return _INDEX_CONFIRM_PATTERN.fullmatch(reply_text.strip()) is not None
+
+
+def extract_action_offer(result: dict[str, Any]) -> list[dict[str, Any]] | None:
+    """Return executable suggested actions from a skill result.
+
+    A displayed offer must be executable later. For that reason a valid action
+    needs a human label, a stable id, and a structured nested request. The chat
+    adapters deliberately ignore shell-only or prose-only suggestions.
+    """
+    actions = result.get("suggested_actions")
+    if not isinstance(actions, list):
+        return None
+    cleaned: list[dict[str, Any]] = []
+    for action in actions:
+        if not isinstance(action, dict):
+            continue
+        action_id = action.get("action_id")
+        label = action.get("label")
+        request = action.get("request")
+        if not isinstance(action_id, str) or not action_id.strip():
+            continue
+        if not isinstance(label, str) or not label.strip():
+            continue
+        if not isinstance(request, dict):
+            continue
+        cleaned.append(action)
+    return cleaned or None
+
+
+def extract_chat_summary_lines(result: dict[str, Any]) -> list[str]:
+    """Return concise skill-authored lines intended for chat display."""
+    lines = result.get("chat_summary_lines")
+    if not isinstance(lines, list):
+        return []
+    return [str(line).strip() for line in lines if str(line).strip()]
+
+
+def load_bundle_fields(output_dir: str | Path | None) -> dict[str, Any]:
+    """Load structured display/action fields from a skill output bundle."""
+    if output_dir is None:
+        return {}
+
+    out_dir = Path(output_dir)
+    if not out_dir.exists():
+        return {}
+
+    fields: dict[str, Any] = {}
+    result_json_path = out_dir / "result.json"
+    if result_json_path.exists():
+        fields["result_json_path"] = str(result_json_path)
+        try:
+            payload = json.loads(result_json_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            payload = None
+        if isinstance(payload, dict):
+            fields["skill_result_json"] = payload
+            # Field meanings:
+            # - chat_summary_lines: concise text written by the skill for chat
+            # - preferred_artifacts: files the UI should prioritize displaying
+            # - suggested_actions: deterministic follow-up requests to offer
+            # - report_md: full markdown report embedded in result.json
+            for key in (
+                "chat_summary_lines",
+                "preferred_artifacts",
+                "suggested_actions",
+                "report_md",
+            ):
+                if key in payload:
+                    fields[key] = payload[key]
+
+    if "report_md" not in fields:
+        for pattern in ("report.md", "*_report.md", "*.md"):
+            for md_file in sorted(out_dir.glob(pattern)):
+                if md_file.name.startswith("."):
+                    continue
+                try:
+                    fields["report_md"] = md_file.read_text(encoding="utf-8")
+                except OSError:
+                    continue
+                return fields
+    return fields
+
+
+def render_action_offer(actions: list[dict[str, Any]]) -> str:
+    """Render actions as numbered chat choices."""
+    if not actions:
+        return ""
+    lines = ["I can do the next step for you:"]
+    for idx, action in enumerate(actions, start=1):
+        suffix = ""
+        if action.get("requires_confirmation") is False:
+            suffix = " (safe refresh)"
+        lines.append(f"{idx}. {action.get('label', f'Action {idx}')}{suffix}")
+    if len(actions) == 1:
+        lines.append("Reply with `yes`, `1`, the action name, or `cancel`.")
+    else:
+        choices = ", ".join(f"`{i}`" for i in range(1, len(actions) + 1))
+        lines.append(f"Reply with {choices}, `yes 1`, the action name, or `cancel`.")
+    return "\n".join(lines)
+
+
+def is_cancel_reply(reply_text: str) -> bool:
+    """Return True when a reply clearly declines the pending offer."""
+    return _normalize_text(reply_text) in _CANCEL_WORDS
+
+
+def _match_by_index(reply_text: str, actions: list[dict[str, Any]]) -> dict[str, Any] | None:
+    m = _INDEX_CONFIRM_PATTERN.fullmatch(reply_text.strip())
+    if not m:
+        return None
+    idx = int(m.group(1)) - 1
+    if 0 <= idx < len(actions):
+        return actions[idx]
+    return None
+
+
+def _match_by_label(reply_text: str, actions: list[dict[str, Any]]) -> dict[str, Any] | None:
+    normalized = _normalize_text(reply_text)
+    exact: list[dict[str, Any]] = []
+    loose: list[dict[str, Any]] = []
+    for action in actions:
+        label = _normalize_text(str(action.get("label", "")))
+        action_id = _normalize_text(str(action.get("action_id", "")))
+        if normalized in {label, action_id}:
+            exact.append(action)
+        if (
+            normalized
+            and _token_count(normalized) > 1
+            and _token_count(label) > 1
+            and (normalized in label or label in normalized)
+        ):
+            loose.append(action)
+    if len(exact) == 1:
+        return exact[0]
+    if len(loose) == 1:
+        return loose[0]
+
+    label_map = {
+        _normalize_text(str(action.get("label", ""))): action for action in actions
+    }
+    close = difflib.get_close_matches(normalized, list(label_map), n=2, cutoff=0.86)
+    if len(close) == 1:
+        return label_map[close[0]]
+    return None
+
+
+def parse_action_reply(reply_text: str, actions: list[dict[str, Any]]) -> dict[str, Any]:
+    """Classify a follow-up reply against stored suggested actions.
+
+    The returned `confirmed` flag means the wording was an explicit approval
+    ("yes", "go ahead", "please show me"). A numeric or label selection may
+    still need a second confirmation when the action requires confirmation.
+    """
+    if not actions:
+        return {"kind": "none"}
+    normalized = _normalize_text(reply_text)
+    if not normalized:
+        return {"kind": "none"}
+    if is_cancel_reply(normalized):
+        return {"kind": "cancel"}
+
+    if normalized in _AFFIRM_ONLY:
+        if len(actions) == 1:
+            return {"kind": "matched", "action": actions[0], "confirmed": True}
+        return {"kind": "ambiguous"}
+
+    index_match = _match_by_index(reply_text, actions)
+    if index_match is not None:
+        confirmed = re.fullmatch(r"\s*\d+\s*", reply_text) is None
+        return {"kind": "matched", "action": index_match, "confirmed": confirmed}
+
+    label_match = _match_by_label(reply_text, actions)
+    if label_match is not None:
+        return {"kind": "matched", "action": label_match, "confirmed": False}
+
+    return {"kind": "none"}
+
+
+def make_pending_action_entry(
+    *,
+    skill: str,
+    actions: list[dict[str, Any]],
+    source_summary: list[str] | None = None,
+    source_output_dir: str | None = None,
+    timestamp: float | None = None,
+    selected_action: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Create the per-chat offer state stored by adapters."""
+    return {
+        "skill": skill,
+        "timestamp": float(timestamp if timestamp is not None else time.time()),
+        "actions": actions,
+        "source_summary": list(source_summary or []),
+        "source_output_dir": source_output_dir,
+        "selected_action": selected_action,
+    }
+
+
+def is_pending_action_expired(
+    entry: dict[str, Any],
+    *,
+    now_ts: float | None = None,
+    ttl_seconds: int = DEFAULT_PENDING_ACTION_TTL_SECONDS,
+) -> bool:
+    """Return True when a stored offer is too old to accept safely."""
+    try:
+        ts = float(entry.get("timestamp", 0))
+    except (TypeError, ValueError):
+        return True
+    now = float(now_ts if now_ts is not None else time.time())
+    return now - ts > ttl_seconds
+
+
+def choice_list_text(actions: list[dict[str, Any]]) -> str:
+    choices = [str(i) for i in range(1, len(actions) + 1)]
+    if not choices:
+        return ""
+    if len(choices) == 1:
+        return choices[0]
+    if len(choices) == 2:
+        return f"{choices[0]} or {choices[1]}"
+    return ", ".join(choices[:-1]) + f", or {choices[-1]}"
+
+
+def execute_stored_action(
+    pending_entry: dict[str, Any],
+    action: dict[str, Any],
+    *,
+    runner: Callable[..., dict[str, Any]],
+    output_root: str | Path,
+) -> dict[str, Any]:
+    """Execute a selected stored action through the normal ClawBio runner.
+
+    The nested request is written to a temporary JSON file and passed as
+    `--input`. `shell_line` is never executed from this path.
+    """
+    request = action.get("request")
+    if not isinstance(request, dict):
+        raise ValueError("stored action is missing a structured request payload")
+    skill = str(pending_entry.get("skill") or "").strip()
+    if not skill:
+        raise ValueError("pending action entry is missing the source skill")
+
+    with tempfile.TemporaryDirectory(prefix="clawbio_action_") as tmpdir:
+        request_path = Path(tmpdir) / "request.json"
+        request_path.write_text(
+            json.dumps(request, indent=2, ensure_ascii=True) + "\n",
+            encoding="utf-8",
+        )
+
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_dir = Path(output_root) / f"{skill}_{ts}"
+        runner_kwargs: dict[str, Any] = {
+            "skill_name": skill,
+            "input_path": str(request_path),
+            "output_dir": str(output_dir),
+            "demo": False,
+        }
+        timeout_secs = action.get("timeout_secs")
+        if isinstance(timeout_secs, int) and timeout_secs > 0:
+            runner_kwargs["timeout"] = timeout_secs
+        return runner(**runner_kwargs)

--- a/bot/roboterri.py
+++ b/bot/roboterri.py
@@ -24,6 +24,7 @@ import logging
 import os
 import re
 import shutil
+import subprocess
 import sys
 import tempfile
 import time
@@ -59,6 +60,35 @@ from bot.tool_loop_utils import (
     synthetic_tool_result_messages,
     tool_error_content,
 )
+
+try:  # Allow running as `python bot/roboterri.py` and as a package import.
+    from action_offers import (
+        choice_list_text,
+        execute_stored_action,
+        extract_action_offer,
+        extract_chat_summary_lines,
+        is_cancel_reply,
+        is_pending_action_expired,
+        load_bundle_fields,
+        looks_like_action_followup,
+        make_pending_action_entry,
+        parse_action_reply,
+        render_action_offer,
+    )
+except ImportError:  # pragma: no cover - package import fallback
+    from bot.action_offers import (
+        choice_list_text,
+        execute_stored_action,
+        extract_action_offer,
+        extract_chat_summary_lines,
+        is_cancel_reply,
+        is_pending_action_expired,
+        load_bundle_fields,
+        looks_like_action_followup,
+        make_pending_action_entry,
+        parse_action_reply,
+        render_action_offer,
+    )
 
 # --------------------------------------------------------------------------- #
 # Config
@@ -223,6 +253,11 @@ _pending_media: dict[int, list[dict]] = {}
 # Pending text queue: bypass LLM paraphrasing for compare/drugphoto
 _pending_text: dict[int, list[str]] = {}
 
+# Pending suggested actions: chat_id -> stored offer bundle. This is the safety
+# boundary for confirmations: users can only select one of these stored
+# structured requests, never provide fresh executable text.
+_pending_actions: dict[int, dict] = {}
+
 BOT_START_TIME = time.time()
 
 _SKILL_REGISTRY = load_default_skill_registry(CLAWBIO_DIR)
@@ -331,6 +366,13 @@ TOOLS = [
                         "description": (
                             "rsID for GWAS variant lookup (e.g. 'rs3798220'). "
                             "Used with gwas skill."
+                        ),
+                    },
+                    "request": {
+                        "type": "object",
+                        "description": (
+                            "Structured nested request payload for skills that document "
+                            "a JSON request contract."
                         ),
                     },
                 },
@@ -445,6 +487,167 @@ TOOLS = [
 # --------------------------------------------------------------------------- #
 
 
+def _run_skill_local_sync(
+    *,
+    skill_name: str,
+    input_path: str | None = None,
+    output_dir: str | None = None,
+    demo: bool = False,
+    extra_args: list[str] | None = None,
+    timeout: int = 300,
+    profile_path: str | None = None,
+) -> dict:
+    """Run a stored follow-up action through the same CLI path used by the bot."""
+    cmd = [sys.executable, str(CLAWBIO_PY), "run", skill_name]
+    if demo:
+        cmd.append("--demo")
+    elif profile_path:
+        cmd.extend(["--profile", profile_path])
+    elif input_path:
+        cmd.extend(["--input", str(input_path)])
+    if output_dir:
+        cmd.extend(["--output", str(output_dir)])
+    if extra_args:
+        cmd.extend(extra_args)
+
+    proc = subprocess.run(
+        cmd,
+        cwd=str(CLAWBIO_DIR),
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+    )
+    return _skill_result_from_output(
+        skill_name=skill_name,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        exit_code=proc.returncode,
+        output_dir=output_dir,
+    )
+
+
+def _skill_result_from_output(
+    *,
+    skill_name: str,
+    stdout: str,
+    stderr: str,
+    exit_code: int,
+    output_dir: str | Path | None,
+) -> dict:
+    """Build the runner-like result shape consumed by the chat renderer."""
+    out_dir = Path(output_dir) if output_dir else None
+    files = (
+        sorted(str(f.relative_to(out_dir)) for f in out_dir.rglob("*") if f.is_file())
+        if out_dir and out_dir.exists()
+        else []
+    )
+    result = {
+        "skill": skill_name,
+        "success": exit_code == 0,
+        "exit_code": exit_code,
+        "output_dir": str(out_dir) if out_dir else None,
+        "files": files,
+        "stdout": stdout,
+        "stderr": stderr,
+    }
+    if exit_code == 0:
+        result.update(load_bundle_fields(out_dir))
+    return result
+
+
+def _trim_report_for_chat(report_text: str) -> str:
+    """Trim verbose report sections while keeping the disclaimer."""
+    keep_lines: list[str] = []
+    skip = False
+    for line in report_text.split("\n"):
+        if line.startswith("## Chromosome Breakdown"):
+            skip = True
+        elif line.startswith("## Ancestry Composition"):
+            skip = False
+        elif line.startswith("## Methods"):
+            skip = True
+        elif line.startswith("## About"):
+            skip = False
+        elif line.startswith("## Reproducibility"):
+            skip = True
+        elif line.startswith("## Disclaimer"):
+            skip = False
+        if line.startswith("!["):
+            continue
+        if not skip:
+            keep_lines.append(line)
+    return "\n".join(keep_lines).strip()
+
+
+def _queue_output_media(chat_id: int, output_dir: Path | None) -> None:
+    """Queue generated reports and figures for chat delivery."""
+    if output_dir is None or not output_dir.exists():
+        return
+    media_items: list[dict[str, str]] = []
+    for f in sorted(output_dir.rglob("*")):
+        if not f.is_file():
+            continue
+        if f.suffix in (".md", ".html"):
+            media_items.append({"type": "document", "path": str(f)})
+        elif f.suffix == ".png":
+            media_items.append({"type": "photo", "path": str(f)})
+    if media_items:
+        _pending_media[chat_id] = _pending_media.get(chat_id, []) + media_items
+
+
+def _render_skill_result(chat_id: int, skill_key: str, result: dict) -> str:
+    """Turn a structured skill result into a chat reply."""
+    output_dir = Path(result["output_dir"]) if result.get("output_dir") else None
+    _queue_output_media(chat_id, output_dir)
+
+    raw_output = str(result.get("stdout", "") or "").strip()
+    report_text = str(result.get("report_md", "") or "").strip()
+    summary_lines = extract_chat_summary_lines(result)
+    actions = extract_action_offer(result)
+
+    if actions:
+        reply_parts: list[str] = []
+        if summary_lines:
+            reply_parts.append("\n".join(summary_lines))
+        elif report_text:
+            reply_parts.append(_trim_report_for_chat(report_text))
+        elif raw_output:
+            reply_parts.append(raw_output)
+        else:
+            reply_parts.append(f"{skill_key} completed.")
+        reply_parts.append(render_action_offer(actions))
+        rendered = "\n\n".join(part for part in reply_parts if part).strip()
+        _pending_actions[chat_id] = make_pending_action_entry(
+            skill=skill_key,
+            actions=actions,
+            source_summary=summary_lines,
+            source_output_dir=str(output_dir) if output_dir else None,
+        )
+        _audit(
+            "action_offer",
+            chat_id=chat_id,
+            skill=skill_key,
+            action_ids=[action.get("action_id") for action in actions],
+            output_dir=str(output_dir) if output_dir else None,
+        )
+        _pending_text.setdefault(chat_id, []).append(rendered)
+        return "Result sent directly to chat. Do not repeat or paraphrase it."
+
+    _pending_actions.pop(chat_id, None)
+
+    if skill_key in ("compare", "drugphoto", "profile"):
+        rendered = raw_output or report_text or f"{skill_key} completed."
+        if rendered:
+            _pending_text.setdefault(chat_id, []).append(rendered)
+        return "Result sent directly to chat. Do not repeat or paraphrase it."
+
+    if summary_lines:
+        return "\n".join(summary_lines)
+    if report_text:
+        return _trim_report_for_chat(report_text)
+    return raw_output if raw_output else f"{skill_key} completed. Output: {output_dir}"
+
+
 async def execute_clawbio(args: dict) -> str:
     """Execute a ClawBio bioinformatics skill via subprocess."""
     skill_key = args.get("skill", "auto")
@@ -453,6 +656,20 @@ async def execute_clawbio(args: dict) -> str:
     raw_user_text = args.get("_raw_user_text") or query or ""
     skill_registry = _SKILL_REGISTRY
     preplanned_plan = None
+    request_input_path: Path | None = None
+    request_payload = args.get("request")
+    if isinstance(request_payload, dict):
+        handle = tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            suffix=".json",
+            prefix="clawbio_request_",
+            delete=False,
+        )
+        with handle:
+            json.dump(request_payload, handle, indent=2, ensure_ascii=True)
+            handle.write("\n")
+        request_input_path = Path(handle.name)
 
     def _error(error_type: str, message: str, **details) -> str:
         clean_details = {k: v for k, v in details.items() if v is not None}
@@ -546,6 +763,8 @@ async def execute_clawbio(args: dict) -> str:
     if file_info:
         input_path = file_info.get("path")
         profile_path = file_info.get("profile_path")
+    if request_input_path is not None:
+        input_path = str(request_input_path)
 
     if mode == "file" and not input_path and not profile_path:
         # Fall back to owner's genome for admin users
@@ -659,81 +878,22 @@ async def execute_clawbio(args: dict) -> str:
 
     skill_key = executed_skills[-1] if executed_skills else skill_key
     stdout_str = "\n".join(part for part in stdout_parts if part)
+    stderr_str = "\n".join(part for part in stderr_parts if part)
     out_dir = output_dirs[-1] if output_dirs else OUTPUT_DIR / f"{skill_key}_{ts}"
 
-    # For compare / drugphoto / profile: send stdout directly (bypass LLM paraphrasing)
-    if any(item in ("compare", "drugphoto", "profile") for item in executed_skills):
-        raw_output = stdout_str.strip()
-        if raw_output:
-            chat_id = args.get("_chat_id")
-            if chat_id:
-                _pending_text.setdefault(chat_id, []).append(raw_output)
-        return "Result sent directly to chat. Do not repeat or paraphrase it."
-
-    # For other skills: collect report + figures from output directory
-    output_files = []
-    for bundle_dir in output_dirs:
-        if bundle_dir.exists():
-            output_files.extend(f.name for f in bundle_dir.rglob("*") if f.is_file())
-    output_files = sorted(output_files)
-
-    # Queue figures and reports for Telegram delivery
-    media_items = []
-    for bundle_dir in output_dirs:
-        if not bundle_dir.exists():
-            continue
-        for f in sorted(bundle_dir.rglob("*")):
-            if not f.is_file():
-                continue
-            if f.suffix in (".md", ".html"):
-                media_items.append({"type": "document", "path": str(f)})
-            elif f.suffix == ".png":
-                media_items.append({"type": "photo", "path": str(f)})
-    if media_items:
-        _pending_media[chat_id] = _pending_media.get(chat_id, []) + media_items
-
-    # Read report for chat display
-    report_text = ""
-    for bundle_dir in output_dirs:
-        if not bundle_dir.exists():
-            continue
-        for pattern in ["report.md", "*_report.md", "*.md"]:
-            for md_file in sorted(bundle_dir.glob(pattern)):
-                if md_file.name.startswith("."):
-                    continue
-                report_text = md_file.read_text(encoding="utf-8")
-                break
-            if report_text:
-                break
-        if report_text:
-            break
-
-    if not report_text:
-        return stdout_str if stdout_str else f"{skill_key} completed. Output: {out_dir}"
-
-    # Trim verbose sections for Telegram readability but ALWAYS keep disclaimer.
-    # Full report is preserved on disk at out_dir.
-    keep_lines = []
-    skip = False
-    for line in report_text.split("\n"):
-        if line.startswith("## Chromosome Breakdown"):
-            skip = True
-        elif line.startswith("## Ancestry Composition"):
-            skip = False
-        elif line.startswith("## Methods"):
-            skip = True
-        elif line.startswith("## About"):
-            skip = False
-        elif line.startswith("## Reproducibility"):
-            skip = True
-        elif line.startswith("## Disclaimer"):
-            skip = False  # always show disclaimer
-        if line.startswith("!["):
-            continue
-        if not skip:
-            keep_lines.append(line)
-
-    return "\n".join(keep_lines).strip()
+    result = _skill_result_from_output(
+        skill_name=skill_key,
+        stdout=stdout_str,
+        stderr=stderr_str,
+        exit_code=0,
+        output_dir=None if skill_key in ("compare", "drugphoto") else out_dir,
+    )
+    if request_input_path is not None:
+        try:
+            request_input_path.unlink()
+        except OSError:
+            pass
+    return _render_skill_result(chat_id or 0, skill_key, result)
 
 
 # --------------------------------------------------------------------------- #
@@ -1246,6 +1406,135 @@ async def send_long_message(update: Update, text: str):
             await update.message.reply_text(chunk)
 
 
+async def _maybe_handle_pending_action_reply(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    user_text: str,
+) -> bool:
+    """Handle confirmation/cancel replies for structured suggested actions."""
+    chat_id = update.effective_chat.id
+    pending = _pending_actions.get(chat_id)
+    if not pending:
+        if looks_like_action_followup(user_text):
+            await update.message.reply_text(
+                "I don't have a pending ClawBio action to run. "
+                "Please choose an action from the latest skill result, "
+                "or rerun that request first."
+            )
+            return True
+        return False
+
+    if is_pending_action_expired(pending):
+        _pending_actions.pop(chat_id, None)
+        _audit("action_offer_expired", chat_id=chat_id, skill=pending.get("skill"))
+        await update.message.reply_text(
+            "That earlier action offer has expired. Please rerun the skill request."
+        )
+        return True
+
+    actions = pending.get("actions", [])
+    selected_action = pending.get("selected_action")
+    if selected_action is not None:
+        if is_cancel_reply(user_text):
+            _pending_actions.pop(chat_id, None)
+            _audit("action_cancelled", chat_id=chat_id, skill=pending.get("skill"))
+            await update.message.reply_text("Okay -- I won't run that follow-up action.")
+            return True
+        parsed = parse_action_reply(user_text, [selected_action])
+        if parsed.get("kind") == "matched" and parsed.get("confirmed"):
+            action = selected_action
+        else:
+            await update.message.reply_text("Please reply `yes` to run it, or `cancel`.")
+            return True
+    else:
+        parsed = parse_action_reply(user_text, actions)
+        if parsed["kind"] == "none":
+            return False
+        if parsed["kind"] == "cancel":
+            _pending_actions.pop(chat_id, None)
+            _audit("action_cancelled", chat_id=chat_id, skill=pending.get("skill"))
+            await update.message.reply_text("Okay -- I won't run any of those follow-up actions.")
+            return True
+        if parsed["kind"] == "ambiguous":
+            await update.message.reply_text(
+                f"Which one would you like me to run: {choice_list_text(actions)}?"
+            )
+            return True
+        action = parsed["action"]
+        if action.get("requires_confirmation") is not False and not parsed.get("confirmed"):
+            pending["selected_action"] = action
+            _audit(
+                "action_confirmation_requested",
+                chat_id=chat_id,
+                skill=pending.get("skill"),
+                action_id=action.get("action_id"),
+            )
+            await update.message.reply_text(
+                f"Please confirm: run {action.get('label', 'that action')}? "
+                "Reply `yes` or `cancel`."
+            )
+            return True
+
+    action_id = action.get("action_id")
+    label = str(action.get("label") or action_id or "that action")
+    _pending_actions.pop(chat_id, None)
+    _audit(
+        "action_confirmed",
+        chat_id=chat_id,
+        skill=pending.get("skill"),
+        action_id=action_id,
+        label=label,
+    )
+
+    await update.message.reply_text(f"Running {label}...")
+    await context.bot.send_chat_action(chat_id=chat_id, action="typing")
+
+    try:
+        result = await asyncio.to_thread(
+            execute_stored_action,
+            pending,
+            action,
+            runner=_run_skill_local_sync,
+            output_root=OUTPUT_DIR,
+        )
+    except Exception as exc:
+        _audit(
+            "action_execute_error",
+            chat_id=chat_id,
+            skill=pending.get("skill"),
+            action_id=action_id,
+            error=str(exc)[:300],
+        )
+        await update.message.reply_text(
+            f"That follow-up action failed before it could start properly: {exc}"
+        )
+        return True
+
+    _audit(
+        "action_execute",
+        chat_id=chat_id,
+        skill=pending.get("skill"),
+        action_id=action_id,
+        success=bool(result.get("success")),
+        output_dir=result.get("output_dir"),
+    )
+
+    if result.get("success"):
+        reply = _render_skill_result(chat_id, str(pending.get("skill") or ""), result)
+    else:
+        err = str(result.get("stderr") or result.get("stdout") or "unknown error")
+        reply = (
+            f"{pending.get('skill', 'follow-up action')} failed "
+            f"(exit {result.get('exit_code', -1)}):\n{err[-1500:]}"
+        )
+    pending_text = _pending_text.pop(chat_id, None)
+    if pending_text:
+        reply = "\n\n".join(pending_text)
+    await send_long_message(update, reply)
+    await _drain_pending_media(update, context)
+    return True
+
+
 # --------------------------------------------------------------------------- #
 # Command handlers
 # --------------------------------------------------------------------------- #
@@ -1476,6 +1765,8 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
            text_len=len(user_text))
 
     try:
+        if await _maybe_handle_pending_action_reply(update, context, user_text):
+            return
         await context.bot.send_chat_action(
             chat_id=update.effective_chat.id, action="typing"
         )

--- a/bot/roboterri_discord.py
+++ b/bot/roboterri_discord.py
@@ -24,6 +24,7 @@ import logging
 import os
 import re
 import shutil
+import subprocess
 import sys
 import tempfile
 import time
@@ -51,6 +52,35 @@ from bot.tool_loop_utils import (
     synthetic_tool_result_messages,
     tool_error_content,
 )
+
+try:
+    from action_offers import (
+        choice_list_text,
+        execute_stored_action,
+        extract_action_offer,
+        extract_chat_summary_lines,
+        is_cancel_reply,
+        is_pending_action_expired,
+        load_bundle_fields,
+        looks_like_action_followup,
+        make_pending_action_entry,
+        parse_action_reply,
+        render_action_offer,
+    )
+except ImportError:  # pragma: no cover - package import fallback
+    from bot.action_offers import (
+        choice_list_text,
+        execute_stored_action,
+        extract_action_offer,
+        extract_chat_summary_lines,
+        is_cancel_reply,
+        is_pending_action_expired,
+        load_bundle_fields,
+        looks_like_action_followup,
+        make_pending_action_entry,
+        parse_action_reply,
+        render_action_offer,
+    )
 
 # --------------------------------------------------------------------------- #
 # Config
@@ -219,7 +249,7 @@ Operational constraints:
 3. When the user sends a genetic data file (23andMe .txt, AncestryDNA .csv, VCF, FASTQ) or asks about pharmacogenomics, nutrigenomics, equity scoring, metagenomics, or genome comparison, use the clawbio tool. When the user asks about disease risk, polygenic risk scores, or "what am I at risk for", use skill='prs'. For a unified profile report use skill='profile'. For gene-drug database lookups use skill='clinpgx'. For variant lookups (rsID, "look up rs...") use skill='gwas'. For quick demos say "run pharmgx demo", "run prs demo", "run profile demo" etc. Reports and figures are sent automatically after your summary.
 4. TOOL OUTPUT RELAY (STRICT): When the clawbio tool returns results, relay the output VERBATIM. Do not paraphrase, summarise, or rewrite tool results. Tool outputs contain precise data (IBS scores, percentages, gene-drug interactions) that must not be altered. You may add a brief intro line before the verbatim output but never replace or condense it.
 5. OWNER GENOME: The bot owner (admin) has their genome pre-loaded. When the admin asks about "my pharmacogenomics", "my risk", "my nutrition", "my genome", or similar personal queries WITHOUT uploading a file, use mode='file' - the system will automatically use the owner's genome. Do NOT ask the admin to upload a file.
-6. DEMO FALLBACK: When a non-admin user asks about pharmacogenomics, nutrigenomics, risk scores, or any skill that needs genetic data but has NOT uploaded a file, do NOT just ask for a file and stop. Instead, offer to run the demo with built-in synthetic data (mode='demo') so they can see the skill in action. Example: "I can run a demo with synthetic data so you can see what the report looks like - shall I go ahead?" If they agree (or if the request is clearly exploratory), run it immediately.
+6. DEMO FALLBACK: When a non-admin user asks about pharmacogenomics, nutrigenomics, risk scores, or any skill that needs genetic data but has NOT uploaded a file, do NOT just ask for a file and stop. Instead, offer to run the demo with built-in synthetic data (mode='demo') so they can see what the report looks like. Example: "I can run a demo with synthetic data so you can see what the report looks like - shall I go ahead?" If they agree (or if the request is clearly exploratory), run it immediately.
 """
 
 BASE_SYSTEM_PROMPT = f"{_soul}\n\n{ROLE_GUARDRAILS}"
@@ -243,8 +273,13 @@ _received_files: dict[int, dict] = {}
 # Pending media queue: channel_id -> list of {"type": "document"|"photo", "path": str}
 _pending_media: dict[int, list[dict]] = {}
 
-# Pending text queue: bypass LLM paraphrasing for compare/drugphoto
-_pending_text: list[str] = []
+# Pending text queue: bypass LLM paraphrasing when exact tool output must be
+# relayed. Keys are channel ids so channels do not mix direct replies.
+_pending_text: dict[int, list[str]] = {}
+
+# Pending suggested actions: channel_id -> stored offer bundle. Users can only
+# select one of these stored structured requests.
+_pending_actions: dict[int, dict] = {}
 
 # Per-user voice reply toggle: user_id -> bool
 _voice_enabled: dict[int, bool] = {}
@@ -357,6 +392,13 @@ TOOLS = [
                         "description": (
                             "rsID for GWAS variant lookup (e.g. 'rs3798220'). "
                             "Used with gwas skill."
+                        ),
+                    },
+                    "request": {
+                        "type": "object",
+                        "description": (
+                            "Structured nested request payload for skills that document "
+                            "a JSON request contract."
                         ),
                     },
                 },
@@ -511,6 +553,167 @@ def _validate_path(filepath: Path, allowed_root: Path) -> bool:
 # --------------------------------------------------------------------------- #
 
 
+def _run_skill_local_sync(
+    *,
+    skill_name: str,
+    input_path: str | None = None,
+    output_dir: str | None = None,
+    demo: bool = False,
+    extra_args: list[str] | None = None,
+    timeout: int = 300,
+    profile_path: str | None = None,
+) -> dict:
+    """Run a stored follow-up action through the same CLI path used by the bot."""
+    cmd = [sys.executable, str(CLAWBIO_PY), "run", skill_name]
+    if demo:
+        cmd.append("--demo")
+    elif profile_path:
+        cmd.extend(["--profile", profile_path])
+    elif input_path:
+        cmd.extend(["--input", str(input_path)])
+    if output_dir:
+        cmd.extend(["--output", str(output_dir)])
+    if extra_args:
+        cmd.extend(extra_args)
+
+    proc = subprocess.run(
+        cmd,
+        cwd=str(CLAWBIO_DIR),
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+    )
+    return _skill_result_from_output(
+        skill_name=skill_name,
+        stdout=proc.stdout,
+        stderr=proc.stderr,
+        exit_code=proc.returncode,
+        output_dir=output_dir,
+    )
+
+
+def _skill_result_from_output(
+    *,
+    skill_name: str,
+    stdout: str,
+    stderr: str,
+    exit_code: int,
+    output_dir: str | Path | None,
+) -> dict:
+    """Build the runner-like result shape consumed by the chat renderer."""
+    out_dir = Path(output_dir) if output_dir else None
+    files = (
+        sorted(str(f.relative_to(out_dir)) for f in out_dir.rglob("*") if f.is_file())
+        if out_dir and out_dir.exists()
+        else []
+    )
+    result = {
+        "skill": skill_name,
+        "success": exit_code == 0,
+        "exit_code": exit_code,
+        "output_dir": str(out_dir) if out_dir else None,
+        "files": files,
+        "stdout": stdout,
+        "stderr": stderr,
+    }
+    if exit_code == 0:
+        result.update(load_bundle_fields(out_dir))
+    return result
+
+
+def _trim_report_for_chat(report_text: str) -> str:
+    """Trim verbose report sections while keeping the disclaimer."""
+    keep_lines: list[str] = []
+    skip = False
+    for line in report_text.split("\n"):
+        if line.startswith("## Chromosome Breakdown"):
+            skip = True
+        elif line.startswith("## Ancestry Composition"):
+            skip = False
+        elif line.startswith("## Methods"):
+            skip = True
+        elif line.startswith("## About"):
+            skip = False
+        elif line.startswith("## Reproducibility"):
+            skip = True
+        elif line.startswith("## Disclaimer"):
+            skip = False
+        if line.startswith("!["):
+            continue
+        if not skip:
+            keep_lines.append(line)
+    return "\n".join(keep_lines).strip()
+
+
+def _queue_output_media(channel_id: int, output_dir: Path | None) -> None:
+    """Queue generated reports and figures for channel delivery."""
+    if output_dir is None or not output_dir.exists():
+        return
+    media_items: list[dict[str, str]] = []
+    for f in sorted(output_dir.rglob("*")):
+        if not f.is_file():
+            continue
+        if f.suffix in (".md", ".html"):
+            media_items.append({"type": "document", "path": str(f)})
+        elif f.suffix == ".png":
+            media_items.append({"type": "photo", "path": str(f)})
+    if media_items:
+        _pending_media[channel_id] = _pending_media.get(channel_id, []) + media_items
+
+
+def _render_skill_result(channel_id: int, skill_key: str, result: dict) -> str:
+    """Turn a structured skill result into a Discord reply."""
+    output_dir = Path(result["output_dir"]) if result.get("output_dir") else None
+    _queue_output_media(channel_id, output_dir)
+
+    raw_output = str(result.get("stdout", "") or "").strip()
+    report_text = str(result.get("report_md", "") or "").strip()
+    summary_lines = extract_chat_summary_lines(result)
+    actions = extract_action_offer(result)
+
+    if actions:
+        reply_parts: list[str] = []
+        if summary_lines:
+            reply_parts.append("\n".join(summary_lines))
+        elif report_text:
+            reply_parts.append(_trim_report_for_chat(report_text))
+        elif raw_output:
+            reply_parts.append(raw_output)
+        else:
+            reply_parts.append(f"{skill_key} completed.")
+        reply_parts.append(render_action_offer(actions))
+        rendered = "\n\n".join(part for part in reply_parts if part).strip()
+        _pending_actions[channel_id] = make_pending_action_entry(
+            skill=skill_key,
+            actions=actions,
+            source_summary=summary_lines,
+            source_output_dir=str(output_dir) if output_dir else None,
+        )
+        _audit(
+            "action_offer",
+            channel_id=channel_id,
+            skill=skill_key,
+            action_ids=[action.get("action_id") for action in actions],
+            output_dir=str(output_dir) if output_dir else None,
+        )
+        _pending_text.setdefault(channel_id, []).append(rendered)
+        return "Result sent directly to chat. Do not repeat or paraphrase it."
+
+    _pending_actions.pop(channel_id, None)
+
+    if skill_key in ("compare", "drugphoto", "profile"):
+        rendered = raw_output or report_text or f"{skill_key} completed."
+        if rendered:
+            _pending_text.setdefault(channel_id, []).append(rendered)
+        return "Result sent directly to chat. Do not repeat or paraphrase it."
+
+    if summary_lines:
+        return "\n".join(summary_lines)
+    if report_text:
+        return _trim_report_for_chat(report_text)
+    return raw_output if raw_output else f"{skill_key} completed. Output: {output_dir}"
+
+
 async def execute_clawbio(args: dict) -> str:
     """Execute a ClawBio bioinformatics skill via subprocess."""
     skill_key = args.get("skill", "auto")
@@ -519,6 +722,21 @@ async def execute_clawbio(args: dict) -> str:
     raw_user_text = args.get("_raw_user_text") or query or ""
     skill_registry = _SKILL_REGISTRY
     preplanned_plan = None
+    channel_id = args.get("_channel_id")
+    request_input_path: Path | None = None
+    request_payload = args.get("request")
+    if isinstance(request_payload, dict):
+        handle = tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            suffix=".json",
+            prefix="clawbio_request_",
+            delete=False,
+        )
+        with handle:
+            json.dump(request_payload, handle, indent=2, ensure_ascii=True)
+            handle.write("\n")
+        request_input_path = Path(handle.name)
 
     def _error(error_type: str, message: str, **details) -> str:
         clean_details = {k: v for k, v in details.items() if v is not None}
@@ -555,9 +773,9 @@ async def execute_clawbio(args: dict) -> str:
 
             orch_input = query
             if mode == "file":
-                for _cid, info in _received_files.items():
-                    orch_input = info["path"]
-                    break
+                file_info = _received_files.get(channel_id) if channel_id else next(iter(_received_files.values()), None)
+                if file_info:
+                    orch_input = file_info["path"]
             if not orch_input:
                 return _error("missing_input", "skill='auto' requires either a file or a query to route.")
 
@@ -606,10 +824,12 @@ async def execute_clawbio(args: dict) -> str:
     # Resolve input and profile for file mode
     input_path = None
     profile_path = None
-    for _cid, info in _received_files.items():
-        input_path = info.get("path")
-        profile_path = info.get("profile_path")
-        break
+    file_info = _received_files.get(channel_id) if channel_id else next(iter(_received_files.values()), None)
+    if file_info:
+        input_path = file_info.get("path")
+        profile_path = file_info.get("profile_path")
+    if request_input_path is not None:
+        input_path = str(request_input_path)
 
     if mode == "file" and not input_path and not profile_path:
         # Fall back to owner's genome for admin users
@@ -666,6 +886,7 @@ async def execute_clawbio(args: dict) -> str:
 
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")
     stdout_parts = []
+    stderr_parts = []
     output_dirs: list[Path] = []
     executed_skills: list[str] = []
 
@@ -710,6 +931,7 @@ async def execute_clawbio(args: dict) -> str:
             return _error("skill_exception", f"{run_skill} crashed:\n{_tb.format_exc()[-1500:]}", selected_skill=run_skill)
 
         stdout_parts.append(stdout_str)
+        stderr_parts.append(stderr_str)
         if proc.returncode != 0:
             err = stderr_str[-1500:] if stderr_str else stdout_str[-1500:] if stdout_str else "unknown error"
             return _error(
@@ -721,71 +943,22 @@ async def execute_clawbio(args: dict) -> str:
 
     skill_key = executed_skills[-1] if executed_skills else skill_key
     stdout_str = "\n".join(part for part in stdout_parts if part)
+    stderr_str = "\n".join(part for part in stderr_parts if part)
     out_dir = output_dirs[-1] if output_dirs else OUTPUT_DIR / f"{skill_key}_{ts}"
 
-    # For compare / drugphoto / profile: send stdout directly (bypass LLM paraphrasing)
-    if any(item in ("compare", "drugphoto", "profile") for item in executed_skills):
-        raw_output = stdout_str.strip()
-        if raw_output:
-            _pending_text.append(raw_output)
-        return "Result sent directly to chat. Do not repeat or paraphrase it."
-
-    # For other skills: collect report + figures from output directory
-    media_items = []
-    for bundle_dir in output_dirs:
-        if not bundle_dir.exists():
-            continue
-        for f in sorted(bundle_dir.rglob("*")):
-            if not f.is_file():
-                continue
-            if f.suffix == ".md":
-                media_items.append({"type": "document", "path": str(f)})
-            elif f.suffix == ".png":
-                media_items.append({"type": "photo", "path": str(f)})
-    if media_items:
-        _pending_media[0] = _pending_media.get(0, []) + media_items
-
-    # Read report for chat display
-    report_text = ""
-    for bundle_dir in output_dirs:
-        if not bundle_dir.exists():
-            continue
-        for pattern in ["report.md", "*_report.md", "*.md"]:
-            for md_file in sorted(bundle_dir.glob(pattern)):
-                if md_file.name.startswith("."):
-                    continue
-                report_text = md_file.read_text(encoding="utf-8")
-                break
-            if report_text:
-                break
-        if report_text:
-            break
-
-    if not report_text:
-        return stdout_str if stdout_str else f"{skill_key} completed. Output: {out_dir}"
-
-    # Trim verbose sections for readability but ALWAYS keep disclaimer.
-    keep_lines = []
-    skip = False
-    for line in report_text.split("\n"):
-        if line.startswith("## Chromosome Breakdown"):
-            skip = True
-        elif line.startswith("## Ancestry Composition"):
-            skip = False
-        elif line.startswith("## Methods"):
-            skip = True
-        elif line.startswith("## About"):
-            skip = False
-        elif line.startswith("## Reproducibility"):
-            skip = True
-        elif line.startswith("## Disclaimer"):
-            skip = False  # always show disclaimer
-        if line.startswith("!["):
-            continue
-        if not skip:
-            keep_lines.append(line)
-
-    return "\n".join(keep_lines).strip()
+    result = _skill_result_from_output(
+        skill_name=skill_key,
+        stdout=stdout_str,
+        stderr=stderr_str,
+        exit_code=0,
+        output_dir=None if skill_key in ("compare", "drugphoto") else out_dir,
+    )
+    if request_input_path is not None:
+        try:
+            request_input_path.unlink()
+        except OSError:
+            pass
+    return _render_skill_result(int(channel_id or 0), skill_key, result)
 
 
 # --------------------------------------------------------------------------- #
@@ -1170,7 +1343,8 @@ async def send_long_message(channel: discord.abc.Messageable, text: str):
 
 async def drain_pending_media(channel: discord.abc.Messageable) -> None:
     """Send any queued ClawBio media (documents + figures) after the text reply."""
-    items = _pending_media.pop(0, [])
+    channel_id = getattr(channel, "id", 0)
+    items = _pending_media.pop(channel_id, [])
     if not items:
         return
     for item in items:
@@ -1185,6 +1359,133 @@ async def drain_pending_media(channel: discord.abc.Messageable) -> None:
             )
         except Exception as e:
             logger.warning(f"Failed to send media {item['path']}: {e}")
+
+
+async def _maybe_handle_pending_action_reply(
+    message: discord.Message,
+    user_text: str,
+) -> bool:
+    """Handle confirmation/cancel replies for structured suggested actions."""
+    channel_id = message.channel.id
+    pending = _pending_actions.get(channel_id)
+    if not pending:
+        if looks_like_action_followup(user_text):
+            await message.channel.send(
+                "I don't have a pending ClawBio action to run. "
+                "Please choose an action from the latest skill result, "
+                "or rerun that request first."
+            )
+            return True
+        return False
+
+    if is_pending_action_expired(pending):
+        _pending_actions.pop(channel_id, None)
+        _audit("action_offer_expired", channel_id=channel_id, skill=pending.get("skill"))
+        await message.channel.send(
+            "That earlier action offer has expired. Please rerun the skill request."
+        )
+        return True
+
+    actions = pending.get("actions", [])
+    selected_action = pending.get("selected_action")
+    if selected_action is not None:
+        if is_cancel_reply(user_text):
+            _pending_actions.pop(channel_id, None)
+            _audit("action_cancelled", channel_id=channel_id, skill=pending.get("skill"))
+            await message.channel.send("Okay -- I won't run that follow-up action.")
+            return True
+        parsed = parse_action_reply(user_text, [selected_action])
+        if parsed.get("kind") == "matched" and parsed.get("confirmed"):
+            action = selected_action
+        else:
+            await message.channel.send("Please reply `yes` to run it, or `cancel`.")
+            return True
+    else:
+        parsed = parse_action_reply(user_text, actions)
+        if parsed["kind"] == "none":
+            return False
+        if parsed["kind"] == "cancel":
+            _pending_actions.pop(channel_id, None)
+            _audit("action_cancelled", channel_id=channel_id, skill=pending.get("skill"))
+            await message.channel.send("Okay -- I won't run any of those follow-up actions.")
+            return True
+        if parsed["kind"] == "ambiguous":
+            await message.channel.send(
+                f"Which one would you like me to run: {choice_list_text(actions)}?"
+            )
+            return True
+        action = parsed["action"]
+        if action.get("requires_confirmation") is not False and not parsed.get("confirmed"):
+            pending["selected_action"] = action
+            _audit(
+                "action_confirmation_requested",
+                channel_id=channel_id,
+                skill=pending.get("skill"),
+                action_id=action.get("action_id"),
+            )
+            await message.channel.send(
+                f"Please confirm: run {action.get('label', 'that action')}? "
+                "Reply `yes` or `cancel`."
+            )
+            return True
+
+    action_id = action.get("action_id")
+    label = str(action.get("label") or action_id or "that action")
+    _pending_actions.pop(channel_id, None)
+    _audit(
+        "action_confirmed",
+        channel_id=channel_id,
+        skill=pending.get("skill"),
+        action_id=action_id,
+        label=label,
+    )
+
+    await message.channel.send(f"Running {label}...")
+
+    try:
+        result = await asyncio.to_thread(
+            execute_stored_action,
+            pending,
+            action,
+            runner=_run_skill_local_sync,
+            output_root=OUTPUT_DIR,
+        )
+    except Exception as exc:
+        _audit(
+            "action_execute_error",
+            channel_id=channel_id,
+            skill=pending.get("skill"),
+            action_id=action_id,
+            error=str(exc)[:300],
+        )
+        await message.channel.send(
+            f"That follow-up action failed before it could start properly: {exc}"
+        )
+        return True
+
+    _audit(
+        "action_execute",
+        channel_id=channel_id,
+        skill=pending.get("skill"),
+        action_id=action_id,
+        success=bool(result.get("success")),
+        output_dir=result.get("output_dir"),
+    )
+
+    if result.get("success"):
+        reply = _render_skill_result(channel_id, str(pending.get("skill") or ""), result)
+    else:
+        err = str(result.get("stderr") or result.get("stdout") or "unknown error")
+        reply = (
+            f"{pending.get('skill', 'follow-up action')} failed "
+            f"(exit {result.get('exit_code', -1)}):\n{err[-1500:]}"
+        )
+    pending_text = _pending_text.pop(channel_id, None)
+    if pending_text:
+        reply = "\n\n".join(pending_text)
+    await send_long_message(message.channel, reply)
+    await drain_pending_media(message.channel)
+    return True
 
 
 # --------------------------------------------------------------------------- #
@@ -1410,9 +1711,9 @@ async def on_message(message: discord.Message):
                     message.channel.id,
                     f"Run the {skill} demo using the clawbio tool with mode='demo'.",
                 )
-                if _pending_text:
-                    reply = "\n\n".join(_pending_text)
-                    _pending_text.clear()
+                pending_text = _pending_text.pop(message.channel.id, None)
+                if pending_text:
+                    reply = "\n\n".join(pending_text)
                 await send_long_message(message.channel, reply)
                 await drain_pending_media(message.channel)
                 # Voice reply if toggled on
@@ -1502,9 +1803,9 @@ async def on_message(message: discord.Message):
             async with message.channel.typing():
                 try:
                     reply = await llm_tool_loop(message.channel.id, content_blocks)
-                    if _pending_text:
-                        reply = "\n\n".join(_pending_text)
-                        _pending_text.clear()
+                    pending_text = _pending_text.pop(message.channel.id, None)
+                    if pending_text:
+                        reply = "\n\n".join(pending_text)
                     await send_long_message(message.channel, reply)
                     # Voice reply if toggled on
                     if _voice_enabled.get(message.author.id):
@@ -1602,9 +1903,9 @@ async def on_message(message: discord.Message):
                     reply = await llm_tool_loop(
                         message.channel.id, "\n\n".join(parts_list)
                     )
-                    if _pending_text:
-                        reply = "\n\n".join(_pending_text)
-                        _pending_text.clear()
+                    pending_text = _pending_text.pop(message.channel.id, None)
+                    if pending_text:
+                        reply = "\n\n".join(pending_text)
                     await send_long_message(message.channel, reply)
                     await drain_pending_media(message.channel)
                     # Voice reply if toggled on
@@ -1647,10 +1948,12 @@ async def on_message(message: discord.Message):
 
     async with message.channel.typing():
         try:
+            if await _maybe_handle_pending_action_reply(message, user_text):
+                return
             reply = await llm_tool_loop(message.channel.id, user_text)
-            if _pending_text:
-                reply = "\n\n".join(_pending_text)
-                _pending_text.clear()
+            pending_text = _pending_text.pop(message.channel.id, None)
+            if pending_text:
+                reply = "\n\n".join(pending_text)
             await send_long_message(message.channel, reply)
             await drain_pending_media(message.channel)
             # Voice reply if toggled on

--- a/clawbio.py
+++ b/clawbio.py
@@ -710,6 +710,67 @@ def upload_profile(
 # --------------------------------------------------------------------------- #
 
 
+def _load_structured_skill_result(out_dir: Path | None) -> tuple[dict | None, Path | None]:
+    """Load a skill's result.json envelope when present and valid."""
+    if out_dir is None:
+        return None, None
+    result_json_path = out_dir / "result.json"
+    if not result_json_path.exists():
+        return None, None
+    try:
+        payload = json.loads(result_json_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None, result_json_path
+    if not isinstance(payload, dict):
+        return None, result_json_path
+    return payload, result_json_path
+
+
+def _load_report_markdown(out_dir: Path | None) -> str | None:
+    """Read the primary markdown report from an output bundle when present."""
+    if out_dir is None or not out_dir.exists():
+        return None
+    for pattern in ("report.md", "*_report.md", "*.md"):
+        for md_file in sorted(out_dir.glob(pattern)):
+            if md_file.name.startswith("."):
+                continue
+            try:
+                return md_file.read_text(encoding="utf-8")
+            except OSError:
+                continue
+    return None
+
+
+def _promote_structured_result_fields(result: dict, out_dir: Path | None) -> None:
+    """Attach parsed result.json fields to the top-level run result."""
+    payload, result_json_path = _load_structured_skill_result(out_dir)
+    if payload is not None:
+        result["skill_result_json"] = payload
+    if result_json_path is not None:
+        result["result_json_path"] = str(result_json_path)
+
+    if isinstance(payload, dict):
+        # Structured result fields form the small skill-to-ClawBio display and
+        # action contract:
+        # - chat_summary_lines: concise, skill-authored text for chat UIs
+        # - preferred_artifacts: generated files the UI should surface first
+        # - suggested_actions: deterministic next-step requests to offer later
+        # - report_md: full markdown report text embedded in result.json
+        for field in (
+            "chat_summary_lines",
+            "preferred_artifacts",
+            "suggested_actions",
+            "report_md",
+        ):
+            if field in payload:
+                result[field] = payload[field]
+
+    if "report_md" not in result:
+        report_md = _load_report_markdown(out_dir)
+        if report_md is not None:
+            result["report_md"] = report_md
+
+
 def run_skill(
     skill_name: str,
     input_path: str | None = None,
@@ -891,6 +952,9 @@ def run_skill(
         "stderr": proc.stderr,
         "duration_seconds": duration,
     }
+
+    if result["success"]:
+        _promote_structured_result_fields(result, out_dir)
 
     # If profile was used, store the result back into it
     if profile_path and result["success"] and out_dir:

--- a/skills/affinity-proteomics/SKILL.md
+++ b/skills/affinity-proteomics/SKILL.md
@@ -72,6 +72,7 @@ You are **Affinity Proteomics**, a specialised ClawBio agent for Olink and SomaL
 3. **Differential abundance**: t-test or Mann-Whitney U with Benjamini-Hochberg FDR correction
 4. **Visualisation**: Volcano plot, heatmap (top N proteins), PCA plot
 5. **Structured reporting**: Markdown report, result.json, per-protein TSV, reproducibility bundle
+6. **Skill Action Menu**: `result.json` includes one read-only follow-up action for the top proteins table
 
 ## Input Formats
 
@@ -108,6 +109,35 @@ python clawbio.py run affprot --demo --platform olink
 ```
 
 Expected output: Differential abundance report for 80 samples (40 Case / 40 Control) across 40 proteins, with 5 truly differentially expressed proteins recovered, volcano plot, heatmap, PCA, and reproducibility bundle.
+
+## Output Structure
+
+- `report.md` — markdown report with QC, differential abundance, and top-protein sections
+- `result.json` — structured summary with `chat_summary_lines`, `preferred_artifacts`, and one `suggested_actions` entry
+- `tables/diff_abundance.tsv` — per-protein differential abundance table
+- `figures/volcano.png`, `figures/heatmap.png`, `figures/pca.png` — standard demo figures
+- `reproducibility/` — command and software-version metadata
+
+## Suggested Actions
+
+The demo result offers a single read-only `Top Proteins` action. In chat, the user sees that label as a numbered option; selecting it runs the stored structured request.
+
+```json
+{
+  "action_id": "show-top-proteins",
+  "label": "Top Proteins",
+  "request": {
+    "schema": "affinity_proteomics.action_request.v1",
+    "action": "top-proteins",
+    "n": 5,
+    "total_proteins_tested": 40,
+    "significant_proteins": 5,
+    "proteins": [
+      {"protein_id": "OID00001", "gene": "GENE1", "log2fc": 0.0, "padj": "0.00e+00"}
+    ]
+  }
+}
+```
 
 ## Dependencies
 

--- a/skills/affinity-proteomics/affinity_proteomics.py
+++ b/skills/affinity-proteomics/affinity_proteomics.py
@@ -42,6 +42,9 @@ DISCLAIMER = (
     "professional before making any medical decisions."
 )
 
+ACTION_REQUEST_SCHEMA = "affinity_proteomics.action_request.v1"
+ACTION_RESULT_SCHEMA = "affinity_proteomics.action_result.v1"
+
 
 # ---------------------------------------------------------------------------
 # Data structures
@@ -506,9 +509,129 @@ def _write_result_json(data, results, contrast, output_dir, timestamp, demo):
              "padj": f"{r.padj:.2e}"}
             for r in results[:10]
         ],
+        "chat_summary_lines": [
+            (
+                f"Affinity proteomics {'demo' if demo else 'analysis'} complete: "
+                f"{len(data.expression)} samples, {data.expression.shape[1]} proteins, "
+                f"{len(sig)} significant proteins."
+            ),
+            "Choose a small report card below for a read-only follow-up.",
+        ],
+        "preferred_artifacts": _artifact_entries(output_dir),
+        "suggested_actions": _build_suggested_actions(results),
         "disclaimer": DISCLAIMER,
     }
     (output_dir / "result.json").write_text(json.dumps(result, indent=2), encoding="utf-8")
+
+
+def _artifact_entries(output_dir: Path) -> list[dict[str, str]]:
+    labels = {
+        "report.md": "Markdown report",
+        "tables/diff_abundance.tsv": "Differential abundance table",
+        "figures/volcano.png": "Volcano plot",
+        "figures/heatmap.png": "Heatmap",
+        "figures/pca.png": "PCA plot",
+        "result.json": "Structured result JSON",
+    }
+    entries: list[dict[str, str]] = []
+    for rel_path, label in labels.items():
+        if (output_dir / rel_path).exists():
+            entries.append({"path": rel_path, "label": label})
+    return entries
+
+
+def _build_suggested_actions(results: list[DiffAbundanceResult]) -> list[dict]:
+    """Return the minimal demo follow-up for the Skill Action Menu."""
+    sig = [r for r in results if r.significant]
+    # Keep the teaching example compact: the request carries structured rows,
+    # and the follow-up handler renders the requested slice.
+    top_proteins = [
+        {
+            "protein_id": r.protein_id,
+            "gene": r.gene_symbol,
+            "log2fc": round(r.log2fc, 4),
+            "padj": f"{r.padj:.2e}",
+        }
+        for r in results[:10]
+    ]
+
+    return [
+        {
+            "action_id": "show-top-proteins",
+            "label": "Top Proteins",
+            "kind": "navigation",
+            "request": {
+                "schema": ACTION_REQUEST_SCHEMA,
+                "action": "top-proteins",
+                "n": 5,
+                "total_proteins_tested": len(results),
+                "significant_proteins": len(sig),
+                "proteins": top_proteins,
+            },
+            "requires_confirmation": False,
+            "expected_artifacts": ["report.md"],
+        }
+    ]
+
+
+def _load_action_request(input_path: Path) -> dict | None:
+    if input_path.suffix.lower() != ".json":
+        return None
+    try:
+        payload = json.loads(input_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if isinstance(payload, dict) and payload.get("schema") == ACTION_REQUEST_SCHEMA:
+        return payload
+    return None
+
+
+def handle_action_request(request: dict, output_dir: Path) -> dict:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if request.get("action") != "top-proteins":
+        raise ValueError(f"Unsupported action request: {request.get('action')}")
+    proteins = request.get("proteins")
+    if not isinstance(proteins, list):
+        raise ValueError("top-proteins request is missing proteins")
+    try:
+        n = max(1, int(request.get("n", 5)))
+    except (TypeError, ValueError):
+        n = 5
+
+    selected = [protein for protein in proteins[:n] if isinstance(protein, dict)]
+    rows = [
+        "| Protein | Gene | log2FC | Adj P |",
+        "|---------|------|--------|-------|",
+    ]
+    for protein in selected:
+        rows.append(
+            "| {protein_id} | {gene} | {log2fc} | {padj} |".format(
+                protein_id=protein.get("protein_id", ""),
+                gene=protein.get("gene", ""),
+                log2fc=protein.get("log2fc", ""),
+                padj=protein.get("padj", ""),
+            )
+        )
+    total_tested = request.get("total_proteins_tested", len(proteins))
+    significant = request.get("significant_proteins", "")
+    report_md = "# Affinity Proteomics Follow-up\n\n## Top Proteins\n\n" + "\n".join(rows) + "\n"
+    summary_lines = [
+        f"Showing top {len(selected)} proteins from {total_tested} tested; "
+        f"{significant} met significance thresholds."
+    ]
+    preferred_artifacts = [{"path": "report.md", "label": "Follow-up report"}]
+    (output_dir / "report.md").write_text(report_md, encoding="utf-8")
+    result = {
+        "schema": ACTION_RESULT_SCHEMA,
+        "source_schema": ACTION_REQUEST_SCHEMA,
+        "action": "top-proteins",
+        "chat_summary_lines": summary_lines,
+        "preferred_artifacts": preferred_artifacts,
+        "report_md": report_md,
+        "disclaimer": DISCLAIMER,
+    }
+    (output_dir / "result.json").write_text(json.dumps(result, indent=2), encoding="utf-8")
+    return result
 
 
 def _write_reproducibility(output_dir, timestamp, platform, demo):
@@ -613,6 +736,15 @@ def main() -> None:
     if not args.output:
         parser.error("--output is required")
 
+    output_dir = Path(args.output)
+    if args.input:
+        # Action requests are follow-up cards; dispatch them before the full pipeline.
+        action_request = _load_action_request(Path(args.input))
+        if action_request is not None:
+            handle_action_request(action_request, output_dir)
+            print(f"[PROT] Follow-up written to: {output_dir / 'report.md'}")
+            return
+
     contrast = tuple(args.contrast.split(","))
     if len(contrast) != 2:
         parser.error("--contrast must be two comma-separated group names")
@@ -637,7 +769,6 @@ def main() -> None:
         meta_path = Path(args.meta) if args.meta else None
         group_col = args.group_col
 
-    output_dir = Path(args.output)
     print(f"[PROT] Starting {platform.upper()} pipeline ({'demo' if args.demo else 'live'} mode)")
 
     summary = run_pipeline(

--- a/skills/affinity-proteomics/tests/test_affinity_proteomics.py
+++ b/skills/affinity-proteomics/tests/test_affinity_proteomics.py
@@ -16,10 +16,12 @@ SKILL_DIR = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(SKILL_DIR))
 
 from affinity_proteomics import (
+    ACTION_REQUEST_SCHEMA,
     DiffAbundanceResult,
     ProteomicsData,
     differential_abundance,
     generate_report,
+    handle_action_request,
     parse_olink_npx,
     run_pipeline,
 )
@@ -181,6 +183,39 @@ class TestOlinkDemo:
         result = json.loads((tmp_path / "result.json").read_text())
         assert result["platform"] == "olink"
         assert result["total_proteins_tested"] == 40
+        assert result["chat_summary_lines"][0].startswith("Affinity proteomics demo complete")
+        assert {action["action_id"] for action in result["suggested_actions"]} == {
+            "show-top-proteins",
+        }
+        assert all(action["request"]["schema"] == ACTION_REQUEST_SCHEMA for action in result["suggested_actions"])
+        assert all(action["request"]["action"] == "top-proteins" for action in result["suggested_actions"])
+        assert result["suggested_actions"][0]["request"]["n"] == 5
+        assert len(result["suggested_actions"][0]["request"]["proteins"]) == 10
+        assert {"path": "report.md", "label": "Markdown report"} in result["preferred_artifacts"]
+
+    def test_action_request_renders_report_section(self, tmp_path):
+        source_dir = tmp_path / "source"
+        run_pipeline(
+            platform="olink", input_path=SKILL_DIR / "example_data" / "olink_demo_npx.csv",
+            meta_path=SKILL_DIR / "example_data" / "olink_demo_meta.csv",
+            group_col="Group", contrast=("Case", "Control"),
+            output_dir=source_dir, demo=True,
+        )
+        source_result = json.loads((source_dir / "result.json").read_text())
+        action = next(
+            action for action in source_result["suggested_actions"]
+            if action["action_id"] == "show-top-proteins"
+        )
+
+        output_dir = tmp_path / "followup"
+        result = handle_action_request(action["request"], output_dir)
+
+        assert (output_dir / "report.md").exists()
+        assert (output_dir / "result.json").exists()
+        assert result["schema"] == "affinity_proteomics.action_result.v1"
+        assert result["action"] == "top-proteins"
+        assert "## Top Proteins" in result["report_md"]
+        assert any("Showing top 5 proteins" in line for line in result["chat_summary_lines"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_action_offers.py
+++ b/tests/test_action_offers.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from bot.action_offers import (
+    execute_stored_action,
+    extract_action_offer,
+    is_pending_action_expired,
+    load_bundle_fields,
+    make_pending_action_entry,
+    parse_action_reply,
+    render_action_offer,
+)
+
+
+def _demo_actions() -> list[dict]:
+    return [
+        {
+            "action_id": "show-demo-report",
+            "label": "Show demo report",
+            "kind": "navigation",
+            "shell_line": "example unsafe text that should not be executed",
+            "request": {
+                "schema": "example.skill_request.v1",
+                "mode": "report",
+                "report_id": "demo",
+            },
+            "requires_confirmation": False,
+            "timeout_secs": 123,
+            "expected_artifacts": ["report.md"],
+        },
+        {
+            "action_id": "prepare-resource",
+            "label": "Prepare local resource",
+            "kind": "request",
+            "request": {
+                "schema": "example.skill_request.v1",
+                "mode": "prepare",
+                "resource": "demo",
+            },
+            "requires_confirmation": True,
+        },
+    ]
+
+
+def test_render_action_offer_lists_choices_and_safe_refresh_hint():
+    rendered = render_action_offer(_demo_actions())
+    assert "I can do the next step for you:" in rendered
+    assert "1. Show demo report (safe refresh)" in rendered
+    assert "2. Prepare local resource" in rendered
+    assert "Reply with `1`, `2`" in rendered
+
+
+def test_extract_action_offer_requires_structured_request():
+    actions = _demo_actions() + [
+        {
+            "action_id": "shell-only",
+            "label": "Do not offer shell-only action",
+            "shell_line": "example unsafe text that should not be executed",
+        }
+    ]
+    assert extract_action_offer({"suggested_actions": actions}) == _demo_actions()
+
+
+def test_parse_action_reply_matches_numeric_choice_without_confirming():
+    parsed = parse_action_reply("1", _demo_actions())
+    assert parsed["kind"] == "matched"
+    assert parsed["action"]["action_id"] == "show-demo-report"
+    assert parsed["confirmed"] is False
+
+
+def test_parse_action_reply_matches_yes_with_index_as_confirmed():
+    parsed = parse_action_reply("yes 2", _demo_actions())
+    assert parsed["kind"] == "matched"
+    assert parsed["action"]["action_id"] == "prepare-resource"
+    assert parsed["confirmed"] is True
+
+
+def test_parse_action_reply_matches_yes_with_single_action_as_confirmed():
+    parsed = parse_action_reply("please show me", [_demo_actions()[0]])
+    assert parsed["kind"] == "matched"
+    assert parsed["action"]["action_id"] == "show-demo-report"
+    assert parsed["confirmed"] is True
+
+
+def test_parse_action_reply_marks_plain_show_me_ambiguous_for_multiple_actions():
+    parsed = parse_action_reply("please show me", _demo_actions())
+    assert parsed["kind"] == "ambiguous"
+
+
+def test_parse_action_reply_matches_exact_label():
+    parsed = parse_action_reply("Prepare local resource", _demo_actions())
+    assert parsed["kind"] == "matched"
+    assert parsed["action"]["action_id"] == "prepare-resource"
+
+
+def test_parse_action_reply_does_not_match_generic_single_word_fragment():
+    actions = [
+        {
+            "action_id": "show-guide",
+            "label": "Show guide",
+            "request": {
+                "schema": "example.skill_request.v1",
+                "mode": "guide",
+            },
+        }
+    ]
+
+    assert parse_action_reply("show", actions)["kind"] == "none"
+
+
+def test_parse_action_reply_handles_cancel():
+    parsed = parse_action_reply("never mind", _demo_actions())
+    assert parsed["kind"] == "cancel"
+
+
+def test_pending_action_entry_expires_after_ttl():
+    entry = make_pending_action_entry(
+        skill="example-actions",
+        actions=_demo_actions(),
+        timestamp=100.0,
+    )
+    assert is_pending_action_expired(entry, now_ts=130.0, ttl_seconds=60) is False
+    assert is_pending_action_expired(entry, now_ts=161.0, ttl_seconds=60) is True
+
+
+def test_execute_stored_action_materializes_request_and_uses_runner(tmp_path: Path):
+    pending = make_pending_action_entry(
+        skill="example-actions",
+        actions=_demo_actions(),
+    )
+    action = _demo_actions()[0]
+    captured: dict[str, object] = {}
+
+    def fake_runner(**kwargs):
+        captured.update(kwargs)
+        request_path = Path(str(kwargs["input_path"]))
+        captured["request_payload"] = json.loads(request_path.read_text(encoding="utf-8"))
+        return {"success": True, "output_dir": str(kwargs["output_dir"])}
+
+    result = execute_stored_action(
+        pending,
+        action,
+        runner=fake_runner,
+        output_root=tmp_path,
+    )
+
+    assert result["success"] is True
+    assert captured["skill_name"] == "example-actions"
+    assert captured["demo"] is False
+    assert captured["timeout"] == 123
+    assert captured["request_payload"] == action["request"]
+    assert str(captured["output_dir"]).startswith(str(tmp_path / "example-actions_"))
+
+
+def test_load_bundle_fields_promotes_structured_chat_fields(tmp_path: Path):
+    payload = {
+        "chat_summary_lines": ["The skill found one follow-up action."],
+        "suggested_actions": _demo_actions(),
+        "preferred_artifacts": [{"path": "generated/demo.png"}],
+        "report_md": "# Embedded report\n",
+    }
+    (tmp_path / "result.json").write_text(
+        json.dumps(payload, indent=2),
+        encoding="utf-8",
+    )
+    (tmp_path / "report.md").write_text("# Fallback report\n", encoding="utf-8")
+
+    fields = load_bundle_fields(tmp_path)
+
+    assert fields["skill_result_json"] == payload
+    assert fields["chat_summary_lines"] == ["The skill found one follow-up action."]
+    assert fields["suggested_actions"] == _demo_actions()
+    assert fields["preferred_artifacts"] == [{"path": "generated/demo.png"}]
+    assert fields["report_md"] == "# Embedded report\n"

--- a/tests/test_clawbio_runner_actions.py
+++ b/tests/test_clawbio_runner_actions.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+_RUNNER_SPEC = importlib.util.spec_from_file_location("clawbio_runner", PROJECT_ROOT / "clawbio.py")
+assert _RUNNER_SPEC and _RUNNER_SPEC.loader
+clawbio_runner = importlib.util.module_from_spec(_RUNNER_SPEC)
+_RUNNER_SPEC.loader.exec_module(clawbio_runner)
+
+
+def test_run_skill_promotes_structured_result_fields(monkeypatch, tmp_path: Path):
+    fake_script = tmp_path / "example_actions.py"
+    fake_script.write_text("# placeholder\n", encoding="utf-8")
+
+    monkeypatch.setitem(
+        clawbio_runner.SKILLS,
+        "example-actions",
+        {
+            "script": fake_script,
+            "demo_args": ["--demo"],
+            "description": "Example structured action skill",
+            "allowed_extra_flags": set(),
+        },
+    )
+
+    class Proc:
+        returncode = 0
+        stdout = "wrapper ok\n"
+        stderr = ""
+
+    def fake_run(cmd, capture_output, text, timeout, cwd):
+        output_dir = Path(cmd[cmd.index("--output") + 1])
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "report.md").write_text("# Fallback report\n", encoding="utf-8")
+        (output_dir / "result.json").write_text(
+            json.dumps(
+                {
+                    "schema": "example.skill_result.v1",
+                    "chat_summary_lines": [
+                        "The skill prepared a structured response.",
+                    ],
+                    "preferred_artifacts": ["report.md", "result.json"],
+                    "suggested_actions": [
+                        {
+                            "action_id": "show-demo-report",
+                            "label": "Show demo report",
+                            "kind": "navigation",
+                            "request": {
+                                "schema": "example.skill_request.v1",
+                                "mode": "report",
+                                "report_id": "demo",
+                            },
+                            "requires_confirmation": False,
+                        }
+                    ],
+                    "report_md": "# Structured Report\n",
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return Proc()
+
+    monkeypatch.setattr(clawbio_runner.subprocess, "run", fake_run)
+
+    output_dir = tmp_path / "runner_out"
+    result = clawbio_runner.run_skill(
+        skill_name="example-actions",
+        demo=True,
+        output_dir=str(output_dir),
+    )
+
+    assert result["success"] is True
+    assert result["stdout"] == "wrapper ok\n"
+    assert result["result_json_path"] == str(output_dir / "result.json")
+    assert result["report_md"] == "# Structured Report\n"
+    assert result["chat_summary_lines"] == ["The skill prepared a structured response."]
+    assert result["preferred_artifacts"] == ["report.md", "result.json"]
+    assert result["suggested_actions"][0]["action_id"] == "show-demo-report"
+    assert result["skill_result_json"]["schema"] == "example.skill_result.v1"


### PR DESCRIPTION
Can we discuss a bit if this is wanted or if this should somehow working differently? 

## Summary

Any skill producing some results is likely to have an idea what is special in its findings. And depending on what was found special, a particular action may be desirable to follow up with. ClawBio of course will have extra thoughts on its own, and so will the user, but the expert skill should be granted an option to make a proposal on what should be next. The .json returned shall therefore be structured as

 - chat_summary_lines: concise text written by the skill for chat
 - preferred_artifacts: files the UI should prioritize displaying
 - suggested_actions: deterministic follow-up requests to offer
 - report_md: full markdown report embedded in result.json

This came up for the skill (GENtle) I was preparing. Immediate use could be for the introduction of a new skills, like a table of content with more detailed follow ups for individual topics. It would feel a bit like hyperlinks, I guess.

## Skill affected

None. It is all optional.

## Checklist

- [X] Tests included and passing (`pytest -v`)
- [ ] Demo data included for reviewers to test
- [X] No patient/sensitive data committed
- [X] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

I kept the diff minimal, but that Demo I should provide, had used it only for GENtle. I'll add a patch for that, still need to make up my mind on what skill to amend.

## Summary by Claude - reviewing code generated by Codex

Adds a small, skill-agnostic framework that lets any ClawBio skill suggest deterministic follow-up actions, and lets both chat adapters (Telegram + Discord) offer, confirm, and execute exactly those actions.

A skill opts in by emitting one or more entries in `result.json`:

````json
{
  "chat_summary_lines": ["Concise text written by the skill for chat."],
  "preferred_artifacts": ["report.md", "result.json"],
  "suggested_actions": [
    {
      "action_id": "show-demo-report",
      "label": "Show demo report",
      "request": {
        "schema": "example.skill_request.v1",
        "mode": "report",
        "report_id": "demo"
      },
      "requires_confirmation": false
    }
  ]
}
````

The runner surfaces those fields on `run_skill()`'s return value. The chat adapter renders the offer as a numbered choice list, stores it per chat with a 30-minute TTL, parses the next user reply (index, label, `yes`, `cancel`, fuzzy match) and — on confirmation — executes only the stored nested `request`, written to a temp file and run through `clawbio.py run <skill> --input`. Any `shell_line` field is intentionally stored but never executed.

## Why

So far each adapter invented continuation prose after a tool result, which is unsafe (LLM-authored shell commands), inconsistent across Telegram and Discord, and gives skills no way to drive the next step deterministically. This change moves authorship of "what should we offer next" to the skill, in structured JSON, and centralises rendering and execution in one shared library.

## What's in this PR

- `bot/action_offers.py` — shared library: extract, render, parse, TTL, execute. Pure, no I/O outside the runner callback.
- `clawbio.py` — `_promote_structured_result_fields()` reads `result.json` on success and attaches `chat_summary_lines`, `preferred_artifacts`, `suggested_actions`, and `report_md` to the runner result.
- `bot/roboterri.py` (Telegram) and `bot/roboterri_discord.py` (Discord) — same wiring on both: per-chat pending offer state, confirmation state machine, audit events, and a generic `request` parameter on the `clawbio` tool schema.
- Side-fix in the Discord adapter: `_pending_text` and `_pending_media` are now keyed per channel (previously a single global list/dict keyed on `0`), so concurrent channels no longer cross-contaminate.
- `tests/test_action_offers.py` (10 tests) and `tests/test_clawbio_runner_actions.py` (1 runner integration test) using a placeholder `example.skill_request.v1` schema.

## What's not in this PR

- No skill is added or modified. No changes to `skills/`, `skills/catalog.json`, `CLAUDE.md`, `pytest.ini`, or the catalog generator.

## Security boundary

- The chat adapter only runs the nested structured `request` payload; the optional `shell_line` field is recorded for skill authors' reference but is never executed.
- Pending offers expire after 30 minutes; ambiguous, single-word, or unrecognised replies are rejected rather than guessed.
- Existing per-skill flag allowlist on `clawbio.py run` continues to apply.

## Test plan

- [ ] `pytest tests/test_action_offers.py tests/test_clawbio_runner_actions.py`
- [ ] Manual: run a skill that emits `suggested_actions[]`, confirm the offer renders, choose `1`, confirm the nested request is executed and the follow-up reply is rendered correctly.
- [ ] Manual on Discord: verify two concurrent channels do not see each other's pending text/media (regression check for the per-channel keying fix).