### PR TITLE
feat(bots): skill workflow-state contract for suggested actions

### DIFF
--- a/bot/action_offers.py
+++ b/bot/action_offers.py
@@ -139,11 +139,13 @@ def load_bundle_fields(output_dir: str | Path | None) -> dict[str, Any]:
             # - chat_summary_lines: concise text written by the skill for chat
             # - preferred_artifacts: files the UI should prioritize displaying
             # - suggested_actions: deterministic follow-up requests to offer
+            # - workflow_state: skill-emitted state identity/lifecycle metadata
             # - report_md: full markdown report embedded in result.json
             for key in (
                 "chat_summary_lines",
                 "preferred_artifacts",
                 "suggested_actions",
+                "workflow_state",
                 "report_md",
             ):
                 if key in payload:
@@ -162,14 +164,39 @@ def load_bundle_fields(output_dir: str | Path | None) -> dict[str, Any]:
     return fields
 
 
-def render_action_offer(actions: list[dict[str, Any]]) -> str:
-    """Render actions as numbered chat choices."""
-    if not actions:
+def render_workflow_state_header(workflow_state: dict[str, Any] | None) -> str:
+    """Render the optional cross-skill workflow lifecycle header."""
+    if not isinstance(workflow_state, dict):
         return ""
-    lines = ["I can do the next step for you:"]
+    lifecycle = workflow_state.get("lifecycle")
+    if not isinstance(lifecycle, str) or not lifecycle.strip():
+        return ""
+    lifecycle = lifecycle.strip()
+    state_label = workflow_state.get("state_label")
+    if isinstance(state_label, str) and state_label.strip():
+        return f"State: {lifecycle} — {state_label.strip()}"
+    return f"State: {lifecycle}"
+
+
+def render_action_offer(
+    actions: list[dict[str, Any]],
+    *,
+    workflow_state: dict[str, Any] | None = None,
+) -> str:
+    """Render actions as numbered chat choices."""
+    header = render_workflow_state_header(workflow_state)
+    if not actions:
+        return header
+    lines = []
+    if header:
+        lines.append(header)
+    lines.append("I can do the next step for you:")
     for idx, action in enumerate(actions, start=1):
         suffix = ""
-        if action.get("requires_confirmation") is False:
+        estimate = action.get("estimate")
+        if isinstance(estimate, str) and estimate.strip():
+            suffix = f" ({estimate.strip()})"
+        elif action.get("requires_confirmation") is False:
             suffix = " (safe refresh)"
         lines.append(f"{idx}. {action.get('label', f'Action {idx}')}{suffix}")
     if len(actions) == 1:

--- a/bot/roboterri.py
+++ b/bot/roboterri.py
@@ -74,6 +74,7 @@ try:  # Allow running as `python bot/roboterri.py` and as a package import.
         make_pending_action_entry,
         parse_action_reply,
         render_action_offer,
+        render_workflow_state_header,
     )
 except ImportError:  # pragma: no cover - package import fallback
     from bot.action_offers import (
@@ -88,6 +89,7 @@ except ImportError:  # pragma: no cover - package import fallback
         make_pending_action_entry,
         parse_action_reply,
         render_action_offer,
+        render_workflow_state_header,
     )
 
 # --------------------------------------------------------------------------- #
@@ -604,6 +606,8 @@ def _render_skill_result(chat_id: int, skill_key: str, result: dict) -> str:
     report_text = str(result.get("report_md", "") or "").strip()
     summary_lines = extract_chat_summary_lines(result)
     actions = extract_action_offer(result)
+    workflow_state = result.get("workflow_state")
+    state_header = render_workflow_state_header(workflow_state)
 
     if actions:
         reply_parts: list[str] = []
@@ -615,7 +619,7 @@ def _render_skill_result(chat_id: int, skill_key: str, result: dict) -> str:
             reply_parts.append(raw_output)
         else:
             reply_parts.append(f"{skill_key} completed.")
-        reply_parts.append(render_action_offer(actions))
+        reply_parts.append(render_action_offer(actions, workflow_state=workflow_state))
         rendered = "\n\n".join(part for part in reply_parts if part).strip()
         _pending_actions[chat_id] = make_pending_action_entry(
             skill=skill_key,
@@ -637,15 +641,19 @@ def _render_skill_result(chat_id: int, skill_key: str, result: dict) -> str:
 
     if skill_key in ("compare", "drugphoto", "profile"):
         rendered = raw_output or report_text or f"{skill_key} completed."
+        if state_header:
+            rendered = "\n\n".join([state_header, rendered])
         if rendered:
             _pending_text.setdefault(chat_id, []).append(rendered)
         return "Result sent directly to chat. Do not repeat or paraphrase it."
 
     if summary_lines:
-        return "\n".join(summary_lines)
+        return "\n\n".join(part for part in (state_header, "\n".join(summary_lines)) if part)
     if report_text:
-        return _trim_report_for_chat(report_text)
-    return raw_output if raw_output else f"{skill_key} completed. Output: {output_dir}"
+        rendered_report = _trim_report_for_chat(report_text)
+        return "\n\n".join(part for part in (state_header, rendered_report) if part)
+    rendered_output = raw_output if raw_output else f"{skill_key} completed. Output: {output_dir}"
+    return "\n\n".join(part for part in (state_header, rendered_output) if part)
 
 
 async def execute_clawbio(args: dict) -> str:

--- a/bot/roboterri_discord.py
+++ b/bot/roboterri_discord.py
@@ -66,6 +66,7 @@ try:
         make_pending_action_entry,
         parse_action_reply,
         render_action_offer,
+        render_workflow_state_header,
     )
 except ImportError:  # pragma: no cover - package import fallback
     from bot.action_offers import (
@@ -80,6 +81,7 @@ except ImportError:  # pragma: no cover - package import fallback
         make_pending_action_entry,
         parse_action_reply,
         render_action_offer,
+        render_workflow_state_header,
     )
 
 # --------------------------------------------------------------------------- #
@@ -670,6 +672,8 @@ def _render_skill_result(channel_id: int, skill_key: str, result: dict) -> str:
     report_text = str(result.get("report_md", "") or "").strip()
     summary_lines = extract_chat_summary_lines(result)
     actions = extract_action_offer(result)
+    workflow_state = result.get("workflow_state")
+    state_header = render_workflow_state_header(workflow_state)
 
     if actions:
         reply_parts: list[str] = []
@@ -681,7 +685,7 @@ def _render_skill_result(channel_id: int, skill_key: str, result: dict) -> str:
             reply_parts.append(raw_output)
         else:
             reply_parts.append(f"{skill_key} completed.")
-        reply_parts.append(render_action_offer(actions))
+        reply_parts.append(render_action_offer(actions, workflow_state=workflow_state))
         rendered = "\n\n".join(part for part in reply_parts if part).strip()
         _pending_actions[channel_id] = make_pending_action_entry(
             skill=skill_key,
@@ -703,15 +707,19 @@ def _render_skill_result(channel_id: int, skill_key: str, result: dict) -> str:
 
     if skill_key in ("compare", "drugphoto", "profile"):
         rendered = raw_output or report_text or f"{skill_key} completed."
+        if state_header:
+            rendered = "\n\n".join([state_header, rendered])
         if rendered:
             _pending_text.setdefault(channel_id, []).append(rendered)
         return "Result sent directly to chat. Do not repeat or paraphrase it."
 
     if summary_lines:
-        return "\n".join(summary_lines)
+        return "\n\n".join(part for part in (state_header, "\n".join(summary_lines)) if part)
     if report_text:
-        return _trim_report_for_chat(report_text)
-    return raw_output if raw_output else f"{skill_key} completed. Output: {output_dir}"
+        rendered_report = _trim_report_for_chat(report_text)
+        return "\n\n".join(part for part in (state_header, rendered_report) if part)
+    rendered_output = raw_output if raw_output else f"{skill_key} completed. Output: {output_dir}"
+    return "\n\n".join(part for part in (state_header, rendered_output) if part)
 
 
 async def execute_clawbio(args: dict) -> str:

--- a/clawbio.py
+++ b/clawbio.py
@@ -848,11 +848,13 @@ def _promote_structured_result_fields(result: dict, out_dir: Path | None) -> Non
         # - chat_summary_lines: concise, skill-authored text for chat UIs
         # - preferred_artifacts: generated files the UI should surface first
         # - suggested_actions: deterministic next-step requests to offer later
+        # - workflow_state: skill-emitted state identity/lifecycle metadata
         # - report_md: full markdown report text embedded in result.json
         for field in (
             "chat_summary_lines",
             "preferred_artifacts",
             "suggested_actions",
+            "workflow_state",
             "report_md",
         ):
             if field in payload:

--- a/skills/affinity-proteomics/SKILL.md
+++ b/skills/affinity-proteomics/SKILL.md
@@ -72,7 +72,7 @@ You are **Affinity Proteomics**, a specialised ClawBio agent for Olink and SomaL
 3. **Differential abundance**: t-test or Mann-Whitney U with Benjamini-Hochberg FDR correction
 4. **Visualisation**: Volcano plot, heatmap (top N proteins), PCA plot
 5. **Structured reporting**: Markdown report, result.json, per-protein TSV, reproducibility bundle
-6. **Skill Action Menu**: `result.json` includes one read-only follow-up action for the top proteins table
+6. **Skill Action Menu**: `result.json` includes a workflow state plus read-only follow-up actions for compact report cards
 
 ## Input Formats
 
@@ -113,29 +113,47 @@ Expected output: Differential abundance report for 80 samples (40 Case / 40 Cont
 ## Output Structure
 
 - `report.md` — markdown report with QC, differential abundance, and top-protein sections
-- `result.json` — structured summary with `chat_summary_lines`, `preferred_artifacts`, and one `suggested_actions` entry
+- `result.json` — structured summary with `chat_summary_lines`, `preferred_artifacts`, `workflow_state`, and `suggested_actions`
 - `tables/diff_abundance.tsv` — per-protein differential abundance table
 - `figures/volcano.png`, `figures/heatmap.png`, `figures/pca.png` — standard demo figures
 - `reproducibility/` — command and software-version metadata
 
 ## Suggested Actions
 
-The demo result offers a single read-only `Top Proteins` action. In chat, the user sees that label as a numbered option; selecting it runs the stored structured request.
+The demo result emits `workflow_state.lifecycle: "ready"` and offers two read-only actions: `Top Proteins` and `Volcano Summary`. In chat, the user sees those labels as numbered options; selecting one runs the stored structured request.
+
+`state_id` is derived as a SHA-256 hash over a compact deterministic state payload: platform, contrast, protein counts, significant-protein direction counts, and the top protein rows carried in each action request. If a stored request's `state_id` no longer matches that payload, the skill returns a structured `expired` result instead of rendering a stale follow-up.
 
 ```json
 {
-  "action_id": "show-top-proteins",
-  "label": "Top Proteins",
-  "request": {
-    "schema": "affinity_proteomics.action_request.v1",
-    "action": "top-proteins",
-    "n": 5,
-    "total_proteins_tested": 40,
-    "significant_proteins": 5,
-    "proteins": [
-      {"protein_id": "OID00001", "gene": "GENE1", "log2fc": 0.0, "padj": "0.00e+00"}
-    ]
-  }
+  "workflow_state": {
+    "state_schema": "affinity_proteomics.workflow_state.v1",
+    "state_id": "sha256:...",
+    "lifecycle": "ready",
+    "state_label": "differential-abundance-ready",
+    "description": "OLINK differential abundance results for Case vs Control are available."
+  },
+  "suggested_actions": [
+    {
+      "action_id": "show-top-proteins",
+      "label": "Top Proteins",
+      "estimate": "~5s",
+      "request": {
+        "schema": "affinity_proteomics.action_request.v1",
+        "action": "top-proteins",
+        "state_schema": "affinity_proteomics.workflow_state.v1",
+        "state_id": "sha256:...",
+        "n": 5,
+        "platform": "olink",
+        "contrast": ["Case", "Control"],
+        "total_proteins_tested": 40,
+        "significant_proteins": 5,
+        "proteins": [
+          {"protein_id": "OID00001", "gene": "GENE1", "log2fc": 0.0, "padj": "0.00e+00"}
+        ]
+      }
+    }
+  ]
 }
 ```
 

--- a/skills/affinity-proteomics/affinity_proteomics.py
+++ b/skills/affinity-proteomics/affinity_proteomics.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import hashlib
 import json
 import math
 import sys
@@ -44,6 +45,7 @@ DISCLAIMER = (
 
 ACTION_REQUEST_SCHEMA = "affinity_proteomics.action_request.v1"
 ACTION_RESULT_SCHEMA = "affinity_proteomics.action_result.v1"
+WORKFLOW_STATE_SCHEMA = "affinity_proteomics.workflow_state.v1"
 
 
 # ---------------------------------------------------------------------------
@@ -456,6 +458,99 @@ def _write_diff_table(results: list[DiffAbundanceResult], path: Path) -> None:
                         f"{r.log2fc:.4f}", f"{r.pvalue:.2e}", f"{r.padj:.2e}", r.significant])
 
 
+def _top_protein_rows(results: list[DiffAbundanceResult], n: int = 10) -> list[dict]:
+    return [
+        {
+            "protein_id": r.protein_id,
+            "gene": r.gene_symbol,
+            "log2fc": round(r.log2fc, 4),
+            "padj": f"{r.padj:.2e}",
+        }
+        for r in results[:n]
+    ]
+
+
+def _build_action_context(
+    data: ProteomicsData,
+    results: list[DiffAbundanceResult],
+    contrast: tuple[str, str],
+) -> dict:
+    sig = [r for r in results if r.significant]
+    context = {
+        "platform": data.platform,
+        "contrast": list(contrast),
+        "total_proteins_tested": len(results),
+        "significant_proteins": len(sig),
+        "up_in_group1": sum(1 for r in sig if r.log2fc > 0),
+        "up_in_group2": sum(1 for r in sig if r.log2fc < 0),
+        "proteins": _top_protein_rows(results),
+    }
+    context["state_id"] = _state_id_from_context(context)
+    return context
+
+
+def _state_id_from_context(context: dict) -> str:
+    state_payload = {k: v for k, v in context.items() if k != "state_id"}
+    encoded = json.dumps(
+        state_payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _workflow_state_from_context(
+    context: dict,
+    *,
+    lifecycle: str = "ready",
+    state_label: str = "differential-abundance-ready",
+    message: str | None = None,
+) -> dict:
+    contrast = context.get("contrast") if isinstance(context.get("contrast"), list) else []
+    contrast_label = " vs ".join(str(item) for item in contrast) if contrast else "the requested contrast"
+    state = {
+        "state_schema": WORKFLOW_STATE_SCHEMA,
+        "state_id": context.get("state_id") or _state_id_from_context(context),
+        "lifecycle": lifecycle,
+        "state_label": state_label,
+        "description": (
+            f"{str(context.get('platform', 'affinity')).upper()} differential "
+            f"abundance results for {contrast_label} are available."
+        ),
+    }
+    if message:
+        state["message"] = message
+    return state
+
+
+def _request_context(request: dict) -> dict:
+    proteins = request.get("proteins")
+    if not isinstance(proteins, list):
+        proteins = []
+    contrast = request.get("contrast")
+    if not isinstance(contrast, list):
+        contrast = []
+    context = {
+        "platform": str(request.get("platform") or "affinity"),
+        "contrast": [str(item) for item in contrast],
+        "total_proteins_tested": _int_request_value(request.get("total_proteins_tested"), len(proteins)),
+        "significant_proteins": _int_request_value(request.get("significant_proteins"), 0),
+        "up_in_group1": _int_request_value(request.get("up_in_group1"), 0),
+        "up_in_group2": _int_request_value(request.get("up_in_group2"), 0),
+        "proteins": [protein for protein in proteins if isinstance(protein, dict)],
+    }
+    context["state_id"] = _state_id_from_context(context)
+    return context
+
+
+def _int_request_value(value, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _write_report_md(data, results, contrast, group_col, output_dir, timestamp, demo, input_label):
     sig = [r for r in results if r.significant]
     lines = [
@@ -494,6 +589,7 @@ def _write_report_md(data, results, contrast, group_col, output_dir, timestamp, 
 
 def _write_result_json(data, results, contrast, output_dir, timestamp, demo):
     sig = [r for r in results if r.significant]
+    action_context = _build_action_context(data, results, contrast)
     result = {
         "tool": "ClawBio Affinity Proteomics",
         "version": "0.1.0",
@@ -504,11 +600,7 @@ def _write_result_json(data, results, contrast, output_dir, timestamp, demo):
         "qc_summary": {k: v for k, v in data.qc_summary.items() if k != "lod_summary"},
         "total_proteins_tested": len(results),
         "significant_proteins": len(sig),
-        "top_10": [
-            {"protein_id": r.protein_id, "gene": r.gene_symbol, "log2fc": round(r.log2fc, 4),
-             "padj": f"{r.padj:.2e}"}
-            for r in results[:10]
-        ],
+        "top_10": action_context["proteins"],
         "chat_summary_lines": [
             (
                 f"Affinity proteomics {'demo' if demo else 'analysis'} complete: "
@@ -518,7 +610,8 @@ def _write_result_json(data, results, contrast, output_dir, timestamp, demo):
             "Choose a small report card below for a read-only follow-up.",
         ],
         "preferred_artifacts": _artifact_entries(output_dir),
-        "suggested_actions": _build_suggested_actions(results),
+        "workflow_state": _workflow_state_from_context(action_context),
+        "suggested_actions": _build_suggested_actions(action_context),
         "disclaimer": DISCLAIMER,
     }
     (output_dir / "result.json").write_text(json.dumps(result, indent=2), encoding="utf-8")
@@ -540,36 +633,45 @@ def _artifact_entries(output_dir: Path) -> list[dict[str, str]]:
     return entries
 
 
-def _build_suggested_actions(results: list[DiffAbundanceResult]) -> list[dict]:
+def _build_suggested_actions(action_context: dict) -> list[dict]:
     """Return the minimal demo follow-up for the Skill Action Menu."""
-    sig = [r for r in results if r.significant]
-    # Keep the teaching example compact: the request carries structured rows,
-    # and the follow-up handler renders the requested slice.
-    top_proteins = [
-        {
-            "protein_id": r.protein_id,
-            "gene": r.gene_symbol,
-            "log2fc": round(r.log2fc, 4),
-            "padj": f"{r.padj:.2e}",
-        }
-        for r in results[:10]
-    ]
+    request_context = {k: v for k, v in action_context.items() if k != "state_id"}
 
     return [
         {
             "action_id": "show-top-proteins",
             "label": "Top Proteins",
+            "description": "Render the top-ranked proteins as a compact table.",
+            "estimate": "~5s",
             "kind": "navigation",
             "request": {
                 "schema": ACTION_REQUEST_SCHEMA,
                 "action": "top-proteins",
+                "state_schema": WORKFLOW_STATE_SCHEMA,
+                "state_id": action_context["state_id"],
                 "n": 5,
-                "total_proteins_tested": len(results),
-                "significant_proteins": len(sig),
-                "proteins": top_proteins,
+                **request_context,
             },
             "requires_confirmation": False,
             "expected_artifacts": ["report.md"],
+            "timeout_secs": 30,
+        },
+        {
+            "action_id": "show-volcano-summary",
+            "label": "Volcano Summary",
+            "description": "Summarise the differential abundance direction counts.",
+            "estimate": "~5s",
+            "kind": "navigation",
+            "request": {
+                "schema": ACTION_REQUEST_SCHEMA,
+                "action": "volcano-summary",
+                "state_schema": WORKFLOW_STATE_SCHEMA,
+                "state_id": action_context["state_id"],
+                **request_context,
+            },
+            "requires_confirmation": False,
+            "expected_artifacts": ["report.md"],
+            "timeout_secs": 30,
         }
     ]
 
@@ -586,45 +688,127 @@ def _load_action_request(input_path: Path) -> dict | None:
     return None
 
 
-def handle_action_request(request: dict, output_dir: Path) -> dict:
-    output_dir.mkdir(parents=True, exist_ok=True)
-    if request.get("action") != "top-proteins":
-        raise ValueError(f"Unsupported action request: {request.get('action')}")
-    proteins = request.get("proteins")
-    if not isinstance(proteins, list):
-        raise ValueError("top-proteins request is missing proteins")
-    try:
-        n = max(1, int(request.get("n", 5)))
-    except (TypeError, ValueError):
-        n = 5
-
-    selected = [protein for protein in proteins[:n] if isinstance(protein, dict)]
-    rows = [
-        "| Protein | Gene | log2FC | Adj P |",
-        "|---------|------|--------|-------|",
-    ]
-    for protein in selected:
-        rows.append(
-            "| {protein_id} | {gene} | {log2fc} | {padj} |".format(
-                protein_id=protein.get("protein_id", ""),
-                gene=protein.get("gene", ""),
-                log2fc=protein.get("log2fc", ""),
-                padj=protein.get("padj", ""),
-            )
+def _stateful_request_workflow_state(request: dict) -> dict | None:
+    """Return valid workflow_state, expired on mismatch, or None for legacy requests."""
+    requested_state_id = request.get("state_id")
+    if not requested_state_id:
+        return None
+    context = _request_context(request)
+    if request.get("state_schema") != WORKFLOW_STATE_SCHEMA or requested_state_id != context["state_id"]:
+        return _workflow_state_from_context(
+            context,
+            lifecycle="expired",
+            state_label="stale-action-request",
+            message=(
+                "This follow-up action no longer matches the analysis state "
+                "that produced it."
+            ),
         )
-    total_tested = request.get("total_proteins_tested", len(proteins))
-    significant = request.get("significant_proteins", "")
-    report_md = "# Affinity Proteomics Follow-up\n\n## Top Proteins\n\n" + "\n".join(rows) + "\n"
+    return _workflow_state_from_context(context)
+
+
+def _current_request_workflow_state(request: dict) -> dict:
+    return _workflow_state_from_context(_request_context(request))
+
+
+def _write_stale_action_result(request: dict, output_dir: Path, workflow_state: dict) -> dict:
+    action = str(request.get("action") or "unknown")
     summary_lines = [
-        f"Showing top {len(selected)} proteins from {total_tested} tested; "
-        f"{significant} met significance thresholds."
+        (
+            "This follow-up action is stale or mismatched. Please rerun the "
+            "affinity-proteomics analysis and choose a fresh action."
+        )
     ]
-    preferred_artifacts = [{"path": "report.md", "label": "Follow-up report"}]
+    report_md = "# Affinity Proteomics Follow-up\n\n" + summary_lines[0] + "\n"
     (output_dir / "report.md").write_text(report_md, encoding="utf-8")
     result = {
         "schema": ACTION_RESULT_SCHEMA,
         "source_schema": ACTION_REQUEST_SCHEMA,
-        "action": "top-proteins",
+        "action": action,
+        "workflow_state": workflow_state,
+        "chat_summary_lines": summary_lines,
+        "preferred_artifacts": [{"path": "report.md", "label": "Follow-up report"}],
+        "report_md": report_md,
+        "disclaimer": DISCLAIMER,
+    }
+    (output_dir / "result.json").write_text(json.dumps(result, indent=2), encoding="utf-8")
+    return result
+
+
+def handle_action_request(request: dict, output_dir: Path) -> dict:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    workflow_state = _stateful_request_workflow_state(request)
+    if workflow_state and workflow_state.get("lifecycle") == "expired":
+        return _write_stale_action_result(request, output_dir, workflow_state)
+
+    action = request.get("action")
+    if action not in {"top-proteins", "volcano-summary"}:
+        raise ValueError(f"Unsupported action request: {request.get('action')}")
+    proteins = request.get("proteins")
+    if not isinstance(proteins, list):
+        raise ValueError("action request is missing proteins")
+
+    if workflow_state is None:
+        workflow_state = _current_request_workflow_state(request)
+
+    total_tested = request.get("total_proteins_tested", len(proteins))
+    significant = request.get("significant_proteins", "")
+    preferred_artifacts = [{"path": "report.md", "label": "Follow-up report"}]
+
+    if action == "top-proteins":
+        try:
+            n = max(1, int(request.get("n", 5)))
+        except (TypeError, ValueError):
+            n = 5
+
+        selected = [protein for protein in proteins[:n] if isinstance(protein, dict)]
+        rows = [
+            "| Protein | Gene | log2FC | Adj P |",
+            "|---------|------|--------|-------|",
+        ]
+        for protein in selected:
+            rows.append(
+                "| {protein_id} | {gene} | {log2fc} | {padj} |".format(
+                    protein_id=protein.get("protein_id", ""),
+                    gene=protein.get("gene", ""),
+                    log2fc=protein.get("log2fc", ""),
+                    padj=protein.get("padj", ""),
+                )
+            )
+        report_md = "# Affinity Proteomics Follow-up\n\n## Top Proteins\n\n" + "\n".join(rows) + "\n"
+        summary_lines = [
+            f"Showing top {len(selected)} proteins from {total_tested} tested; "
+            f"{significant} met significance thresholds."
+        ]
+    else:
+        contrast = request.get("contrast") if isinstance(request.get("contrast"), list) else []
+        group1 = str(contrast[0]) if len(contrast) > 0 else "group 1"
+        group2 = str(contrast[1]) if len(contrast) > 1 else "group 2"
+        up_group1 = request.get("up_in_group1", 0)
+        up_group2 = request.get("up_in_group2", 0)
+        top_gene = proteins[0].get("gene", "") if proteins and isinstance(proteins[0], dict) else ""
+        report_md = (
+            "# Affinity Proteomics Follow-up\n\n"
+            "## Volcano Summary\n\n"
+            f"- Proteins tested: {total_tested}\n"
+            f"- Significant proteins: {significant}\n"
+            f"- Up in {group1}: {up_group1}\n"
+            f"- Up in {group2}: {up_group2}\n"
+            f"- Top ranked protein: {top_gene or 'not available'}\n"
+        )
+        summary_lines = [
+            (
+                f"Volcano summary: {significant} significant proteins; "
+                f"{up_group1} up in {group1}, {up_group2} up in {group2}."
+            )
+        ]
+
+    (output_dir / "report.md").write_text(report_md, encoding="utf-8")
+    result = {
+        "schema": ACTION_RESULT_SCHEMA,
+        "source_schema": ACTION_REQUEST_SCHEMA,
+        "action": action,
+        "workflow_state": workflow_state,
         "chat_summary_lines": summary_lines,
         "preferred_artifacts": preferred_artifacts,
         "report_md": report_md,

--- a/skills/affinity-proteomics/tests/test_affinity_proteomics.py
+++ b/skills/affinity-proteomics/tests/test_affinity_proteomics.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(SKILL_DIR))
 
 from affinity_proteomics import (
     ACTION_REQUEST_SCHEMA,
+    WORKFLOW_STATE_SCHEMA,
     DiffAbundanceResult,
     ProteomicsData,
     differential_abundance,
@@ -184,13 +185,22 @@ class TestOlinkDemo:
         assert result["platform"] == "olink"
         assert result["total_proteins_tested"] == 40
         assert result["chat_summary_lines"][0].startswith("Affinity proteomics demo complete")
+        assert result["workflow_state"]["state_schema"] == WORKFLOW_STATE_SCHEMA
+        assert result["workflow_state"]["state_id"].startswith("sha256:")
+        assert result["workflow_state"]["lifecycle"] == "ready"
+        assert result["workflow_state"]["state_label"] == "differential-abundance-ready"
         assert {action["action_id"] for action in result["suggested_actions"]} == {
             "show-top-proteins",
+            "show-volcano-summary",
         }
         assert all(action["request"]["schema"] == ACTION_REQUEST_SCHEMA for action in result["suggested_actions"])
-        assert all(action["request"]["action"] == "top-proteins" for action in result["suggested_actions"])
-        assert result["suggested_actions"][0]["request"]["n"] == 5
-        assert len(result["suggested_actions"][0]["request"]["proteins"]) == 10
+        assert all(action["request"]["state_schema"] == WORKFLOW_STATE_SCHEMA for action in result["suggested_actions"])
+        assert all(action["request"]["state_id"] == result["workflow_state"]["state_id"] for action in result["suggested_actions"])
+        top_action = next(action for action in result["suggested_actions"] if action["action_id"] == "show-top-proteins")
+        assert top_action["request"]["action"] == "top-proteins"
+        assert top_action["request"]["n"] == 5
+        assert top_action["estimate"] == "~5s"
+        assert len(top_action["request"]["proteins"]) == 10
         assert {"path": "report.md", "label": "Markdown report"} in result["preferred_artifacts"]
 
     def test_action_request_renders_report_section(self, tmp_path):
@@ -214,8 +224,34 @@ class TestOlinkDemo:
         assert (output_dir / "result.json").exists()
         assert result["schema"] == "affinity_proteomics.action_result.v1"
         assert result["action"] == "top-proteins"
+        assert result["workflow_state"]["lifecycle"] == "ready"
+        assert result["workflow_state"]["state_id"] == source_result["workflow_state"]["state_id"]
         assert "## Top Proteins" in result["report_md"]
         assert any("Showing top 5 proteins" in line for line in result["chat_summary_lines"])
+
+    def test_action_request_rejects_mismatched_state(self, tmp_path):
+        source_dir = tmp_path / "source"
+        run_pipeline(
+            platform="olink", input_path=SKILL_DIR / "example_data" / "olink_demo_npx.csv",
+            meta_path=SKILL_DIR / "example_data" / "olink_demo_meta.csv",
+            group_col="Group", contrast=("Case", "Control"),
+            output_dir=source_dir, demo=True,
+        )
+        source_result = json.loads((source_dir / "result.json").read_text())
+        action = next(
+            action for action in source_result["suggested_actions"]
+            if action["action_id"] == "show-top-proteins"
+        )
+        stale_request = {**action["request"], "state_id": "sha256:stale"}
+
+        output_dir = tmp_path / "stale"
+        result = handle_action_request(stale_request, output_dir)
+
+        assert result["schema"] == "affinity_proteomics.action_result.v1"
+        assert result["action"] == "top-proteins"
+        assert result["workflow_state"]["lifecycle"] == "expired"
+        assert result["workflow_state"]["state_label"] == "stale-action-request"
+        assert any("stale or mismatched" in line for line in result["chat_summary_lines"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_action_offers.py
+++ b/tests/test_action_offers.py
@@ -11,6 +11,7 @@ from bot.action_offers import (
     make_pending_action_entry,
     parse_action_reply,
     render_action_offer,
+    render_workflow_state_header,
 )
 
 
@@ -50,6 +51,38 @@ def test_render_action_offer_lists_choices_and_safe_refresh_hint():
     assert "1. Show demo report (safe refresh)" in rendered
     assert "2. Prepare local resource" in rendered
     assert "Reply with `1`, `2`" in rendered
+
+
+def test_render_action_offer_adds_state_header_and_estimate():
+    actions = [{**_demo_actions()[0], "estimate": "~5s"}]
+    rendered = render_action_offer(
+        actions,
+        workflow_state={
+            "lifecycle": "ready",
+            "state_label": "demo-ready",
+        },
+    )
+
+    assert rendered.startswith("State: ready — demo-ready\n")
+    assert "1. Show demo report (~5s)" in rendered
+    assert "(safe refresh)" not in rendered
+
+
+def test_render_workflow_state_header_requires_explicit_lifecycle():
+    assert render_workflow_state_header({"state_label": "implicit-ready"}) == ""
+    assert render_workflow_state_header({"lifecycle": "expired"}) == "State: expired"
+
+
+def test_render_action_offer_can_render_state_without_actions():
+    rendered = render_action_offer(
+        [],
+        workflow_state={
+            "lifecycle": "expired",
+            "state_label": "stale-action-request",
+        },
+    )
+
+    assert rendered == "State: expired — stale-action-request"
 
 
 def test_extract_action_offer_requires_structured_request():
@@ -158,6 +191,12 @@ def test_load_bundle_fields_promotes_structured_chat_fields(tmp_path: Path):
     payload = {
         "chat_summary_lines": ["The skill found one follow-up action."],
         "suggested_actions": _demo_actions(),
+        "workflow_state": {
+            "state_schema": "example.workflow_state.v1",
+            "state_id": "sha256:abc",
+            "lifecycle": "ready",
+            "state_label": "demo-ready",
+        },
         "preferred_artifacts": [{"path": "generated/demo.png"}],
         "report_md": "# Embedded report\n",
     }
@@ -172,5 +211,6 @@ def test_load_bundle_fields_promotes_structured_chat_fields(tmp_path: Path):
     assert fields["skill_result_json"] == payload
     assert fields["chat_summary_lines"] == ["The skill found one follow-up action."]
     assert fields["suggested_actions"] == _demo_actions()
+    assert fields["workflow_state"]["state_id"] == "sha256:abc"
     assert fields["preferred_artifacts"] == [{"path": "generated/demo.png"}]
     assert fields["report_md"] == "# Embedded report\n"

--- a/tests/test_clawbio_runner_actions.py
+++ b/tests/test_clawbio_runner_actions.py
@@ -44,6 +44,12 @@ def test_run_skill_promotes_structured_result_fields(monkeypatch, tmp_path: Path
                         "The skill prepared a structured response.",
                     ],
                     "preferred_artifacts": ["report.md", "result.json"],
+                    "workflow_state": {
+                        "state_schema": "example.workflow_state.v1",
+                        "state_id": "sha256:abc",
+                        "lifecycle": "ready",
+                        "state_label": "demo-ready",
+                    },
                     "suggested_actions": [
                         {
                             "action_id": "show-demo-report",
@@ -81,5 +87,6 @@ def test_run_skill_promotes_structured_result_fields(monkeypatch, tmp_path: Path
     assert result["report_md"] == "# Structured Report\n"
     assert result["chat_summary_lines"] == ["The skill prepared a structured response."]
     assert result["preferred_artifacts"] == ["report.md", "result.json"]
+    assert result["workflow_state"]["state_id"] == "sha256:abc"
     assert result["suggested_actions"][0]["action_id"] == "show-demo-report"
     assert result["skill_result_json"]["schema"] == "example.skill_result.v1"


### PR DESCRIPTION
Hello,

BioClaw since PR #240
- after skill runs
- allows suggested_actions
- chat shows numbered choices
- user selects one
- runs one structured follow-up request

This PR extends this, adding an explicit state of the skill execution:
- skill emits “here is the current analysis state”
- skill says “from this state, these transitions are valid”
- each next action has inputs, expected outputs, cost/time, maybe prerequisites
- ClawBio can ask the skill or a descriptor what states/actions are available
- the user can either pick from the menu or request a result in prose
- ClawBio maps that request to a valid transition

This is meant to be most useful for skills where the natural workflow is exploratory or multi-step: affinity proteomics, GWAS lookup, clinical variant reporting, Galaxy workflows, NCBI datasets, RNA-seq, target evidence mapping. Anything where “the report is not the end; it reveals the next sensible questions” benefits.

Both Claude and Codex liked this. I want to experiment with this a bit more, leaving this as a draft for now. Please comment.

## Summary

This PR extends the structured `suggested_actions` framework from PR #240 with a small workflow-state contract.

A skill can now emit `workflow_state` alongside `suggested_actions`, giving ClawBio and the chat adapters enough information to show a common lifecycle header and pass state-aware structured requests back to the skill. The skill remains responsible for validating whether a selected action still matches the state that produced it.

## Framework changes

- `bot/action_offers.py`
  - Adds `render_workflow_state_header`.
  - Extends `render_action_offer(actions, *, workflow_state=None)` with a backward-compatible keyword-only argument.
  - Loads `workflow_state` from result bundles.
  - Renders optional `estimate` strings as compact action suffixes.

- `clawbio.py`
  - Promotes `workflow_state` from `result.json` through `_promote_structured_result_fields`, so adapters can read it from the normal runner result.

- `bot/roboterri.py` and `bot/roboterri_discord.py`
  - Pass `workflow_state` into action-menu rendering.
  - Render lifecycle headers above summary/report/raw output when a result has state but no offered actions.
  - Do not add any separate workflow-state store; pending actions still carry the stored nested request.

Existing `suggested_actions` without `workflow_state` render as before.

## Affinity-proteomics as the first stateful consumer

`affinity-proteomics` now emits:

- `workflow_state` with `state_schema`, deterministic `state_id`, `lifecycle: "ready"`, and `state_label`.
- Two read-only actions from that state:
  - `Top Proteins`
  - `Volcano Summary`
- Compact `estimate` strings, e.g. `~5s`.

Each action request carries the `state_id` it expects. For this synchronous deterministic skill, `state_id` is a SHA-256 hash over the compact action payload: platform, contrast, protein counts, direction counts, and top protein rows.

That means this example demonstrates request-content integrity and stale/mismatched request rejection, not persistent cross-run state tracking. If the request’s claimed `state_id` does not match the payload, the skill returns a successful structured result with `workflow_state.lifecycle: "expired"` and chat summary lines asking the user to rerun the analysis.

```mermaid
flowchart LR
    A["Normal affinity-proteomics run"] --> B["result.json"]
    B --> C["workflow_state<br/>lifecycle: ready<br/>state_id: sha256:..."]
    B --> D["suggested_actions[]"]
    D --> E["Chat menu<br/>State: ready — differential-abundance-ready<br/>1. Top Proteins (~5s)<br/>2. Volcano Summary (~5s)"]
    E --> F["User selects action"]
    F --> G["Stored nested request dispatched via clawbio.py run --input"]
    G --> H{"state_id matches<br/>request payload?"}
    H -->|yes| I["Follow-up report"]
    H -->|no| J["Expired result<br/>lifecycle: expired"]
```

## Notes

- When an action has `estimate`, the adapter renders that suffix instead of `(safe refresh)` to keep the menu quiet.
- Actions may now include `description` for future richer UIs; current chat adapters do not render it.
- No GENtle-specific support is included in this PR.

## Tests

- `python3 -m py_compile skills/affinity-proteomics/affinity_proteomics.py`
- `/opt/homebrew/bin/pytest tests/test_action_offers.py tests/test_clawbio_runner_actions.py -q`
- `git diff --check`

## Checklist

- [] SKILL.md is present and complete (YAML frontmatter + methodology)
- [ ] Tests included and passing (`pytest -v`)
- [X ] Demo data included for reviewers to test
- [X] No patient/sensitive data committed
- [X] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Prompt from which this PR was created
```md
We are working in the ClawBio repository.

Context:
PR #240 introduced structured `suggested_actions` for ClawBio skills. A skill can now write `suggested_actions[]` into `result.json`; the Telegram and Discord adapters render those as numbered follow-up choices; when the user selects one, ClawBio executes the stored structured request. The first concrete example is `affinity-proteomics`.

Motivation:
Today `suggested_actions` is a flat menu. There is no concept of “this offer is only valid in the state the skill was in when it produced the result.” If the skill is re-run, or if a user picks an old offer later, ClawBio has no deterministic way to tell whether the offer still matches the relevant analysis state. The state-machine layer should add just enough identity for stale or mismatched follow-ups to be rejected safely, and for a skill to declare which actions are valid from the current state.

Goal:
Design and implement a small, generic skill workflow state contract for suggested actions.

The intent is not to build a large workflow engine. The intent is to let a skill expose:
- the current workflow state,
- valid next actions from that state,
- structured action requests,
- optional runtime/cost estimates,
- enough state identity to avoid stale or unsafe follow-ups.

This should preserve the simple Gopher-like menu UX from PR #240 while giving skills a more explicit model underneath.

Scope discipline:
Keep the diff limited to this feature. Do not regenerate unrelated catalogs, reformat unrelated files, or add support for unrelated adjacent features. If you notice extra improvements, list them as follow-up work instead of including them.

Please first inspect the current implementation:
- `clawbio.py`
- `bot/action_offers.py`
- `bot/roboterri.py`
- `bot/roboterri_discord.py`
- `tests/test_action_offers.py`
- `tests/test_clawbio_runner_actions.py`
- `skills/affinity-proteomics/affinity_proteomics.py`
- `skills/affinity-proteomics/SKILL.md`
- `skills/affinity-proteomics/tests/test_affinity_proteomics.py`

Then propose a minimal plan before editing code.

In that plan, include three short JSON snippets:
1. normal skill output with `workflow_state.lifecycle: "ready"` and `suggested_actions`;
2. the exact nested request received via `--input` when the user selects action #1;
3. a stale-state rejection result with `workflow_state.lifecycle: "expired"`.

Preferred schema shape:
- Add a sibling object next to `suggested_actions`:
  - `workflow_state`
    - `state_schema`: string identifier, not JSON Schema; e.g. `affinity_proteomics.workflow_state.v1`
    - `state_id`: deterministic identity for the current analysis state
    - `lifecycle`: optional common lifecycle value
    - `state_label`: short human-readable state label
    - `description`: optional short explanation of the state itself; usually stable across equivalent runs
    - `message`: optional standard human-readable situational explanation; may change per result, e.g. a stale-rejection explanation
- `message` is a standard field on `workflow_state`, not a skill-specific extension.
- Skills may add skill-specific extension fields such as `phase` and `reason`, but adapters do not parse them in this PR.
- `workflow_state` joins the runner-promoted field list in `clawbio.py`’s `_promote_structured_result_fields`, so adapters can read it from the runner result envelope without reparsing `result.json`.
- Keep the existing `suggested_actions[]` array in its current position and with existing field names.
- Each action keeps the existing field names and positions where applicable:
  - `action_id`
  - `label`
  - `description`
  - `request`
  - `requires_confirmation`
  - `expected_artifacts`
  - `timeout_secs`
- Adding new optional action fields is allowed. In this PR, `estimate` is the only expected new action field.
- Each action’s nested `request` should carry the `state_id` it expects, and preferably the relevant `state_schema`.

Do not rename existing fields. Backward compatibility means old payloads keep working and new payloads still use the established field names.

Common lifecycle state:
In addition to skill-specific workflow state, add a small cross-skill lifecycle vocabulary that ClawBio adapters may interpret consistently.

`workflow_state.lifecycle` is an optional string with one of:
- `ready`: actions can be selected now.
- `busy`: the skill is doing in-process work, or the represented state is not ready because the skill is computing.
- `waiting`: the skill is blocked on user input, confirmation, files, an external/local resource, or an out-of-process job.
- `disabled`: actions are intentionally unavailable.
- `error`: the state exists but follow-up actions are blocked by an actual failure, such as missing data or a caught internal exception.
- `expired`: the state or offer is no longer valid, including stale-state rejection.

Omitting `lifecycle` is equivalent to `ready`. Skills that have no need to expose lifecycle should omit the field. Adapters must not render a lifecycle header when the field is omitted.

The skill’s emitted lifecycle is authoritative. ClawBio and the adapters do not transition lifecycle on the skill’s behalf:
- no inferred `busy` while a subprocess runs,
- no client-side `expired` timeout lifecycle,
- no lifecycle changes based on adapter-local state.

Do not require adapters to understand skill-specific values. Adapters may use `lifecycle` for generic rendering decisions, but they should not implement skill-specific state logic.

Adapter lifecycle behavior:
- If `lifecycle` is omitted, render the menu exactly as today.
- For `ready`, `busy`, and `waiting`, the adapter offers any emitted actions normally. The lifecycle header is informational only.
- For `disabled`, `error`, and `expired`, the adapter should not offer selectable actions unless the skill explicitly emits actions anyway.
- Do not invent actions from lifecycle alone.
- When the adapter renders the lifecycle header, the exact format is:
  - `State: <lifecycle> — <state_label>`
- Use an em dash with a single space on each side.
- When `state_label` is absent, render:
  - `State: <lifecycle>`
- When `lifecycle` is absent, render no header.

Skill-specific state:
For this PR, `workflow_state` means a skill-emitted snapshot of the analysis context, not hidden process memory and not a global workflow database.

A state changes only when a skill run emits a new `workflow_state`:
- a normal run can emit an initial state,
- an action-request run can either preserve that state or emit a new state,
- if it emits a new state, its returned `suggested_actions[]` should refer to the new `state_id`.

The skill chooses how to compute `state_id`. A content hash over relevant inputs/results, a hash over a compact state payload, or a run-generated UUID are all acceptable. The implementation must document the choice in `SKILL.md` so reviewers know when an offer should become stale.

Do not require ClawBio to know global “latest state” across unrelated runs. The Telegram and Discord adapters continue to store the current pending action bundle in `_pending_actions`; they do not need a separate `_pending_workflow_state` store. Each action’s nested `request` carries the `state_id` it expects.

Staleness/mismatch behavior:
The skill validates incoming action requests. A request should include the expected `state_id` and, when needed, enough compact state data or artifact reference for the skill to verify that the request matches the state it claims to operate on.

If validation fails, the skill exits successfully with a structured rejection result:
- exit code `0`,
- `workflow_state.lifecycle` is `expired`,
- `result.json` contains `chat_summary_lines` explaining that the action is stale or mismatched,
- no crash,
- no silent success,
- no special chat UI required.

The chat adapters render that rejection through the existing success path.

Action estimate:
`estimate` is an optional string field on each action, for example:
- `"estimate": "~5s"`
- `"estimate": "~30s, low cost"`

The chat adapter renders it verbatim in parentheses:
- `1. Top Proteins (~5s)`

No parsing or structured cost model in this PR.

Design constraints:
1. Backwards compatible:
   Existing `suggested_actions` without `workflow_state` must continue to work unchanged.

2. Generic:
   The state-machine layer must not be GENtle-specific. GENtle is an important future beneficiary, but this PR should introduce a ClawBio-side contract that any skill can use.

3. Small:
   Do not add a database, global workflow engine, JSON Schema infrastructure, or natural-language planning layer.

4. Safety:
   ClawBio must still execute only stored structured requests, not free-form shell lines.

5. UX:
   The chat adapters should continue rendering simple numbered choices.

   If `workflow_state.lifecycle` is present, the adapter may render one compact header line above the menu using the exact format above.

   If an action includes `estimate`, render it in this compact form only when present:
   - `1. Top Proteins (~5s)`
   - `2. Volcano Summary (~30s, low cost)`

6. First consumer:
   Use `affinity-proteomics` as the first minimal consumer again. Prefer the smallest useful demonstration of the state model. Two actions from the same state are acceptable if that better demonstrates “valid transitions from this state”; avoid adding more than needed.

   `affinity-proteomics` is synchronous and deterministic. It is expected to exercise only:
   - `ready` on a normal run,
   - `expired` on stale-state rejection.

   Other lifecycle values should land when a multi-call, asynchronous, externally-dependent, or user-input-dependent skill consumes the contract.

7. Tests:
   Add or update focused tests for:
   - extracting/rendering stateful actions,
   - backward compatibility with old `suggested_actions`,
   - compact estimate rendering,
   - runner promotion of `workflow_state`,
   - affinity-proteomics emitting `workflow_state.lifecycle: "ready"`,
   - affinity-proteomics handling valid stateful action requests,
   - affinity-proteomics rejecting a stale/mismatched state request with `workflow_state.lifecycle: "expired"`.

   Include a concrete stale-state scenario: an action request carries `state_id=A`, but the skill computes or receives current state `state_id=B`; the result should be a structured rejection, not a crash and not a silent success.

   Rendering and parsing tests live in `tests/test_action_offers.py`; runner-promotion tests live in `tests/test_clawbio_runner_actions.py`; affinity emission and stale-rejection tests live in `skills/affinity-proteomics/tests/`.

Deliverables:
- A short proposed plan first, including the three JSON examples.
- Then implement the smallest coherent version.
- If the affinity-proteomics emitted shape changes, update its `## Suggested Actions` section in `SKILL.md` in the same commit.
- Run focused tests:
  - `pytest tests/test_action_offers.py tests/test_clawbio_runner_actions.py skills/affinity-proteomics/tests/`
- Summarize changed files, behavior, tests run, and follow-up ideas.

Non-goals for this PR:
- No GENtle-specific implementation unless already required by existing code.
- No persistent database.
- No multi-user workflow persistence beyond the existing pending-action lifetime.
- No catalog churn or unrelated documentation updates.
- No renaming or restructuring of existing suggested-action fields.
- No renames of existing audit-log event names such as `action_offer`, `action_cancelled`, `action_confirmed`, `action_execute_error`, or `action_execute`. New state-related audit events are allowed only if clearly useful.
- No implementation of `busy`, `waiting`, `disabled`, or `error` in the affinity-proteomics consumer just to demonstrate the vocabulary.
```