### PR TITLE
Clock emoji for clocks - and adjusting the upper/lower case for consistency

### DIFF
--- a/skills/methylation-clock/SKILL.md
+++ b/skills/methylation-clock/SKILL.md
@@ -36,9 +36,9 @@ metadata:
     - epigenetic age
     - methylation clock
     - pyaging
-    - horvath
-    - grimage
-    - dunedinpace
+    - Horvath
+    - GrimAge
+    - DunedinPACE
     - GEO
     - GSE
 ---

--- a/skills/methylation-clock/SKILL.md
+++ b/skills/methylation-clock/SKILL.md
@@ -18,7 +18,7 @@ metadata:
       bins:
       - python3
     always: false
-    emoji: 🧪
+    emoji: 🕰️
     homepage: https://github.com/ClawBio/ClawBio
     os:
     - darwin

--- a/skills/proteomics-clock/SKILL.md
+++ b/skills/proteomics-clock/SKILL.md
@@ -12,8 +12,8 @@ metadata:
   - aging
   - olink
   - organ-clock
-  - biological-age
-  - goeminne
+  - biological age
+  - Goeminne
   inputs:
   - name: input_file
     type: file
@@ -155,7 +155,7 @@ python skills/proteomics-clock/proteomics_clock.py \
 python skills/proteomics-clock/proteomics_clock.py --demo --output /tmp/proteomics_demo
 ```
 
-Expected output: predictions for 20 synthetic samples across Heart, Brain, Kidney (and more) organ clocks, with distribution boxplots, correlation heatmap, and sample-organ heatmap.
+Expected output: Predictions for 20 synthetic samples across heart, brain, kidney (and more) organ clocks, with distribution boxplots, correlation heatmap, and sample-organ heatmap.
 
 ## Algorithm / Methodology
 

--- a/skills/proteomics-clock/SKILL.md
+++ b/skills/proteomics-clock/SKILL.md
@@ -47,6 +47,7 @@ metadata:
       bins:
       - python3
     always: false
+    emoji: 🕰️
     homepage: https://github.com/ClawBio/ClawBio
     os:
     - darwin
@@ -278,4 +279,3 @@ This skill computes organ ages for a single timepoint. For longitudinal or treat
 - [Goeminne et al. (2025)](https://doi.org/10.1016/j.cmet.2024.10.005) Cell Metabolism 37(1):205-222.e6 — organ-specific proteomic aging clocks
 - [organAging GitHub](https://github.com/ludgergoeminne/organAging) — model coefficients and example scripts
 - [Olink Proteomics](https://olink.com) — Proximity Extension Assay platform
-i


### PR DESCRIPTION
## Summary

I was after the build lint failure and found this warning about a missing emoji for the aging clocks. Well, that seemed rather obvious for me to fix.

## Skill affected

proteomics-clock
methylation-clock

## Checklist

- [X] SKILL.md is present and complete (YAML frontmatter + methodology)
- [X] No patient/sensitive data committed
- [X] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

No functional change, no tests performed, if the warning is not showing then we are gold.