### PR TITLE
feat(proteomics-de): add RO-Crate provenance and migrate to shared repro helpers

### DIFF
--- a/skills/proteomics-de/SKILL.md
+++ b/skills/proteomics-de/SKILL.md
@@ -180,6 +180,7 @@ proteomics_de_report/
 ├── tables/
 │   ├── imputed_proteinGroups.csv
 │   └── de_results.csv
+├── ro-crate-metadata.json
 └── reproducibility/
     ├── commands.sh
     ├── environment.yml

--- a/skills/proteomics-de/proteomics_de.py
+++ b/skills/proteomics-de/proteomics_de.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import sys
 from pathlib import Path
 
@@ -14,7 +13,10 @@ if str(_PROJECT_ROOT) not in sys.path:
 from clawbio.common.reproducibility import (  # noqa: E402
     ReproCommand,
     ReproPath,
+    write_checksums,
+    write_environment_yml,
     write_portable_commands_sh,
+    write_ro_crate,
 )
 
 import matplotlib.pyplot as plt
@@ -457,14 +459,6 @@ def plot_volcano(de_results: pd.DataFrame, outpath: Path, s0: float = 0.1, fdr: 
     plt.close()
 
 
-def _sha256(path: Path) -> str:
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(8192), b""):
-            h.update(chunk)
-    return h.hexdigest()
-
-
 def repro_command_for_bundle(
     output_dir: Path,
     input_path: Path,
@@ -509,9 +503,6 @@ def write_repro_files(
     imputation_scale: float,
 ) -> None:
     """Write reproducibility files (commands, environment, checksums)"""
-    repro_dir = output_dir / "reproducibility"
-    repro_dir.mkdir(parents=True, exist_ok=True)
-
     write_portable_commands_sh(
         output_dir,
         repro_command_for_bundle(
@@ -521,26 +512,18 @@ def write_repro_files(
         repo_root=_PROJECT_ROOT,
     )
 
-    env = """name: clawbio-proteomics-de
-channels:
-  - conda-forge
-dependencies:
-  - python>=3.10
-  - pandas
-  - numpy
-  - matplotlib
-  - scikit-learn
-  - scipy
-  - seaborn
-"""
-    (repro_dir / "environment.yml").write_text(env)
+    write_environment_yml(
+        output_dir,
+        env_name="clawbio-proteomics-de",
+        pip_deps=["pandas", "numpy", "matplotlib", "scikit-learn", "scipy", "seaborn"],
+        python_version="3.10",
+    )
 
-    checksums = []
-    for path in sorted((output_dir / "tables").glob("*.csv")):
-        checksums.append(f"{_sha256(path)}  tables/{path.name}")
-    for path in sorted((output_dir / "figures").glob("*.png")):
-        checksums.append(f"{_sha256(path)}  figures/{path.name}")
-    (repro_dir / "checksums.sha256").write_text("\n".join(checksums) + "\n")
+    checksum_paths = [
+        *sorted((output_dir / "tables").glob("*.csv")),
+        *sorted((output_dir / "figures").glob("*.png")),
+    ]
+    write_checksums(checksum_paths, output_dir, anchor=output_dir)
 
 
 def run_analysis(
@@ -682,6 +665,7 @@ def run_analysis(
 - Commands: `reproducibility/commands.sh`
 - Environment: `reproducibility/environment.yml`
 - Checksums: `reproducibility/checksums.sha256`
+- Provenance: `ro-crate-metadata.json`
 
 ## Disclaimer
 {DISCLAIMER}
@@ -758,6 +742,24 @@ def main() -> None:
         ttest_df=args.ttest_df,
         imputation_shift=args.imputation_shift,
         imputation_scale=args.imputation_scale,
+    )
+
+    write_ro_crate(
+        Path(args.output),
+        skill_name="proteomics-de",
+        skill_version="0.1.0",
+        script_path="skills/proteomics-de/proteomics_de.py",
+        description="Proteomics differential expression from LFQ or DIA-NN data",
+        params={
+            "input_type": args.input_type,
+            "contrast": args.contrast,
+            "s0": args.s0,
+            "fdr": args.fdr,
+            "ttest_df": args.ttest_df,
+            "imputation_shift": args.imputation_shift,
+            "imputation_scale": args.imputation_scale,
+            "demo": args.demo,
+        },
     )
 
     print(pd.Series(result).to_json(indent=2))


### PR DESCRIPTION
## Summary

- Add `write_ro_crate` to emit `ro-crate-metadata.json` with run provenance (skill version, script path, params, output file inventory) per RO-Crate 1.1
- Migrate inline `environment.yml` string and hand-rolled `_sha256`/checksums loop to `write_environment_yml` and `write_checksums` from `clawbio.common.reproducibility`
- Document `ro-crate-metadata.json` in `SKILL.md` output structure and `report.md` reproducibility section

## Skill affected

`proteomics-de`

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology)
- [x] Tests included and passing (`pytest -v`)
- [x] Demo data included for reviewers to test
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

```
$ pytest skills/proteomics-de/tests/ -q
24 passed in 1.27s
```

Demo output structure:
```
proteomics_de_report/
├── report.md
├── ro-crate-metadata.json
├── figures/
│   ├── imputation_distribution.png
│   ├── pca.png
│   └── volcano.png
├── tables/
│   ├── imputed_proteinGroups.csv
│   └── de_results.csv
└── reproducibility/
    ├── commands.sh
    ├── environment.yml
    └── checksums.sha256
```