### PR TITLE
Clarify reproducibility workflow contract and add user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Snap a photo of a medication in Telegram. ClawBio identifies the drug from the p
 
 Or take any genetic variant (identified by its rsID — a unique label like [rs9923231](https://www.ncbi.nlm.nih.gov/snp/rs9923231)) and search nine genomic databases at once to find every known disease association, tissue-specific effect, and population frequency. Or estimate your genetic predisposition to conditions like type 2 diabetes by combining thousands of small-effect variants into a single polygenic risk score. Or explore the [UK Biobank](https://www.ukbiobank.ac.uk/) — a half-million-person research dataset — by asking in plain English what fields measure blood pressure, grip strength, or depression, and get back the exact field IDs, descriptions, and linked publications you need.
 
-Helper-backed analyses write a `reproducibility/` bundle with replay commands, environment metadata, and output checksums. Exact files can vary by skill and required external inputs still need to be present. See [docs/reproducibility.md](docs/reproducibility.md).
+Many ClawBio analyses write a `reproducibility/` bundle with replay commands, environment metadata, and output checksums. The exact files can vary by skill, and some replays still require the original external inputs to be present. See [docs/reproducibility.md](docs/reproducibility.md).
 
 ---
 
@@ -130,7 +130,7 @@ python skills/claw-ancestry-pca/ancestry_pca.py --demo --output fig3
 
 Current agentic bioinformatics systems address either the **reasoning layer** (constraining LLM outputs with knowledge graphs or fine-tuning) or the **connectivity layer** (wrapping tools as MCP servers). Neither addresses the **specification layer**: the encoding of a domain expert's analytical decisions into a machine-readable contract that constrains agent behaviour. Without this layer, the agent must reconstruct expert knowledge from its training distribution, a stochastic, unversioned process.
 
-A **skill** is a self-contained directory comprising a declarative specification (`SKILL.md`), validated Python code, demo data, and reproducibility support. In helper-backed skills, that usually includes a `reproducibility/` bundle with `commands.sh`, `environment.yml`, and SHA-256 checksums, sometimes with extra lock metadata such as `runtime-lock.json`. The specification is a contract, not a prompt: it encodes the domain expert's analytical decisions so the LLM orchestrates but does not improvise.
+A **skill** is a self-contained directory comprising a declarative specification (`SKILL.md`), validated Python code, demo data, and reproducibility support. In many skills, that includes a `reproducibility/` bundle with `commands.sh`, `environment.yml`, and SHA-256 checksums, sometimes with extra lock metadata such as `runtime-lock.json`. The specification is a contract, not a prompt: it encodes the domain expert's analytical decisions so the LLM orchestrates but does not improvise.
 
 ```
 Ad-hoc LLM code generation  = stochastic, unversioned, unverifiable
@@ -140,7 +140,7 @@ ClawBio skill                = specification-constrained, versioned, reproducibl
 - **Specification-first**: Domain expertise resides in `SKILL.md`, not in model weights. Specifications are versioned, human-readable, peer-reviewable, and trivially updatable.
 - **Agent-agnostic**: Skills execute identically whether invoked by Claude, ChatGPT, or a locally hosted model via Ollama. Reproducibility is decoupled from any specific AI vendor.
 - **Local-first**: Your genomic data never leaves your laptop. No cloud uploads, no data exfiltration.
-- **Reproducible**: Helper-backed analyses export replay metadata such as `commands.sh`, `environment.yml`, and SHA-256 checksums so runs can be rechecked without the original agent session.
+- **Reproducible**: Many skills export replay metadata such as `commands.sh`, `environment.yml`, and SHA-256 checksums so runs can be rechecked without the original agent session.
 - **MIT licensed**: Open-source, free, community-driven.
 
 ## Why Not Just Use an LLM?
@@ -153,7 +153,7 @@ An LLM should not be improvising these from training data. ClawBio encodes the c
 
 ## Provenance and Reproducibility
 
-ClawBio's current reproducibility contract centers on a **`reproducibility/` bundle** written inside the output directory for helper-backed skills:
+ClawBio's current reproducibility contract centers on a **`reproducibility/` bundle** written inside the output directory for skills that use the shared reproducibility helpers:
 
 ```
 report/

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Snap a photo of a medication in Telegram. ClawBio identifies the drug from the p
 
 Or take any genetic variant (identified by its rsID — a unique label like [rs9923231](https://www.ncbi.nlm.nih.gov/snp/rs9923231)) and search nine genomic databases at once to find every known disease association, tissue-specific effect, and population frequency. Or estimate your genetic predisposition to conditions like type 2 diabetes by combining thousands of small-effect variants into a single polygenic risk score. Or explore the [UK Biobank](https://www.ukbiobank.ac.uk/) — a half-million-person research dataset — by asking in plain English what fields measure blood pressure, grip strength, or depression, and get back the exact field IDs, descriptions, and linked publications you need.
 
-Every result ships with a reproducibility bundle: `commands.sh`, `environment.yml`, and SHA-256 checksums. A reviewer can reproduce your Figure 3 in 30 seconds without emailing you.
+Helper-backed analyses write a `reproducibility/` bundle with replay commands, environment metadata, and output checksums. Exact files can vary by skill and required external inputs still need to be present. See [docs/reproducibility.md](docs/reproducibility.md).
 
 ---
 
@@ -118,11 +118,11 @@ You read a paper. You want to reproduce Figure 3. So you:
 Now imagine the same paper published a **skill**:
 
 ```bash
-python ancestry_pca.py --demo --output fig3
-# Figure 3 reproduced. Identical. SHA-256 verified. 30 seconds.
+python skills/claw-ancestry-pca/ancestry_pca.py --demo --output fig3
+# Example demo output regenerated. Verify bundled checksums where provided.
 ```
 
-**That's ClawBio.** Every figure in your paper should be one command away from reproduction.
+**That's ClawBio.** The goal is to make replayable bioinformatics workflows straightforward when a skill ships demo data and helper-backed reproducibility outputs.
 
 ---
 
@@ -130,7 +130,7 @@ python ancestry_pca.py --demo --output fig3
 
 Current agentic bioinformatics systems address either the **reasoning layer** (constraining LLM outputs with knowledge graphs or fine-tuning) or the **connectivity layer** (wrapping tools as MCP servers). Neither addresses the **specification layer**: the encoding of a domain expert's analytical decisions into a machine-readable contract that constrains agent behaviour. Without this layer, the agent must reconstruct expert knowledge from its training distribution, a stochastic, unversioned process.
 
-A **skill** is a self-contained directory comprising a declarative specification (`SKILL.md`), validated Python code, demo data, and a reproducibility bundle (`commands.sh`, `environment.yml`, SHA-256 checksums). The specification is a contract, not a prompt: it encodes the domain expert's analytical decisions so the LLM orchestrates but does not improvise.
+A **skill** is a self-contained directory comprising a declarative specification (`SKILL.md`), validated Python code, demo data, and reproducibility support. In helper-backed skills, that usually includes a `reproducibility/` bundle with `commands.sh`, `environment.yml`, and SHA-256 checksums, sometimes with extra lock metadata such as `runtime-lock.json`. The specification is a contract, not a prompt: it encodes the domain expert's analytical decisions so the LLM orchestrates but does not improvise.
 
 ```
 Ad-hoc LLM code generation  = stochastic, unversioned, unverifiable
@@ -140,7 +140,7 @@ ClawBio skill                = specification-constrained, versioned, reproducibl
 - **Specification-first**: Domain expertise resides in `SKILL.md`, not in model weights. Specifications are versioned, human-readable, peer-reviewable, and trivially updatable.
 - **Agent-agnostic**: Skills execute identically whether invoked by Claude, ChatGPT, or a locally hosted model via Ollama. Reproducibility is decoupled from any specific AI vendor.
 - **Local-first**: Your genomic data never leaves your laptop. No cloud uploads, no data exfiltration.
-- **Reproducible**: Every analysis exports `commands.sh`, `environment.yml`, and SHA-256 checksums. Anyone can reproduce it without the agent.
+- **Reproducible**: Helper-backed analyses export replay metadata such as `commands.sh`, `environment.yml`, and SHA-256 checksums so runs can be rechecked without the original agent session.
 - **MIT licensed**: Open-source, free, community-driven.
 
 ## Why Not Just Use an LLM?
@@ -153,19 +153,21 @@ An LLM should not be improvising these from training data. ClawBio encodes the c
 
 ## Provenance and Reproducibility
 
-Every ClawBio analysis ships with a **reproducibility bundle** — not as an afterthought, but as part of the output:
+ClawBio's current reproducibility contract centers on a **`reproducibility/` bundle** written inside the output directory for helper-backed skills:
 
 ```
 report/
 ├── report.md              # Full analysis with figures and tables
 ├── figures/               # Publication-quality PNGs
 ├── tables/                # CSV data tables
-├── commands.sh            # Exact commands to reproduce
-├── environment.yml        # Conda environment snapshot
-└── checksums.sha256       # SHA-256 of every input and output file
+├── reproducibility/
+│   ├── commands.sh        # Replay command for this run
+│   ├── environment.yml    # Suggested Conda environment snapshot
+│   ├── checksums.sha256   # SHA-256 for selected output files
+│   └── runtime-lock.json  # Optional extra lock metadata when supported
 ```
 
-**Why this matters**: a reviewer can re-run your analysis in 30 seconds. A collaborator can reproduce your Figure 3 without emailing you. Future-you can regenerate results two years later from the same bundle.
+The exact contents can vary by skill, and some replays also require the original external inputs or tools to be available locally. For a user-facing walkthrough, including a truthful `multiqc-reporter` example based on direct script invocation, see [docs/reproducibility.md](docs/reproducibility.md).
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,7 +91,7 @@ ClawBio enforces a strict local-first privacy model:
 
 ## Reproducibility Contract
 
-ClawBio's validated reproducibility contract is helper-backed rather than universal. For skills that use the shared reproducibility helpers, the output directory typically includes:
+ClawBio's validated reproducibility contract is not universal across every skill. For skills that use the shared reproducibility helpers, the output directory typically includes:
 
 1. **`reproducibility/commands.sh`**: A replay command for the skill run without needing the original agent session.
 2. **`reproducibility/environment.yml`**: A suggested Conda environment snapshot for the run.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,8 +32,8 @@ ClawBio is a collection of modular AI agent skills for bioinformatics, designed 
                     │   Output Layer       │
                     │  - Markdown report   │
                     │  - Figures (PNG/SVG) │
-                    │  - Audit log         │
-                    │  - Repro bundle      │
+                    │  - Optional repro    │
+                    │    bundle            │
                     └─────────────────────┘
 ```
 
@@ -52,7 +52,7 @@ Every skill works standalone. The Bio Orchestrator adds:
 - Automatic routing (user does not need to know skill names)
 - Multi-skill chaining (pipe output of one skill to the next)
 - Unified reporting (combine results from multiple skills)
-- Reproducibility wrapping (Repro Enforcer applied automatically)
+- Access to skill-defined reproducibility outputs where a routed skill implements them
 
 A user can invoke any skill directly without the orchestrator.
 
@@ -77,10 +77,7 @@ Visualisation (matplotlib/seaborn figures)
 Report Assembly (markdown + embedded figures)
     │
     ▼
-Reproducibility Export (conda env, commands, checksums)
-    │
-    ▼
-Audit Log Append (timestamped action record)
+Optional Reproducibility Export (helper-backed commands, environment, checksums)
 ```
 
 ## Privacy Model
@@ -94,14 +91,21 @@ ClawBio enforces a strict local-first privacy model:
 
 ## Reproducibility Contract
 
-Every analysis produces:
+ClawBio's validated reproducibility contract is helper-backed rather than universal. For skills that use the shared reproducibility helpers, the output directory typically includes:
 
-1. **commands.sh**: Exact shell commands to reproduce the analysis without the agent.
-2. **environment.yml**: Conda environment specification with pinned versions.
-3. **checksums.sha256**: SHA-256 hashes of all input files.
-4. **analysis_log.md**: Timestamped record of every action taken.
+1. **`reproducibility/commands.sh`**: A replay command for the skill run without needing the original agent session.
+2. **`reproducibility/environment.yml`**: A suggested Conda environment snapshot for the run.
+3. **`reproducibility/checksums.sha256`**: SHA-256 hashes for selected output files.
+4. **Optional extras**: Some skills may emit additional provenance files such as `runtime-lock.json` or other lock metadata.
 
-This means any result can be reproduced on any machine with the same inputs, independent of OpenClaw.
+Important boundaries:
+
+- Reproducibility behavior can vary by skill.
+- Replays may still require external tools or the original input files to be present locally.
+- `analysis_log.md` is not a guaranteed output for every skill.
+- Portable replay scripts reduce path friction, but they are not a blanket promise that every run will reproduce unchanged on every machine.
+
+See `docs/reproducibility.md` for the user workflow and a concrete `multiqc-reporter` example.
 
 ## Skill Packaging
 

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -1,12 +1,12 @@
 # Reproducibility Guide
 
-ClawBio's reproducibility support is designed to let someone replay a completed skill run without needing the original agent session. The exact files can vary by skill, but the current helper-backed contract centers on a `reproducibility/` directory written inside the chosen output directory.
+ClawBio's reproducibility support is designed to let someone replay a completed skill run without needing the original agent session. The exact files can vary by skill, but the current shared pattern centers on a `reproducibility/` directory written inside the chosen output directory.
 
 This guide uses [`multiqc-reporter`](../skills/multiqc-reporter/) as the concrete example because it already has a validated direct-script workflow. For this example, the exact recorded replay path is a direct Python invocation of `skills/multiqc-reporter/multiqc_reporter.py` rather than `python clawbio.py run`.
 
 ## What The Bundle Contains
 
-Most helper-backed skills write these files under `<output_dir>/reproducibility/`:
+Many skills write these files under `<output_dir>/reproducibility/`:
 
 - `commands.sh`: a replay script for the same skill run
 - `environment.yml`: a suggested Conda environment snapshot
@@ -14,7 +14,7 @@ Most helper-backed skills write these files under `<output_dir>/reproducibility/
 
 Some skills may also write extra provenance or lock files when supported, such as `runtime-lock.json` or other lock metadata. Do not assume every skill emits the exact same extras.
 
-What the current docs should not imply:
+Keep these limits in mind:
 
 - Reproducibility is not a blanket guarantee that any run will replay unchanged on every machine.
 - External tools still need to be installed when a skill depends on them.
@@ -64,7 +64,7 @@ From the repository checkout, rerun the saved command:
 bash /tmp/multiqc_demo/reproducibility/commands.sh
 ```
 
-For helper-backed scripts, `commands.sh` is self-anchoring:
+For scripts that use the shared reproducibility helpers, `commands.sh` is self-anchoring:
 
 - `OUTPUT_DIR` is derived from the location of `commands.sh`
 - `CLAWBIO_ROOT` defaults to the repository path recorded when the bundle was created

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -1,0 +1,140 @@
+# Reproducibility Guide
+
+ClawBio's reproducibility support is designed to let someone replay a completed skill run without needing the original agent session. The exact files can vary by skill, but the current helper-backed contract centers on a `reproducibility/` directory written inside the chosen output directory.
+
+This guide uses [`multiqc-reporter`](../skills/multiqc-reporter/) as the concrete example because it already has a validated direct-script workflow. For this example, the exact recorded replay path is a direct Python invocation of `skills/multiqc-reporter/multiqc_reporter.py` rather than `python clawbio.py run`.
+
+## What The Bundle Contains
+
+Most helper-backed skills write these files under `<output_dir>/reproducibility/`:
+
+- `commands.sh`: a replay script for the same skill run
+- `environment.yml`: a suggested Conda environment snapshot
+- `checksums.sha256`: SHA-256 digests for selected output files
+
+Some skills may also write extra provenance or lock files when supported, such as `runtime-lock.json` or other lock metadata. Do not assume every skill emits the exact same extras.
+
+What the current docs should not imply:
+
+- Reproducibility is not a blanket guarantee that any run will replay unchanged on every machine.
+- External tools still need to be installed when a skill depends on them.
+- External inputs still need to be available when the original run used user-provided files.
+- `analysis_log.md` is not a universal output across all skills.
+
+## Quick Example
+
+`multiqc-reporter` requires `multiqc` on `PATH`, and the replay is direct script invocation:
+
+```bash
+python skills/multiqc-reporter/multiqc_reporter.py --demo --output /tmp/multiqc_demo
+```
+
+Use a fresh output directory. The skill writes:
+
+- `/tmp/multiqc_demo/report.md`
+- `/tmp/multiqc_demo/multiqc_report.html`
+- `/tmp/multiqc_demo/multiqc_data/`
+- `/tmp/multiqc_demo/reproducibility/`
+
+For this demo run, `reproducibility/commands.sh` records the `--demo` invocation and `reproducibility/environment.yml` captures the suggested Python and `multiqc` environment for the run.
+
+## Recreate The Environment
+
+The simplest path is to inspect the generated environment first:
+
+```bash
+cat /tmp/multiqc_demo/reproducibility/environment.yml
+```
+
+For `multiqc-reporter`, the important requirement is still that `multiqc` is installed and available on `PATH`. A typical replay setup is:
+
+```bash
+conda env create -f /tmp/multiqc_demo/reproducibility/environment.yml
+conda activate clawbio-multiqc-reporter
+multiqc --version
+```
+
+If your workflow or environment manager also produces a lock artifact such as `runtime-lock.json`, treat that as a stricter runtime snapshot than the base `environment.yml`.
+
+## Replay The Analysis
+
+From the repository checkout, rerun the saved command:
+
+```bash
+bash /tmp/multiqc_demo/reproducibility/commands.sh
+```
+
+For helper-backed scripts, `commands.sh` is self-anchoring:
+
+- `OUTPUT_DIR` is derived from the location of `commands.sh`
+- `CLAWBIO_ROOT` defaults to the repository path recorded when the bundle was created
+- you can override `CLAWBIO_ROOT` if you are replaying from a different checkout
+
+Example with an explicit checkout path:
+
+```bash
+CLAWBIO_ROOT="$PWD" bash /tmp/multiqc_demo/reproducibility/commands.sh
+```
+
+For non-demo runs, make sure the original input directories still exist. The replay script can only rerun what the skill can still read.
+
+For `multiqc-reporter`, rerunning into the same output directory is valid, but MultiQC may add suffixed artifacts such as `multiqc_report_1.html` or `multiqc_data_1/` instead of replacing the original HTML report and data directory in place. If you want the cleanest manual replay comparison, start from a fresh output directory.
+
+## Verify Outputs
+
+First, inspect the output tree:
+
+```bash
+find /tmp/multiqc_demo -maxdepth 2 -type f | sort
+```
+
+Then verify the recorded checksums:
+
+```bash
+cd /tmp/multiqc_demo
+sha256sum -c reproducibility/checksums.sha256
+```
+
+`checksums.sha256` covers selected output files recorded by the skill. For `multiqc-reporter`, that includes `report.md`, `multiqc_report.html`, and files under `multiqc_data/` when present.
+
+If a checksum does not match, check whether:
+
+- the external tool version changed
+- the input directories changed
+- the output directory already contained files from an earlier run
+
+If the replay added suffixed files such as `multiqc_report_1.html`, that does not automatically mean the recorded bundle failed. `checksums.sha256` only verifies the files that the skill originally recorded for that run.
+
+## External Inputs
+
+Not every replay is demo-mode.
+
+When a skill was originally run with user-supplied files or directories:
+
+- keep those inputs available
+- keep the relative or absolute paths valid for the replay command
+- expect the skill's external dependencies to be installed locally
+
+This matters for `multiqc-reporter` because non-demo runs depend on the original QC directories, and MultiQC itself must be installed before replay.
+
+## Troubleshooting
+
+`multiqc: command not found`
+
+- Install MultiQC first, for example with `pip install multiqc` or via the generated `environment.yml`.
+
+`checksums.sha256` verifies some files but not others
+
+- That is expected. Skills choose which outputs to checksum. Read the skill's `report.md` and `SKILL.md` to see what is considered part of the reproducibility contract.
+
+The replay command points at the wrong repository path
+
+- Override `CLAWBIO_ROOT` when running `commands.sh`.
+
+The run succeeds but the report is empty
+
+- `multiqc-reporter` treats "no recognized QC files found" as a valid MultiQC outcome. Check `multiqc_report.html` and `multiqc_data/multiqc_data.json`.
+
+You expected `analysis_log.md`
+
+- Some skills may emit extra logs, but it is not a universal ClawBio guarantee today.

--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@
             <div class="comment"># Or with natural language:</div>
             <div class="cmd">$ openclaw &quot;Profile my pharmacogenes&quot;</div>
           </div>
-          <p style="color:var(--text-muted);font-size:0.9rem;margin-top:1rem;">Helper-backed skills write a <code style="background:var(--bg3);padding:0.1rem 0.4rem;border-radius:4px;font-size:0.85rem;">reproducibility/</code> bundle with replay commands, environment metadata, and output checksums. Exact files vary by skill, and some replays still require local tools or original inputs.</p>
+          <p style="color:var(--text-muted);font-size:0.9rem;margin-top:1rem;">Many skills write a <code style="background:var(--bg3);padding:0.1rem 0.4rem;border-radius:4px;font-size:0.85rem;">reproducibility/</code> bundle with replay commands, environment metadata, and output checksums. Exact files vary by skill, and some replays still require local tools or original inputs.</p>
         </div>
       </div>
     </div>
@@ -188,7 +188,7 @@
       <p class="section-sub">ChatGPT and Claude are smart generalists. ClawBio skills are domain experts' proven pipelines — executed correctly every time.</p>
       <div class="features-grid">
         <div class="feature-card"><div class="feature-icon">🏠</div><div class="feature-title">Local-first</div><div class="feature-desc">Your genomic data never leaves your laptop. No cloud uploads, no data exfiltration. Full privacy by design.</div></div>
-        <div class="feature-card"><div class="feature-icon">🔁</div><div class="feature-title">Reproducible</div><div class="feature-desc">Helper-backed analyses export replay bundles with commands, environment metadata, and output checksums so runs can be rechecked without the original agent session.</div></div>
+        <div class="feature-card"><div class="feature-icon">🔁</div><div class="feature-title">Reproducible</div><div class="feature-desc">Many skills export replay bundles with commands, environment metadata, and output checksums so runs can be rechecked without the original agent session.</div></div>
         <div class="feature-card"><div class="feature-icon">🧩</div><div class="feature-title">Modular</div><div class="feature-desc">Each skill is a self-contained directory (SKILL.md + Python scripts) that plugs into the orchestrator — or runs standalone.</div></div>
         <div class="feature-card"><div class="feature-icon">⚖️</div><div class="feature-title">MIT Licensed</div><div class="feature-desc">Open-source, free, community-driven. Clone it, run it, build a skill, submit a PR.</div></div>
         <div class="feature-card"><div class="feature-icon">🌍</div><div class="feature-title">Equity-aware</div><div class="feature-desc">Built-in support for underrepresented populations. HEIM diversity metrics baked into the roadmap.</div></div>
@@ -230,7 +230,7 @@
         <div>
           <div class="showcase-name">RoboTerri</div>
           <div class="showcase-role">Telegram AI Agent</div>
-          <div class="showcase-desc">A bioinformatics intelligence agent on Telegram — inspired by Professor Teresa K. Attwood, a pioneer of bioinformatics education and research. Run pharmacogenomics reports from your own genetic data. Snap a photo of your medication, get personalised dosage guidance. Local-first, with reproducibility support where the underlying skill provides helper-backed outputs.</div>
+          <div class="showcase-desc">A bioinformatics intelligence agent on Telegram — inspired by Professor Teresa K. Attwood, a pioneer of bioinformatics education and research. Run pharmacogenomics reports from your own genetic data. Snap a photo of your medication, get personalised dosage guidance. Local-first, with reproducibility support where the underlying skill writes a replay bundle.</div>
           <div class="showcase-skills">
             <span class="showcase-skill">PharmGx Reporter</span>
             <span class="showcase-skill">Drug Photo Lookup</span>
@@ -338,7 +338,7 @@
         <div style="background:var(--bg2);border:1px solid var(--border);border-radius:10px;padding:1rem 1.25rem;display:flex;align-items:center;gap:1rem;">
           <span style="font-size:1.5rem;flex-shrink:0;">🔁</span>
           <div>
-            <div style="font-weight:600;font-size:0.95rem;">Portable reproducibility bundles: helper-backed skills now write a <code style="background:var(--bg3);padding:0.1rem 0.3rem;border-radius:3px;font-size:0.82rem;">commands.sh</code> with anchor-relative replay and path handling to reduce checkout friction. Replays still depend on the skill, the local toolchain, and the required inputs being available.</div>
+            <div style="font-weight:600;font-size:0.95rem;">Portable reproducibility bundles: skills that use the shared helpers now write a <code style="background:var(--bg3);padding:0.1rem 0.3rem;border-radius:3px;font-size:0.82rem;">commands.sh</code> with anchor-relative replay and path handling to reduce checkout friction. Replays still depend on the skill, the local toolchain, and the required inputs being available.</div>
             <div style="color:var(--text-muted);font-size:0.85rem;margin-top:0.15rem;">PR #146 · 3 May 2026</div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -167,16 +167,16 @@
         <div>
           <div class="code-block">
             <div class="comment"># With ClawBio</div>
-            <div class="cmd">$ python ancestry_pca.py --demo --output fig3</div>
+            <div class="cmd">$ python skills/multiqc-reporter/multiqc_reporter.py --demo --output /tmp/multiqc_demo</div>
             <br>
-            <div class="success">✓ Figure 3 reproduced.</div>
-            <div class="success">✓ Identical. SHA-256 verified.</div>
-            <div class="success">✓ 30 seconds.</div>
+            <div class="success">✓ Demo report regenerated.</div>
+            <div class="success">✓ Replay command saved alongside outputs.</div>
+            <div class="success">✓ Checksums available for verification.</div>
             <br>
             <div class="comment"># Or with natural language:</div>
             <div class="cmd">$ openclaw &quot;Profile my pharmacogenes&quot;</div>
           </div>
-          <p style="color:var(--text-muted);font-size:0.9rem;margin-top:1rem;">Every skill exports <code style="background:var(--bg3);padding:0.1rem 0.4rem;border-radius:4px;font-size:0.85rem;">commands.sh</code>, <code style="background:var(--bg3);padding:0.1rem 0.4rem;border-radius:4px;font-size:0.85rem;">environment.yml</code>, and SHA-256 checksums — anyone can reproduce without the agent.</p>
+          <p style="color:var(--text-muted);font-size:0.9rem;margin-top:1rem;">Helper-backed skills write a <code style="background:var(--bg3);padding:0.1rem 0.4rem;border-radius:4px;font-size:0.85rem;">reproducibility/</code> bundle with replay commands, environment metadata, and output checksums. Exact files vary by skill, and some replays still require local tools or original inputs.</p>
         </div>
       </div>
     </div>
@@ -188,7 +188,7 @@
       <p class="section-sub">ChatGPT and Claude are smart generalists. ClawBio skills are domain experts' proven pipelines — executed correctly every time.</p>
       <div class="features-grid">
         <div class="feature-card"><div class="feature-icon">🏠</div><div class="feature-title">Local-first</div><div class="feature-desc">Your genomic data never leaves your laptop. No cloud uploads, no data exfiltration. Full privacy by design.</div></div>
-        <div class="feature-card"><div class="feature-icon">🔁</div><div class="feature-title">Reproducible</div><div class="feature-desc">Every analysis exports a reproducibility bundle — commands, environment, and SHA-256 checksums. Reproduce without the agent.</div></div>
+        <div class="feature-card"><div class="feature-icon">🔁</div><div class="feature-title">Reproducible</div><div class="feature-desc">Helper-backed analyses export replay bundles with commands, environment metadata, and output checksums so runs can be rechecked without the original agent session.</div></div>
         <div class="feature-card"><div class="feature-icon">🧩</div><div class="feature-title">Modular</div><div class="feature-desc">Each skill is a self-contained directory (SKILL.md + Python scripts) that plugs into the orchestrator — or runs standalone.</div></div>
         <div class="feature-card"><div class="feature-icon">⚖️</div><div class="feature-title">MIT Licensed</div><div class="feature-desc">Open-source, free, community-driven. Clone it, run it, build a skill, submit a PR.</div></div>
         <div class="feature-card"><div class="feature-icon">🌍</div><div class="feature-title">Equity-aware</div><div class="feature-desc">Built-in support for underrepresented populations. HEIM diversity metrics baked into the roadmap.</div></div>
@@ -230,7 +230,7 @@
         <div>
           <div class="showcase-name">RoboTerri</div>
           <div class="showcase-role">Telegram AI Agent</div>
-          <div class="showcase-desc">A bioinformatics intelligence agent on Telegram — inspired by Professor Teresa K. Attwood, a pioneer of bioinformatics education and research. Run pharmacogenomics reports from your own genetic data. Snap a photo of your medication, get personalised dosage guidance. All local-first, all reproducible.</div>
+          <div class="showcase-desc">A bioinformatics intelligence agent on Telegram — inspired by Professor Teresa K. Attwood, a pioneer of bioinformatics education and research. Run pharmacogenomics reports from your own genetic data. Snap a photo of your medication, get personalised dosage guidance. Local-first, with reproducibility support where the underlying skill provides helper-backed outputs.</div>
           <div class="showcase-skills">
             <span class="showcase-skill">PharmGx Reporter</span>
             <span class="showcase-skill">Drug Photo Lookup</span>
@@ -338,7 +338,7 @@
         <div style="background:var(--bg2);border:1px solid var(--border);border-radius:10px;padding:1rem 1.25rem;display:flex;align-items:center;gap:1rem;">
           <span style="font-size:1.5rem;flex-shrink:0;">🔁</span>
           <div>
-            <div style="font-weight:600;font-size:0.95rem;">Portable reproducibility bundles: every skill now writes a <code style="background:var(--bg3);padding:0.1rem 0.3rem;border-radius:3px;font-size:0.82rem;">commands.sh</code> with portable paths, anchor-relative replay, and non-deterministic output exclusions. Anyone can rerun an analysis without the agent and verify the result.</div>
+            <div style="font-weight:600;font-size:0.95rem;">Portable reproducibility bundles: helper-backed skills now write a <code style="background:var(--bg3);padding:0.1rem 0.3rem;border-radius:3px;font-size:0.82rem;">commands.sh</code> with anchor-relative replay and path handling to reduce checkout friction. Replays still depend on the skill, the local toolchain, and the required inputs being available.</div>
             <div style="color:var(--text-muted);font-size:0.85rem;margin-top:0.15rem;">PR #146 · 3 May 2026</div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- add a dedicated user-facing reproducibility guide at `docs/reproducibility.md`
- align `README.md`, `docs/architecture.md`, and `index.html` with the current helper-backed reproducibility contract instead of overpromising universal replay behavior
- document and manually verify a concrete replay workflow using `multiqc-reporter` demo mode

## Skill affected

Documentation only. No skill implementation code changed.

The concrete example in this PR uses `multiqc-reporter` as a truthful replay walkthrough because it already supports a small demo workflow and emits a reproducibility bundle, but the skill itself was not modified.

Closes #230.

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology) — no skill spec changes in this PR
- [ ] Tests included and passing (`pytest -v`) — docs-only PR; validation was done by manual execution and re-execution of the documented workflow instead
- [x] Demo data included for reviewers to test — the PR uses the existing `multiqc-reporter` demo workflow as the reviewable example
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

Manual verification only, using the exact workflow documented in the new guide:

```bash
python skills/multiqc-reporter/multiqc_reporter.py --demo --output /tmp/multiqc_demo
bash /tmp/multiqc_demo/reproducibility/commands.sh
cd /tmp/multiqc_demo && sha256sum -c reproducibility/checksums.sha256
```

Observed results:

- initial demo run completed successfully and wrote `report.md`, `multiqc_report.html`, `multiqc_data/`, and `reproducibility/`
- `report.md` contained the expected `SAMPLE_01`, `SAMPLE_02`, and `SAMPLE_03` rows
- replay via `reproducibility/commands.sh` completed successfully
- checksum verification returned `OK` for all files recorded in `reproducibility/checksums.sha256`
- rerunning into the same output directory caused MultiQC to create suffixed artifacts such as `multiqc_report_1.html` and `multiqc_data_1/`; the guide now documents that behavior explicitly so reviewers are not surprised during manual replay

Why this PR is needed:

The repo previously described reproducibility in stronger terms than the current helper-backed implementation guarantees, including broad language around universal replay and universal bundle contents. This PR narrows those claims to match what the repository actually produces today, while still giving users a concrete, repeatable workflow they can follow.
