### PR TITLE
fix: validate CLAWBIO_ROOT in portable replay scripts

### DIFF
--- a/clawbio/common/reproducibility.py
+++ b/clawbio/common/reproducibility.py
@@ -108,6 +108,10 @@ def write_portable_commands_sh(
         'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"',
         'OUTPUT_DIR="$(dirname "$SCRIPT_DIR")"',
         f': "${{CLAWBIO_ROOT:={default_root}}}"',
+        'if [ ! -d "$CLAWBIO_ROOT" ]; then',
+        '  echo "Invalid CLAWBIO_ROOT: $CLAWBIO_ROOT" >&2',
+        "  exit 1",
+        "fi",
         "",
     ]
     if command.preflight:

--- a/clawbio/common/tests/test_reproducibility.py
+++ b/clawbio/common/tests/test_reproducibility.py
@@ -258,7 +258,7 @@ class TestWritePortableCommandsSh:
         text = path.read_text()
         assert 'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"' in text
         assert 'OUTPUT_DIR="$(dirname "$SCRIPT_DIR")"' in text
-        assert f'CLAWBIO_ROOT:={tmp_path.resolve()}' in text
+        assert f': "${{CLAWBIO_ROOT:={tmp_path.resolve()}}}"' in text
         assert 'python "$CLAWBIO_ROOT/skills/example/example.py" --demo' in text
 
 

--- a/clawbio/common/tests/test_reproducibility.py
+++ b/clawbio/common/tests/test_reproducibility.py
@@ -243,6 +243,24 @@ class TestWritePortableCommandsSh:
         assert 'echo "Invalid CLAWBIO_ROOT: $CLAWBIO_ROOT" >&2' in text
         assert "exit 1" in text
 
+    def test_portable_commands_keep_existing_root_and_output_exports(self, tmp_path):
+        command = ReproCommand(
+            script_path=Path("skills/example/example.py"),
+            args=["--demo"],
+        )
+
+        path = write_portable_commands_sh(
+            tmp_path,
+            command,
+            repo_root=tmp_path,
+        )
+
+        text = path.read_text()
+        assert 'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"' in text
+        assert 'OUTPUT_DIR="$(dirname "$SCRIPT_DIR")"' in text
+        assert f': "${{CLAWBIO_ROOT:={tmp_path.resolve()}}}"' in text
+        assert 'python "$CLAWBIO_ROOT/skills/example/example.py"' in text
+
 
 # ---------------------------------------------------------------------------
 # TestWriteCondaLock

--- a/clawbio/common/tests/test_reproducibility.py
+++ b/clawbio/common/tests/test_reproducibility.py
@@ -259,7 +259,7 @@ class TestWritePortableCommandsSh:
         assert 'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"' in text
         assert 'OUTPUT_DIR="$(dirname "$SCRIPT_DIR")"' in text
         assert f'CLAWBIO_ROOT:={tmp_path.resolve()}' in text
-        assert 'python "$CLAWBIO_ROOT/skills/example/example.py"' in text
+        assert 'python "$CLAWBIO_ROOT/skills/example/example.py" --demo' in text
 
 
 # ---------------------------------------------------------------------------

--- a/clawbio/common/tests/test_reproducibility.py
+++ b/clawbio/common/tests/test_reproducibility.py
@@ -9,11 +9,13 @@ import pytest
 
 from clawbio.common.checksums import sha256_file
 from clawbio.common.reproducibility import (
+    ReproCommand,
     write_checksums,
     write_environment_yml,
     write_commands_sh,
     write_conda_lock,
     write_ro_crate,
+    write_portable_commands_sh,
 )
 
 
@@ -220,6 +222,26 @@ class TestWriteCommandsSh:
         write_commands_sh(tmp_path, "python skill.py")
         mode = (tmp_path / "reproducibility" / "commands.sh").stat().st_mode
         assert mode & stat.S_IXUSR, "owner execute bit not set"
+
+
+class TestWritePortableCommandsSh:
+    def test_portable_commands_validate_clawbio_root_directory(self, tmp_path):
+        command = ReproCommand(
+            script_path=Path("skills/example/example.py"),
+            args=["--demo"],
+            comment="Replay example run",
+        )
+
+        path = write_portable_commands_sh(
+            tmp_path,
+            command,
+            repo_root=tmp_path,
+        )
+
+        text = path.read_text()
+        assert 'if [ ! -d "$CLAWBIO_ROOT" ]; then' in text
+        assert 'echo "Invalid CLAWBIO_ROOT: $CLAWBIO_ROOT" >&2' in text
+        assert "exit 1" in text
 
 
 # ---------------------------------------------------------------------------

--- a/clawbio/common/tests/test_reproducibility.py
+++ b/clawbio/common/tests/test_reproducibility.py
@@ -260,6 +260,7 @@ class TestWritePortableCommandsSh:
         assert 'OUTPUT_DIR="$(dirname "$SCRIPT_DIR")"' in text
         assert f': "${{CLAWBIO_ROOT:={tmp_path.resolve()}}}"' in text
         assert 'python "$CLAWBIO_ROOT/skills/example/example.py" --demo' in text
+        assert f'python "{(tmp_path.resolve() / "skills/example/example.py")}" --demo' not in text
 
 
 # ---------------------------------------------------------------------------

--- a/clawbio/common/tests/test_reproducibility.py
+++ b/clawbio/common/tests/test_reproducibility.py
@@ -258,8 +258,7 @@ class TestWritePortableCommandsSh:
         text = path.read_text()
         assert 'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"' in text
         assert 'OUTPUT_DIR="$(dirname "$SCRIPT_DIR")"' in text
-        assert ': "${CLAWBIO_ROOT:=' in text
-        assert '$CLAWBIO_ROOT' in text
+        assert f'CLAWBIO_ROOT:={tmp_path.resolve()}' in text
         assert 'python "$CLAWBIO_ROOT/skills/example/example.py"' in text
 
 

--- a/clawbio/common/tests/test_reproducibility.py
+++ b/clawbio/common/tests/test_reproducibility.py
@@ -258,7 +258,8 @@ class TestWritePortableCommandsSh:
         text = path.read_text()
         assert 'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"' in text
         assert 'OUTPUT_DIR="$(dirname "$SCRIPT_DIR")"' in text
-        assert f': "${{CLAWBIO_ROOT:={tmp_path.resolve()}}}"' in text
+        assert ': "${CLAWBIO_ROOT:=' in text
+        assert '$CLAWBIO_ROOT' in text
         assert 'python "$CLAWBIO_ROOT/skills/example/example.py"' in text
 
 


### PR DESCRIPTION
## Summary

- Add an early `CLAWBIO_ROOT` directory check to generated portable replay scripts.
- Add regression coverage for both the new fail-fast behavior and the existing portable replay contract.
- Keep successful replay behavior unchanged while making invalid replay setup fail clearly and immediately.

## Skill affected

- Shared reproducibility helpers in `clawbio/common/reproducibility.py`
- Shared helper tests in `clawbio/common/tests/test_reproducibility.py`

## Checklist

- [x] SKILL.md is present and complete (not applicable: this PR changes shared helpers, not a skill definition)
- [ ] Tests included and passing (`pytest -v`) — targeted checks for this change pass, but the full helper file is not green in this environment because `rocrate` is missing
- [x] Demo data included for reviewers to test (not applicable: no demo dataset is needed for this shared helper change)
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## What this fixes

Portable replay scripts already embedded a default `CLAWBIO_ROOT`, but they did not verify that the path actually existed before trying to run the replay command. If the value was stale or wrong, the script failed later and less clearly inside the replay step.

This PR makes that failure happen immediately, with a direct error message at the top of the generated script.

## Implementation

`write_portable_commands_sh(...)` now emits this guard right after initializing `CLAWBIO_ROOT`:

```bash
if [ ! -d "$CLAWBIO_ROOT" ]; then
  echo "Invalid CLAWBIO_ROOT: $CLAWBIO_ROOT" >&2
  exit 1
fi
```

This preserves the existing behavior when `CLAWBIO_ROOT` is valid, including cases where callers already export their own override.

## Validation

Targeted automated checks:

- `python -m pytest clawbio/common/tests/test_reproducibility.py -k portable_commands -v`
  - `2 passed, 39 deselected`
- `python -m pytest clawbio/common/tests/test_reproducibility.py -k clawbio_root -v`
  - `1 passed, 40 deselected`

Manual execution and re-execution:

- Generated a real `reproducibility/commands.sh` with `write_portable_commands_sh(...)`
- Verified that `CLAWBIO_ROOT=/definitely/not/a/repo bash reproducibility/commands.sh` fails early with:
  - `Invalid CLAWBIO_ROOT: /definitely/not/a/repo`
  - exit code `1`
- Verified that replay still works when:
  - `CLAWBIO_ROOT` is unset and the embedded default is used
  - `CLAWBIO_ROOT` is explicitly set to a valid repo path
  - the script is executed from outside the repository (`/tmp`), confirming that replay does not depend on the current working directory

Full-file test status in this environment:

- `python -m pytest clawbio/common/tests/test_reproducibility.py -v` currently ends with `33 passed, 8 failed`
- The 8 failures are outside this change and come from `TestWriteRoCrate`, which currently raises `ModuleNotFoundError: No module named 'rocrate'` in this local environment

## Scope

This PR is intentionally limited to issue `#222`.
It does not bundle:

- configurable Python interpreter support
- `REPLAY.md` generation
- documentation-only reproducibility changes
