### PR TITLE
fix(mendelian-randomisation): support n=1 input cleanly

### DIFF
--- a/skills/mendelian-randomisation/mendelian_randomisation.py
+++ b/skills/mendelian-randomisation/mendelian_randomisation.py
@@ -112,7 +112,10 @@ def ivw(instruments: list[Instrument]) -> MREstimate:
     beta_ivw = np.sum(w * bx * by) / np.sum(w * bx ** 2)
 
     residuals = by - beta_ivw * bx
-    phi = max(1.0, np.sum(w * residuals ** 2) / (len(instruments) - 1))
+    if len(instruments) == 1:
+        phi = 1.0
+    else:
+        phi = max(1.0, np.sum(w * residuals ** 2) / (len(instruments) - 1))
     se_ivw = math.sqrt(phi / np.sum(w * bx ** 2))
 
     z = beta_ivw / se_ivw
@@ -654,7 +657,13 @@ def main() -> None:
     elif args.instruments:
         with open(args.instruments) as f:
             data = json.load(f)
-        instruments = [Instrument(**s) for s in data["instruments"]]
+        instruments = [Instrument(
+            snp=s["SNP"], effect_allele=s["effect_allele"], other_allele=s["other_allele"],
+            eaf=s["eaf"], beta_exposure=s["beta_exposure"], se_exposure=s["se_exposure"],
+            pval_exposure=s["pval_exposure"], beta_outcome=s["beta_outcome"],
+            se_outcome=s["se_outcome"], pval_outcome=s["pval_outcome"],
+            f_statistic=s["f_statistic"],
+        ) for s in data["instruments"]]
         exposure = data.get("exposure", "Exposure")
         outcome = data.get("outcome", "Outcome")
     else:


### PR DESCRIPTION
## Summary

Two small fixes so `mendelian-randomisation` accepts the canonical instrument JSON shape and runs cleanly at `n_instruments == 1`. No public-API changes; no behaviour changes for `n >= 2`.

## What's fixed

**1. `--instruments` parses canonical uppercase `"SNP"` keys.** The `--instruments file.json` codepath at `mendelian_randomisation.py:657` did `Instrument(**s)`, which kwargs-unpacks the JSON dict directly into the dataclass. The dataclass field is `snp` (lowercase, line 49), but the canonical demo file `example_data/demo_instruments.json` uses uppercase `"SNP"`. The `--demo` codepath worked because `load_demo_instruments` (line 575) does an explicit field mapping (`snp=s["SNP"], ...`); the user-input parser didn't. Net effect: passing any JSON shaped like the canonical demo (including the demo file itself, via `--instruments`) crashed with:

```
TypeError: Instrument.__init__() got an unexpected keyword argument 'SNP'. Did you mean 'snp'?
```

Fix: mirror the explicit field mapping from `load_demo_instruments`. Both codepaths now consume the same canonical JSON shape.

**2. IVW at n=1 emits a `RuntimeWarning` from `0/0` in the phi heterogeneity term.** At `n = 1`, the formula

```python
phi = max(1.0, np.sum(w * residuals ** 2) / (len(instruments) - 1))
```

degenerates to `max(1.0, 0 / 0)`. NumPy emits a `RuntimeWarning: invalid value encountered in scalar divide`, the inner expression resolves to `NaN`, and `max(1.0, NaN)` returns `1.0` (because `NaN > 1.0` is `False`). So the IVW output is mathematically correct: the resulting `SE_IVW = sqrt(1 / (w * bx^2)) = SE_out / |β_exp|`, which is exactly the first-order delta-method SE for the Wald ratio. But every n=1 call emits a noisy warning.

Fix: short-circuit `phi = 1.0` when `len(instruments) == 1`. Identical numerical output; no warning.

## Why this matters

We're building an MR orchestrator (`mr-region-run`, single-locus two-sample MR) on top of this skill, and rely on the property that IVW at n=1 returns the textbook Wald ratio so Phase 1 (single-instrument) and Phase 2 (multi-instrument) can share one estimator engine. Verified end-to-end:

| Input | β_exp = 0.5, SE_exp = 0.05, β_out = -0.2, SE_out = 0.04 |
|---|---|
| Expected `WR = β_out / β_exp` | -0.4 |
| Expected `SE_WR = SE_out / \|β_exp\|` (first-order delta) | 0.08 |
| Reza-skill IVW estimate at n=1 | **-0.4** ✓ |
| Reza-skill IVW SE at n=1 | **0.08** ✓ |
| p-value | 5.73e-07 |

Without these fixes, exercising the property required two workarounds (lowercase JSON keys + a `warnings` filter) that diverged from the documented canonical shape. With the fixes, the canonical shape Just Works.

## What's NOT changed

- IVW behaviour at n >= 2 (the if-branch only applies to n=1).
- MR-Egger, Weighted Median, Weighted Mode, sensitivity analysis (untouched).
- The `Instrument` dataclass field names (still lowercase, matching internal convention).
- The canonical demo file shape (already uppercase `"SNP"`; this PR makes the parser match the file, not vice versa).
- Public CLI surface or any other entry point.

## Test plan

- [x] Existing tests pass: `pytest skills/mendelian-randomisation/tests/ -q` → 23 passed.
- [x] `python mendelian_randomisation.py --demo --output /tmp/demo` → IVW estimate matches pre-fix output (n=30 path unchanged).
- [x] `python mendelian_randomisation.py --instruments demo_instruments.json --output /tmp/uppercase` → now works (previously crashed with `TypeError`).
- [x] `python mendelian_randomisation.py --instruments single_instrument.json --output /tmp/n1` → no `RuntimeWarning`, IVW estimate matches hand-computed Wald ratio exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
