### PR TITLE
feat(omics-target-evidence-mapper): add RO-Crate reproducibility bundle

### DIFF
--- a/skills/omics-target-evidence-mapper/SKILL.md
+++ b/skills/omics-target-evidence-mapper/SKILL.md
@@ -61,7 +61,10 @@ This skill is for research triage only. It does not infer causality, rank therap
 3. Query public data sources.
 4. Normalise results into a structured evidence object.
 5. Write JSON and Markdown outputs.
-6. Write file checksums for reproducibility.
+6. Write reproducibility bundle:
+   - `reproducibility/checksums.sha256` — SHA-256 hashes of all output files
+   - `reproducibility/environment.yml` — pinned Conda/pip environment
+   - `ro-crate-metadata.json` — RO-Crate 1.1 provenance record (run params, outputs, script)
 
 # CLI Reference
 

--- a/skills/omics-target-evidence-mapper/omics_target_evidence_mapper.py
+++ b/skills/omics-target-evidence-mapper/omics_target_evidence_mapper.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import sys
 from datetime import UTC, datetime
@@ -11,6 +10,8 @@ from pathlib import Path
 from typing import Any
 
 import requests
+
+from clawbio.common.reproducibility import write_checksums, write_environment_yml, write_ro_crate
 
 
 DEMO_GENE = "IL6R"
@@ -323,20 +324,6 @@ def write_json(path: Path, content: dict[str, Any]) -> None:
     path.write_text(json.dumps(content, indent=2, ensure_ascii=False), encoding="utf-8")
 
 
-def sha256_of_file(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as f:
-        for chunk in iter(lambda: f.read(8192), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def write_checksums(output_dir: Path, files: list[Path]) -> None:
-    lines = []
-    for file_path in files:
-        lines.append(f"{sha256_of_file(file_path)}  {file_path.name}")
-    write_text(output_dir / "checksums.sha256", "\n".join(lines) + "\n")
-
 
 def main() -> None:
     args = parse_args()
@@ -365,7 +352,27 @@ def main() -> None:
     write_json(evidence_path, evidence)
     write_text(report_path, report)
     write_json(metadata_path, metadata)
-    write_checksums(output_dir, [evidence_path, report_path, metadata_path])
+    write_checksums([evidence_path, report_path, metadata_path], output_dir, anchor=output_dir)
+    write_environment_yml(
+        output_dir,
+        env_name="clawbio-omics-target-evidence-mapper",
+        pip_deps=["requests", "rocrate"],
+        python_version="3.11",
+    )
+    write_ro_crate(
+        output_dir,
+        skill_name="omics-target-evidence-mapper",
+        skill_version="0.1.0",
+        script_path="skills/omics-target-evidence-mapper/omics_target_evidence_mapper.py",
+        description="Aggregate public target-level evidence across omics and translational sources",
+        params={
+            "gene": evidence["query"]["gene"],
+            "disease": evidence["query"].get("disease", ""),
+            "max_papers": args.max_papers,
+            "max_trials": args.max_trials,
+            "demo": args.demo,
+        },
+    )
 
     print(f"Done. Output written to: {output_dir}")
 


### PR DESCRIPTION
## Summary

- Replaces local `sha256_of_file` / `write_checksums` with imports from `clawbio.common.reproducibility`
- Adds `write_environment_yml` and `write_ro_crate` calls so every run emits a full repro bundle alongside evidence outputs
- Documents the three bundle artefacts in SKILL.md

## Skill affected

omics-target-evidence-mapper

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology)
- [x] Tests included and passing (`pytest -v`)
- [x] Demo data included for reviewers to test
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

```
$ python -m pytest skills/omics-target-evidence-mapper/tests/ -q
..
2 passed in 1.44s
```