### PR TITLE
documentation: Improve CLAWBIO-BRIEF.md

### DIFF
--- a/docs/CLAWBIO-BRIEF.md
+++ b/docs/CLAWBIO-BRIEF.md
@@ -69,7 +69,7 @@ flowchart TD
     analysed -->|"Specialist skill writes its outputs"| artifacts
 ```
 
-The diagram separates **selection** from **execution**. Bio Orchestrator first detects what kind of input or request it has received, then selects a suitable skill from the available registry. A user can override that suggestion by naming a skill directly through the CLI or API. `clawbio.py` then validates and launches the selected skill. The specialist skill performs the scientific work and is responsible for writing the report, tables, figures, and structured `result.json`. Where supported, reproducibility artifacts include `commands.sh`, `environment.yml`, and checksums. The structured `result.json` envelope is documented in [docs/skill-action-contract.md](skill-action-contract.md).
+The diagram separates **selection** from **execution**. Bio Orchestrator first detects what kind of input or request it has received, then selects a suitable skill from the available registry. A user can override that suggestion by naming a skill directly through the CLI or API. `clawbio.py` then validates and launches the selected skill. The specialist skill performs the scientific work and is responsible for writing the report, tables, figures, and structured `result.json`. Where supported, reproducibility artifacts include `commands.sh`, `environment.yml`, and checksums. The structured `result.json` fields are summarised in [docs/architecture.md](architecture.md#structured-next-steps).
 
 Some skills use shared helper code for standardised metadata, disclaimers, checksums, or replay commands, but that is an implementation detail for developers rather than a separate agent role.
 

--- a/docs/CLAWBIO-BRIEF.md
+++ b/docs/CLAWBIO-BRIEF.md
@@ -8,7 +8,12 @@
 
 ## What is ClawBio?
 
-ClawBio is a bioinformatics skill library for local, reproducible genomic analysis. It packages domain methods as composable skills that an agent can route, execute, and report on without sending biological data to third-party cloud services.
+ClawBio is a bioinformatics skill library for local, reproducible genomic analysis. It gives AI agents two things they otherwise lack in computational biology:
+
+- **Skill wrapping**: a consistent way to interact with specialist tools and workflows through documented inputs, outputs, commands, safety constraints, and reproducibility artifacts.
+- **Routing**: a way to decide which specialist skill or agent should handle a request, and what information needs to be retrieved or forwarded between steps.
+
+Both are designed for local execution: biological data does not leave the researcher's machine unless a workflow explicitly uses an external source.
 
 At a high level, ClawBio provides documented workflows for pharmacogenomics, GWAS lookup, PRS calculation, UK Biobank exploration, fine-mapping, and sequencing analysis, with clear inputs, outputs, and reproducibility artifacts.
 
@@ -45,21 +50,28 @@ This is a substantial expansion from the older brief, which described the projec
 
 ## How ClawBio Works
 
-ClawBio uses a simple operating model:
+In the repository, routing (when used) is handled by the **Bio Orchestrator** skill (`skills/bio-orchestrator/`), which looks at file types, table headers, keywords, and explicit user choices. Direct CLI/API calls can bypass routing entirely by naming a skill explicitly.
 
-```text
-User request or input file
-    -> agent routing layer
-        -> specialist ClawBio skill
-            -> report + tables + figures + reproducibility bundle
+```mermaid
+flowchart TD
+    request["User request or input file"]
+    classified["Input and intent classified"]
+    selected["Suitable skill selected"]
+    launched["Skill run launched"]
+    analysed["Domain analysis completed"]
+    artifacts["Report + tables + figures + reproducibility bundle"]
+
+    request -->|"Bio Orchestrator detects file type, headers, and intent"| classified
+    classified -->|"Bio Orchestrator selects a suitable skill from the registry"| selected
+    request -->|"User names a skill directly via CLI/API"| launched
+    selected -->|"clawbio.py validates the selected skill and allowed flags"| launched
+    launched -->|"Specialist skill script runs its documented method"| analysed
+    analysed -->|"Specialist skill writes its outputs"| artifacts
 ```
 
-In practice, that means an agent can:
+The diagram separates **selection** from **execution**. Bio Orchestrator first detects what kind of input or request it has received, then selects a suitable skill from the available registry. A user can override that suggestion by naming a skill directly through the CLI or API. `clawbio.py` then validates and launches the selected skill. The specialist skill performs the scientific work and is responsible for writing the report, tables, figures, and structured `result.json`. Where supported, reproducibility artifacts include `commands.sh`, `environment.yml`, and checksums. The structured `result.json` envelope is documented in [docs/skill-action-contract.md](skill-action-contract.md).
 
-- detect the analysis intent or file type
-- route to a specialist skill such as PharmGx, GWAS Lookup, UKB Navigator, or Fine-Mapping
-- run the analysis locally
-- return a report plus reproducibility artifacts such as `commands.sh`, `environment.yml`, and checksums
+Some skills use shared helper code for standardised metadata, disclaimers, checksums, or replay commands, but that is an implementation detail for developers rather than a separate agent role.
 
 ## Skills Snapshot
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,36 +6,17 @@ ClawBio is a collection of modular AI agent skills for bioinformatics, designed 
 
 ## System Design
 
-```
-                    ┌─────────────────────┐
-                    │    User Request      │
-                    │  (natural language)  │
-                    └──────────┬──────────┘
-                               │
-                    ┌──────────▼──────────┐
-                    │   Bio Orchestrator   │
-                    │  (routing + planning │
-                    │   + report assembly) │
-                    └──────────┬──────────┘
-                               │
-              ┌────────────────┼────────────────┐
-              │                │                 │
-    ┌─────────▼───────┐ ┌─────▼──────┐ ┌───────▼────────┐
-    │  Equity Scorer   │ │ Seq Wrangler│ │ Struct Predictor│
-    │  VCF Annotator   │ │ scRNA Orch  │ │ Lit Synthesizer │
-    │                  │ │             │ │ Repro Enforcer  │
-    └─────────┬───────┘ └─────┬──────┘ └───────┬────────┘
-              │                │                 │
-              └────────────────┼────────────────┘
-                               │
-                    ┌──────────▼──────────┐
-                    │   Output Layer       │
-                    │  - Markdown report   │
-                    │  - Figures (PNG/SVG) │
-                    │  - Optional repro    │
-                    │    bundle            │
-                    └─────────────────────┘
-```
+ClawBio is easiest to read as a set of layers rather than one monolithic
+agent. Each layer has a narrow responsibility:
+
+| Layer | Main Files / Components | Responsibility |
+|-------|-------------------------|----------------|
+| Interfaces | CLI, Python API, RoboTerri, Discord, OpenClaw gateway, Claude Code | Accept a user request, collect files, and either name a skill directly or ask for routing. |
+| Skill self-description | `skills/<name>/SKILL.md`, optional `skills/<name>/INTENTS.json`, `skills/catalog.json` | Describe what the skill does, what inputs it accepts, how it is invoked, and when it should be considered. |
+| Routing and planning | `skills/bio-orchestrator/`, `clawbio/skill_intents.py`, `docs/skill-intents.md` | Detect file types, headers, keywords, and structured intent descriptors; select a suitable skill or plan a small chain. |
+| Runner and safety gate | `clawbio.py` / `clawbio.run_skill()` | Validate the selected skill, enforce allowed flags, prepare output directories, and launch the skill script. |
+| Specialist skill execution | `skills/<name>/<script>.py` plus skill-local helpers | Run the domain method and produce skill-owned outputs. |
+| Output contract | `report.md`, `result.json`, `tables/`, `figures/`, `reproducibility/` | Return human-readable reports, machine-readable results, preferred artifacts, suggested follow-ups, and replay metadata where supported. |
 
 ## Routing Logic
 
@@ -56,6 +37,24 @@ Every skill works standalone. The Bio Orchestrator adds:
 
 A user can invoke any skill directly without the orchestrator.
 
+## Skill Self-Description
+
+Skills describe themselves before they execute. `SKILL.md` is the primary
+human- and agent-readable contract: it records the domain method, expected
+inputs, outputs, safety boundaries, demo commands, and gotchas. Python scripts
+are implementations of that contract, not replacements for it.
+
+Some skills also publish optional intent descriptors in `INTENTS.json` or
+`skill_intents.json`; see [docs/skill-intents.md](skill-intents.md) for the
+descriptor schema. These files are data-only routing metadata for chat adapters
+and planners: aliases, trigger terms, slot extraction rules, safe execution
+plans, and confirmation gates. They do not grant new shell powers or new CLI
+flags; `clawbio.py` still enforces the registered allow-list.
+
+Together, `SKILL.md`, optional intent descriptors, and `skills/catalog.json`
+let agents discover what a skill can do without scraping prose from previous
+chat sessions.
+
 ## Data Flow
 
 ```
@@ -74,11 +73,36 @@ Results (tables, metrics, intermediate files)
 Visualisation (matplotlib/seaborn figures)
     │
     ▼
+Structured Output (result.json + preferred artifacts)
+    │
+    ▼
 Report Assembly (markdown + embedded figures)
     │
     ▼
 Optional Reproducibility Export (helper-backed commands, environment, checksums)
 ```
+
+The same run may also expose UI-facing fields from `result.json`, including
+`chat_summary_lines`, `preferred_artifacts`, `workflow_state`, and
+`suggested_actions`. These fields let chat or GUI frontends render compact
+summaries and offer deterministic next steps without inventing follow-up
+commands.
+
+## Structured Next Steps
+
+Where supported, a skill can describe valid follow-up actions in its
+`result.json` output:
+
+- `workflow_state`: the lifecycle, label, and stable state identity for the
+  completed run.
+- `preferred_artifacts`: files the UI should surface first.
+- `suggested_actions`: deterministic next-step requests, such as "show top
+  results" or "summarise by category".
+- `chat_summary_lines`: short skill-authored text suitable for chat adapters.
+
+This keeps next-step menus tied to the skill's own state rather than to an
+agent's guess. Not every skill emits these fields yet; skills without them still
+return the standard report and output bundle.
 
 ## Privacy Model
 


### PR DESCRIPTION
Codex, Claude and me had a look at the introduction to ClawBio by docs/CLAWBIO-BRIEF.md and docs/architecture.md.  We updated diagrams, think to have helped with the clarity of the writing, and also referenced the suggested actions.