### PR TITLE
feat: surface discrepancies between LLM plans and ClawBio rules

### DIFF
--- a/bot/action_offers.py
+++ b/bot/action_offers.py
@@ -16,6 +16,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
 
+from clawbio.contract_alerts import normalise_contract_alerts, render_contract_alerts
+
 DEFAULT_PENDING_ACTION_TTL_SECONDS = 30 * 60
 
 # These are stand-alone confirmation/navigation phrases. They are intentionally
@@ -140,16 +142,22 @@ def load_bundle_fields(output_dir: str | Path | None) -> dict[str, Any]:
             # - preferred_artifacts: files the UI should prioritize displaying
             # - suggested_actions: deterministic follow-up requests to offer
             # - workflow_state: skill-emitted state identity/lifecycle metadata
+            # - contract_alerts: structured contract/path discrepancy alerts
             # - report_md: full markdown report embedded in result.json
             for key in (
                 "chat_summary_lines",
                 "preferred_artifacts",
                 "suggested_actions",
                 "workflow_state",
+                "contract_alerts",
                 "report_md",
             ):
                 if key in payload:
-                    fields[key] = payload[key]
+                    fields[key] = (
+                        normalise_contract_alerts(payload[key])
+                        if key == "contract_alerts"
+                        else payload[key]
+                    )
 
     if "report_md" not in fields:
         for pattern in ("report.md", "*_report.md", "*.md"):

--- a/bot/roboterri.py
+++ b/bot/roboterri.py
@@ -54,6 +54,7 @@ from clawbio.skill_intents import (
     skill_intent_tool_summary,
     skill_names_for_tool_schema,
 )
+from clawbio.contract_alerts import append_contract_alert_log
 from bot.tool_loop_utils import (
     execute_tool_calls_safely,
     repair_tool_call_history,
@@ -74,6 +75,7 @@ try:  # Allow running as `python bot/roboterri.py` and as a package import.
         make_pending_action_entry,
         parse_action_reply,
         render_action_offer,
+        render_contract_alerts,
         render_workflow_state_header,
     )
 except ImportError:  # pragma: no cover - package import fallback
@@ -89,6 +91,7 @@ except ImportError:  # pragma: no cover - package import fallback
         make_pending_action_entry,
         parse_action_reply,
         render_action_offer,
+        render_contract_alerts,
         render_workflow_state_header,
     )
 
@@ -598,9 +601,14 @@ def _render_skill_result(chat_id: int, skill_key: str, result: dict) -> str:
     actions = extract_action_offer(result)
     workflow_state = result.get("workflow_state")
     state_header = render_workflow_state_header(workflow_state)
+    alert_text = render_contract_alerts(result.get("contract_alerts"))
 
     if actions:
         reply_parts: list[str] = []
+        if state_header:
+            reply_parts.append(state_header)
+        if alert_text:
+            reply_parts.append(alert_text)
         if summary_lines:
             reply_parts.append("\n".join(summary_lines))
         elif report_text:
@@ -609,7 +617,7 @@ def _render_skill_result(chat_id: int, skill_key: str, result: dict) -> str:
             reply_parts.append(raw_output)
         else:
             reply_parts.append(f"{skill_key} completed.")
-        reply_parts.append(render_action_offer(actions, workflow_state=workflow_state))
+        reply_parts.append(render_action_offer(actions))
         rendered = "\n\n".join(part for part in reply_parts if part).strip()
         _pending_actions[chat_id] = make_pending_action_entry(
             skill=skill_key,
@@ -631,19 +639,18 @@ def _render_skill_result(chat_id: int, skill_key: str, result: dict) -> str:
 
     if skill_key in ("compare", "drugphoto", "profile"):
         rendered = raw_output or report_text or f"{skill_key} completed."
-        if state_header:
-            rendered = "\n\n".join([state_header, rendered])
+        rendered = "\n\n".join(part for part in (state_header, alert_text, rendered) if part)
         if rendered:
             _pending_text.setdefault(chat_id, []).append(rendered)
         return "Result sent directly to chat. Do not repeat or paraphrase it."
 
     if summary_lines:
-        return "\n\n".join(part for part in (state_header, "\n".join(summary_lines)) if part)
+        return "\n\n".join(part for part in (state_header, alert_text, "\n".join(summary_lines)) if part)
     if report_text:
         rendered_report = _trim_report_for_chat(report_text)
-        return "\n\n".join(part for part in (state_header, rendered_report) if part)
+        return "\n\n".join(part for part in (state_header, alert_text, rendered_report) if part)
     rendered_output = raw_output if raw_output else f"{skill_key} completed. Output: {output_dir}"
-    return "\n\n".join(part for part in (state_header, rendered_output) if part)
+    return "\n\n".join(part for part in (state_header, alert_text, rendered_output) if part)
 
 
 async def execute_clawbio(args: dict) -> str:
@@ -796,7 +803,15 @@ async def execute_clawbio(args: dict) -> str:
         selected_intent=plan.intent_id,
         matched_route=plan.matched_route,
         commands=[item.argv for item in plan.executions],
+        contract_alerts=plan.contract_alerts,
     )
+    if plan.contract_alerts:
+        append_contract_alert_log(
+            OUTPUT_DIR / "contract_alerts.jsonl",
+            plan.contract_alerts,
+            skill=plan.skill,
+            intent_id=plan.intent_id,
+        )
     logger.info(
         "Skill intent plan: skill=%s intent=%s status=%s reason=%s",
         plan.skill, plan.intent_id, plan.status, plan.reason,
@@ -807,6 +822,7 @@ async def execute_clawbio(args: dict) -> str:
             selected_skill=plan.skill,
             selected_intent=plan.intent_id,
             matched_route=plan.matched_route,
+            contract_alerts=plan.contract_alerts,
         )
     if plan.status == "needs_input" or not plan.executions:
         return _error(
@@ -815,6 +831,7 @@ async def execute_clawbio(args: dict) -> str:
             selected_skill=plan.skill,
             selected_intent=plan.intent_id,
             matched_route=plan.matched_route,
+            contract_alerts=plan.contract_alerts,
         )
 
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/bot/roboterri_discord.py
+++ b/bot/roboterri_discord.py
@@ -46,6 +46,7 @@ from clawbio.skill_intents import (
     skill_intent_tool_summary,
     skill_names_for_tool_schema,
 )
+from clawbio.contract_alerts import append_contract_alert_log
 from bot.tool_loop_utils import (
     execute_tool_calls_safely,
     repair_tool_call_history,
@@ -66,6 +67,7 @@ try:
         make_pending_action_entry,
         parse_action_reply,
         render_action_offer,
+        render_contract_alerts,
         render_workflow_state_header,
     )
 except ImportError:  # pragma: no cover - package import fallback
@@ -81,6 +83,7 @@ except ImportError:  # pragma: no cover - package import fallback
         make_pending_action_entry,
         parse_action_reply,
         render_action_offer,
+        render_contract_alerts,
         render_workflow_state_header,
     )
 
@@ -674,9 +677,14 @@ def _render_skill_result(channel_id: int, skill_key: str, result: dict) -> str:
     actions = extract_action_offer(result)
     workflow_state = result.get("workflow_state")
     state_header = render_workflow_state_header(workflow_state)
+    alert_text = render_contract_alerts(result.get("contract_alerts"))
 
     if actions:
         reply_parts: list[str] = []
+        if state_header:
+            reply_parts.append(state_header)
+        if alert_text:
+            reply_parts.append(alert_text)
         if summary_lines:
             reply_parts.append("\n".join(summary_lines))
         elif report_text:
@@ -685,7 +693,7 @@ def _render_skill_result(channel_id: int, skill_key: str, result: dict) -> str:
             reply_parts.append(raw_output)
         else:
             reply_parts.append(f"{skill_key} completed.")
-        reply_parts.append(render_action_offer(actions, workflow_state=workflow_state))
+        reply_parts.append(render_action_offer(actions))
         rendered = "\n\n".join(part for part in reply_parts if part).strip()
         _pending_actions[channel_id] = make_pending_action_entry(
             skill=skill_key,
@@ -707,19 +715,18 @@ def _render_skill_result(channel_id: int, skill_key: str, result: dict) -> str:
 
     if skill_key in ("compare", "drugphoto", "profile"):
         rendered = raw_output or report_text or f"{skill_key} completed."
-        if state_header:
-            rendered = "\n\n".join([state_header, rendered])
+        rendered = "\n\n".join(part for part in (state_header, alert_text, rendered) if part)
         if rendered:
             _pending_text.setdefault(channel_id, []).append(rendered)
         return "Result sent directly to chat. Do not repeat or paraphrase it."
 
     if summary_lines:
-        return "\n\n".join(part for part in (state_header, "\n".join(summary_lines)) if part)
+        return "\n\n".join(part for part in (state_header, alert_text, "\n".join(summary_lines)) if part)
     if report_text:
         rendered_report = _trim_report_for_chat(report_text)
-        return "\n\n".join(part for part in (state_header, rendered_report) if part)
+        return "\n\n".join(part for part in (state_header, alert_text, rendered_report) if part)
     rendered_output = raw_output if raw_output else f"{skill_key} completed. Output: {output_dir}"
-    return "\n\n".join(part for part in (state_header, rendered_output) if part)
+    return "\n\n".join(part for part in (state_header, alert_text, rendered_output) if part)
 
 
 async def execute_clawbio(args: dict) -> str:
@@ -871,7 +878,15 @@ async def execute_clawbio(args: dict) -> str:
         selected_intent=plan.intent_id,
         matched_route=plan.matched_route,
         commands=[item.argv for item in plan.executions],
+        contract_alerts=plan.contract_alerts,
     )
+    if plan.contract_alerts:
+        append_contract_alert_log(
+            OUTPUT_DIR / "contract_alerts.jsonl",
+            plan.contract_alerts,
+            skill=plan.skill,
+            intent_id=plan.intent_id,
+        )
     logger.info(
         "Skill intent plan: skill=%s intent=%s status=%s reason=%s",
         plan.skill, plan.intent_id, plan.status, plan.reason,
@@ -882,6 +897,7 @@ async def execute_clawbio(args: dict) -> str:
             selected_skill=plan.skill,
             selected_intent=plan.intent_id,
             matched_route=plan.matched_route,
+            contract_alerts=plan.contract_alerts,
         )
     if plan.status == "needs_input" or not plan.executions:
         return _error(
@@ -890,6 +906,7 @@ async def execute_clawbio(args: dict) -> str:
             selected_skill=plan.skill,
             selected_intent=plan.intent_id,
             matched_route=plan.matched_route,
+            contract_alerts=plan.contract_alerts,
         )
 
     ts = datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/clawbio.py
+++ b/clawbio.py
@@ -28,6 +28,8 @@ import time
 from datetime import datetime
 from pathlib import Path
 
+from clawbio.contract_alerts import append_contract_alert_log, normalise_contract_alerts
+
 # --------------------------------------------------------------------------- #
 # Paths
 # --------------------------------------------------------------------------- #
@@ -1088,16 +1090,30 @@ def _promote_structured_result_fields(result: dict, out_dir: Path | None) -> Non
         # - preferred_artifacts: generated files the UI should surface first
         # - suggested_actions: deterministic next-step requests to offer later
         # - workflow_state: skill-emitted state identity/lifecycle metadata
+        # - contract_alerts: structured contract/path discrepancy alerts
         # - report_md: full markdown report text embedded in result.json
         for field in (
             "chat_summary_lines",
             "preferred_artifacts",
             "suggested_actions",
             "workflow_state",
+            "contract_alerts",
             "report_md",
         ):
             if field in payload:
-                result[field] = payload[field]
+                result[field] = (
+                    normalise_contract_alerts(payload[field])
+                    if field == "contract_alerts"
+                    else payload[field]
+                )
+
+        if out_dir is not None and result.get("contract_alerts"):
+            append_contract_alert_log(
+                out_dir / "contract_alerts.jsonl",
+                result["contract_alerts"],
+                run_id=out_dir.name,
+                skill=result.get("skill") or None,
+            )
 
     if "report_md" not in result:
         report_md = _load_report_markdown(out_dir)

--- a/clawbio/contract_alerts.py
+++ b/clawbio/contract_alerts.py
@@ -1,0 +1,282 @@
+"""Structured contract-discrepancy alerts for ClawBio.
+
+Contract alerts are not biomedical findings. They describe places where the
+chosen route, input, state, policy, or schema does not line up with the
+declared ClawBio contracts.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+CONTRACT_ALERT_SCHEMA = "clawbio.contract_alert.v1"
+CONTRACT_ALERT_LOG_SCHEMA = "clawbio.contract_alert_log.v1"
+
+ALERT_SEVERITIES = ("error", "warning", "info")
+ALERT_KINDS = {
+    "planner.intent_input_mismatch",
+    "planner.missing_required_slot",
+    "planner.demo_requires_explicit_request",
+    "planner.unregistered_skill",
+    "runner.descriptor_security_skip",
+    "runner.input_contract_mismatch",
+    "skill.state_mismatch",
+    "skill.version_drift",
+    "skill.missing_required_input",
+    "policy.remote_execution_requires_consent",
+    "other",
+}
+
+_SEVERITY_ORDER = {"error": 0, "warning": 1, "info": 2}
+_SEVERITY_LABEL = {"error": "Error", "warning": "Warning", "info": "Info"}
+_MAX_MESSAGE_CHARS = 200
+_MAX_FIELD_CHARS = 120
+_MAX_EVIDENCE_ITEMS = 5
+_MAX_EVIDENCE_CHARS = 100
+_MAX_REMEDY_LABEL_CHARS = 80
+_SECRET_ASSIGNMENT_PATTERN = re.compile(
+    r"(?i)\b(api[_-]?key|token|secret|password)\s*[:=]\s*[^\s,;]+"
+)
+_SECRET_TOKEN_PATTERN = re.compile(
+    r"\b(sk-[A-Za-z0-9_-]{8,}|gi_[A-Za-z0-9]{8,}|gh[pousr]_[A-Za-z0-9_]{8,})\b"
+)
+
+
+def _clamp(text: str, max_chars: int) -> str:
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) <= max_chars:
+        return text
+    return text[: max_chars - 3].rstrip() + "..."
+
+
+def _redact_home_paths(text: str) -> str:
+    try:
+        home = str(Path.home())
+    except Exception:
+        return text
+    if not home or home == os.sep:
+        return text
+    return text.replace(home, "~")
+
+
+def _redact_secrets(text: str) -> str:
+    redacted = _SECRET_ASSIGNMENT_PATTERN.sub(lambda m: f"{m.group(1)}=<redacted>", text)
+    redacted = _SECRET_TOKEN_PATTERN.sub("<redacted-secret>", redacted)
+    return redacted
+
+
+def _safe_text(value: Any, *, max_chars: int = _MAX_FIELD_CHARS) -> str:
+    if isinstance(value, str):
+        text = value
+    else:
+        text = json.dumps(value, sort_keys=True, ensure_ascii=True, default=str)
+    return _clamp(_redact_secrets(_redact_home_paths(text)), max_chars)
+
+
+def _normalise_remedies(value: Any) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        return []
+    remedies: list[dict[str, str]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        label = item.get("label")
+        skill = item.get("skill")
+        action = item.get("action")
+        has_skill = isinstance(skill, str) and bool(skill.strip())
+        has_action = isinstance(action, str) and bool(action.strip())
+        if not isinstance(label, str) or not label.strip() or has_skill == has_action:
+            continue
+        remedy = {"label": _safe_text(label, max_chars=_MAX_REMEDY_LABEL_CHARS)}
+        if has_skill:
+            remedy["skill"] = _safe_text(skill, max_chars=_MAX_REMEDY_LABEL_CHARS)
+        else:
+            remedy["action"] = _safe_text(action, max_chars=_MAX_REMEDY_LABEL_CHARS)
+        remedies.append(remedy)
+    return remedies
+
+
+def make_contract_alert(
+    *,
+    kind: str,
+    message: str,
+    severity: str = "warning",
+    expected: Any | None = None,
+    observed: Any | None = None,
+    evidence: list[Any] | None = None,
+    remedies: list[dict[str, Any]] | None = None,
+    blocking: bool = False,
+    detail: str | None = None,
+) -> dict[str, Any]:
+    """Create a normalised contract alert.
+
+    ``expected`` and ``observed`` are display labels. Raw values belong in
+    ``evidence`` only after sanitisation.
+    """
+
+    if severity not in ALERT_SEVERITIES:
+        allowed = ", ".join(ALERT_SEVERITIES)
+        raise ValueError(f"invalid contract alert severity: {severity!r}; expected one of {allowed}")
+    if kind not in ALERT_KINDS:
+        raise ValueError(f"invalid contract alert kind: {kind!r}")
+    if not isinstance(message, str) or not message.strip():
+        raise ValueError("invalid contract alert message: expected non-empty string")
+
+    alert = {
+        "schema": CONTRACT_ALERT_SCHEMA,
+        "severity": severity,
+        "kind": kind,
+        "message": message,
+        "blocking": bool(blocking),
+    }
+    if expected is not None:
+        alert["expected"] = expected
+    if observed is not None:
+        alert["observed"] = observed
+    if evidence:
+        alert["evidence"] = evidence
+    if remedies:
+        alert["remedies"] = remedies
+    if detail:
+        alert["detail"] = detail
+    normalised = normalise_contract_alerts([alert])
+    if not normalised:
+        raise ValueError("invalid contract alert")
+    return normalised[0]
+
+
+def normalise_contract_alerts(value: Any) -> list[dict[str, Any]]:
+    """Return valid, sanitised contract alerts; invalid entries are dropped."""
+
+    if not isinstance(value, list):
+        return []
+    alerts: list[dict[str, Any]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        severity = item.get("severity")
+        kind = item.get("kind")
+        message = item.get("message")
+        if severity not in ALERT_SEVERITIES:
+            continue
+        if kind not in ALERT_KINDS:
+            continue
+        if not isinstance(message, str) or not message.strip():
+            continue
+
+        alert: dict[str, Any] = {
+            "schema": CONTRACT_ALERT_SCHEMA,
+            "severity": severity,
+            "kind": kind,
+            "message": _safe_text(message, max_chars=_MAX_MESSAGE_CHARS),
+            "blocking": bool(item.get("blocking", False)),
+        }
+        if item.get("schema") not in (None, CONTRACT_ALERT_SCHEMA):
+            continue
+        for key in ("expected", "observed"):
+            if item.get(key) is not None:
+                alert[key] = _safe_text(item[key], max_chars=_MAX_FIELD_CHARS)
+        if isinstance(item.get("detail"), str) and item["detail"].strip():
+            alert["detail"] = _safe_text(item["detail"], max_chars=_MAX_FIELD_CHARS)
+        evidence = item.get("evidence")
+        if isinstance(evidence, list):
+            cleaned = [
+                _safe_text(entry, max_chars=_MAX_EVIDENCE_CHARS)
+                for entry in evidence[:_MAX_EVIDENCE_ITEMS]
+                if str(entry).strip()
+            ]
+            if cleaned:
+                alert["evidence"] = cleaned
+        remedies = _normalise_remedies(item.get("remedies"))
+        if remedies:
+            alert["remedies"] = remedies
+        alerts.append(alert)
+    return alerts
+
+
+def sorted_contract_alerts(alerts: Any) -> list[dict[str, Any]]:
+    """Return alerts sorted by display severity."""
+
+    return sorted(
+        normalise_contract_alerts(alerts),
+        key=lambda item: (_SEVERITY_ORDER[item["severity"]], item["kind"], item["message"]),
+    )
+
+
+def render_contract_alerts(alerts: Any) -> str:
+    """Render contract alerts as compact chat text."""
+
+    lines: list[str] = []
+    for alert in sorted_contract_alerts(alerts):
+        kind_label = alert["kind"].split(".", 1)[-1].replace("_", " ")
+        lines.append(f"{_SEVERITY_LABEL[alert['severity']]}: {kind_label}")
+        lines.append(alert["message"])
+        expected = alert.get("expected")
+        observed = alert.get("observed")
+        if expected or observed:
+            parts = []
+            if expected:
+                parts.append(f"expected {expected}")
+            if observed:
+                parts.append(f"observed {observed}")
+            lines.append("; ".join(parts))
+        remedies = alert.get("remedies")
+        if isinstance(remedies, list) and remedies:
+            labels = [str(item.get("label", "")).strip() for item in remedies if item.get("label")]
+            if labels:
+                lines.append("Remedies: " + "; ".join(labels))
+        lines.append("")
+    return "\n".join(lines).strip()
+
+
+def append_contract_alert_log(
+    log_path: str | Path,
+    alerts: Any,
+    *,
+    run_id: str | None = None,
+    skill: str | None = None,
+    intent_id: str | None = None,
+    timestamp: str | None = None,
+) -> int:
+    """Append sanitised alerts as JSONL and never raise on logging failure.
+
+    ``intent_id`` is the routing intent identifier when an ``INTENTS.json``
+    planner picked the route; it is omitted for direct CLI/API invocation.
+    Required log fields are ``schema``, ``timestamp``, and ``alert``.
+    ``run_id``, ``skill``, and ``intent_id`` may be absent for pre-run alerts.
+
+    v1 uses append-only writes and does not deduplicate or rotate logs.
+    Operators may archive the global fallback log manually.
+    """
+
+    cleaned = normalise_contract_alerts(alerts)
+    if not cleaned:
+        return 0
+    path = Path(log_path)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        stamp = timestamp or datetime.now(timezone.utc).isoformat(timespec="seconds")
+        count = 0
+        with path.open("a", encoding="utf-8") as handle:
+            for alert in cleaned:
+                record: dict[str, Any] = {
+                    "schema": CONTRACT_ALERT_LOG_SCHEMA,
+                    "timestamp": stamp,
+                    "alert": alert,
+                }
+                if run_id is not None:
+                    record["run_id"] = str(run_id)
+                if skill is not None:
+                    record["skill"] = str(skill)
+                if intent_id is not None:
+                    record["intent_id"] = str(intent_id)
+                handle.write(json.dumps(record, sort_keys=True, ensure_ascii=True) + "\n")
+                count += 1
+        return count
+    except OSError:
+        return 0

--- a/clawbio/skill_intents.py
+++ b/clawbio/skill_intents.py
@@ -19,6 +19,8 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from clawbio.contract_alerts import make_contract_alert
+
 
 SCHEMA = "clawbio.skill_intents.v1"
 DESCRIPTOR_FILENAMES = ("INTENTS.json", "skill_intents.json")
@@ -125,9 +127,14 @@ class SkillExecutionPlan:
     requested_mode: str | None = None
     descriptor_path: str | None = None
     warnings: list[str] = field(default_factory=list)
+    contract_alerts: list[dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
+
+
+def _contract_alert(kind: str, message: str, **kwargs: Any) -> dict[str, Any]:
+    return make_contract_alert(kind=kind, message=message, **kwargs)
 
 
 def load_default_skill_registry(project_root: str | Path | None = None) -> dict[str, dict[str, Any]]:
@@ -667,6 +674,7 @@ def _plan_descriptor_route(
     skill_dir = Path(str(descriptor["_skill_dir"]))
     executions: list[SkillIntentExecution] = []
     warnings: list[str] = []
+    contract_alerts: list[dict[str, Any]] = []
     missing_skills: set[str] = set()
     missing_slots: set[str] = set()
 
@@ -679,7 +687,17 @@ def _plan_descriptor_route(
             continue
         step_demo = bool(step.get("demo", False))
         if step_demo and not explicit_demo:
-            warnings.append(f"Skipped demo step {index}; user did not request a demo.")
+            message = f"Skipped demo step {index}; user did not request a demo."
+            warnings.append(message)
+            contract_alerts.append(
+                _contract_alert(
+                    "planner.demo_requires_explicit_request",
+                    message,
+                    expected="explicit demo request",
+                    observed="no explicit demo request",
+                    blocking=False,
+                )
+            )
             continue
         step_skill = str(step.get("skill") or descriptor_skill)
         if step_skill not in skill_registry:
@@ -699,7 +717,17 @@ def _plan_descriptor_route(
             try:
                 input_path = _resolve_descriptor_input(step.get("input"), skill_dir)
             except DescriptorError as err:
-                warnings.append(f"Skipped unsafe input path at step {index}: {err}")
+                message = f"Skipped unsafe input path at step {index}: {err}"
+                warnings.append(message)
+                contract_alerts.append(
+                    _contract_alert(
+                        "runner.descriptor_security_skip",
+                        message,
+                        expected="safe descriptor input path",
+                        observed="unsafe descriptor input path",
+                        blocking=False,
+                    )
+                )
                 continue
         if step_demo:
             argv.append("--demo")
@@ -707,13 +735,33 @@ def _plan_descriptor_route(
             argv.extend(["--input", str(input_path)])
         safe_args, arg_warnings = _safe_argv_list(step.get("args"), step_skill, skill_registry)
         warnings.extend(arg_warnings)
+        contract_alerts.extend(
+            _contract_alert(
+                "runner.descriptor_security_skip",
+                warning,
+                expected="allowlisted descriptor argument",
+                observed="skipped descriptor argument",
+                blocking=False,
+            )
+            for warning in arg_warnings
+        )
         argv.extend(safe_args)
         output_dir = None
         if step.get("output"):
             try:
                 output_dir = str(_resolve_descriptor_input(step.get("output"), skill_dir))
             except DescriptorError as err:
-                warnings.append(f"Skipped unsafe output path at step {index}: {err}")
+                message = f"Skipped unsafe output path at step {index}: {err}"
+                warnings.append(message)
+                contract_alerts.append(
+                    _contract_alert(
+                        "runner.descriptor_security_skip",
+                        message,
+                        expected="safe descriptor output path",
+                        observed="unsafe descriptor output path",
+                        blocking=False,
+                    )
+                )
                 continue
             argv.extend(["--output", output_dir])
         confirmation = step.get("confirmation") or {}
@@ -742,6 +790,7 @@ def _plan_descriptor_route(
 
     if missing_skills:
         missing = ", ".join(sorted(missing_skills))
+        missing_warning = f"Register {missing} before exposing it for execution."
         return SkillExecutionPlan(
             status="needs_registration",
             raw_user_text=text,
@@ -764,11 +813,23 @@ def _plan_descriptor_route(
             requested_skill=requested_skill,
             requested_mode=requested_mode,
             descriptor_path=descriptor.get("_descriptor_path"),
-            warnings=[*warnings, f"Register {missing} before exposing it for execution."],
+            warnings=[*warnings, missing_warning],
+            contract_alerts=[
+                *contract_alerts,
+                _contract_alert(
+                    "planner.unregistered_skill",
+                    missing_warning,
+                    expected="registered skill alias",
+                    observed="unregistered skill alias",
+                    blocking=True,
+                    evidence=[f"skill: {missing}"],
+                ),
+            ],
         )
 
     if missing_slots:
         missing = ", ".join(sorted(missing_slots))
+        missing_warning = f"Missing required slot(s): {missing}."
         return SkillExecutionPlan(
             status="needs_input",
             raw_user_text=text,
@@ -788,7 +849,18 @@ def _plan_descriptor_route(
             requested_skill=requested_skill,
             requested_mode=requested_mode,
             descriptor_path=descriptor.get("_descriptor_path"),
-            warnings=[*warnings, f"Missing required slot(s): {missing}."],
+            warnings=[*warnings, missing_warning],
+            contract_alerts=[
+                *contract_alerts,
+                _contract_alert(
+                    "planner.missing_required_slot",
+                    missing_warning,
+                    expected="all required route slots",
+                    observed="missing route slot",
+                    blocking=True,
+                    evidence=[f"slot: {item}" for item in sorted(missing_slots)],
+                ),
+            ],
         )
 
     status = "planned"
@@ -816,6 +888,7 @@ def _plan_descriptor_route(
         requested_mode=requested_mode,
         descriptor_path=descriptor.get("_descriptor_path"),
         warnings=warnings,
+        contract_alerts=contract_alerts,
     )
 
 
@@ -866,6 +939,7 @@ def _plan_legacy_fallback(
         pass
     elif skill != "auto":
         # Deterministic fallback: do not silently switch to demo for weak tool calls.
+        warning = "Demo mode is only planned when the user explicitly asks for a demo."
         return SkillExecutionPlan(
             status="needs_input",
             raw_user_text=text,
@@ -876,7 +950,16 @@ def _plan_legacy_fallback(
             reason="No intent descriptor matched and no input/profile was available.",
             requested_skill=requested_skill,
             requested_mode=requested_mode,
-            warnings=["Demo mode is only planned when the user explicitly asks for a demo."],
+            warnings=[warning],
+            contract_alerts=[
+                _contract_alert(
+                    "planner.demo_requires_explicit_request",
+                    warning,
+                    expected="explicit demo request or input file",
+                    observed="no input and no explicit demo request",
+                    blocking=True,
+                )
+            ],
         )
     argv.extend(extra_args)
     return SkillExecutionPlan(
@@ -901,6 +984,15 @@ def _plan_legacy_fallback(
         requested_mode=requested_mode,
         warnings=[] if accepted_demo or requested_mode != "demo" else [
             "Ignored weak demo mode because the user text did not explicitly request a demo."
+        ],
+        contract_alerts=[] if accepted_demo or requested_mode != "demo" else [
+            _contract_alert(
+                "planner.demo_requires_explicit_request",
+                "Ignored weak demo mode because the user text did not explicitly request a demo.",
+                expected="explicit demo request",
+                observed="weak demo mode hint",
+                blocking=False,
+            )
         ],
     )
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,10 +83,12 @@ Optional Reproducibility Export (helper-backed commands, environment, checksums)
 ```
 
 The same run may also expose UI-facing fields from `result.json`, including
-`chat_summary_lines`, `preferred_artifacts`, `workflow_state`, and
-`suggested_actions`. These fields let chat or GUI frontends render compact
-summaries and offer deterministic next steps without inventing follow-up
-commands.
+`chat_summary_lines`, `preferred_artifacts`, `workflow_state`,
+`suggested_actions`, and `contract_alerts`. These fields let chat or GUI
+frontends render compact summaries, offer deterministic next steps, and surface
+contract/path mismatches without inventing follow-up commands. See
+[docs/skill-action-contract.md](skill-action-contract.md) for the canonical
+schema reference.
 
 ## Structured Next Steps
 

--- a/docs/skill-action-contract.md
+++ b/docs/skill-action-contract.md
@@ -55,6 +55,7 @@ The chat-facing fields currently understood by the runner and adapters are:
 | `preferred_artifacts` | Output files the UI should surface first.            |
 | `workflow_state`      | Optional state identity and lifecycle metadata.      |
 | `suggested_actions`   | Stored follow-up actions the user may choose.        |
+| `contract_alerts`     | Structured alerts when intent, data, policy, or state contracts diverge. |
 | `report_md`           | Full markdown report text embedded in `result.json`. |
 
 These fields are additive. A skill can continue to emit only a normal report,
@@ -102,6 +103,7 @@ workflow_state.lifecycle      -> generic UI condition
 workflow_state.state_id       -> skill-specific snapshot identity
 suggested_actions[]           -> valid transitions or follow-up views
 preferred_artifacts[]         -> useful resources from this state
+contract_alerts[]             -> exceptions to the coherent contract path
 ```
 
 Examples:
@@ -247,6 +249,144 @@ suffix remains:
 ```text
 1. Top Results (safe refresh)
 ```
+
+## Contract Alerts
+
+`contract_alerts` is an optional sibling of `workflow_state` and
+`suggested_actions` in `result.json`. It is for contract/path discrepancies,
+not biomedical findings. In the happy path, the field should be absent.
+
+Use it when the route, input data, workflow state, policy, or schema version no
+longer matches what the selected path expected:
+
+```json
+{
+  "contract_alerts": [
+    {
+      "schema": "clawbio.contract_alert.v1",
+      "severity": "warning",
+      "kind": "planner.intent_input_mismatch",
+      "message": "The requested route expects genotype data, but the input looks like a proteomics table.",
+      "expected": "genotype-style input",
+      "observed": "proteomics-style table",
+      "evidence": ["filename extension: .csv", "detected assay columns"],
+      "remedies": [
+        {"label": "Use affinity-proteomics", "skill": "affprot"},
+        {"label": "Show compatible skills", "action": "list-compatible-skills"}
+      ],
+      "blocking": false
+    }
+  ]
+}
+```
+
+Field meanings:
+
+| Field | Meaning |
+|-------|---------|
+| `schema` | Must be `clawbio.contract_alert.v1`. |
+| `severity` | One of `error`, `warning`, or `info`. |
+| `kind` | Namespaced alert kind from the vocabulary below. |
+| `message` | Short human-readable explanation. |
+| `expected` | Optional human-readable label for what the route/state expected. |
+| `observed` | Optional human-readable label for what was observed instead. |
+| `evidence` | Optional sanitised clues; never raw user data or secrets. |
+| `remedies` | Optional non-executed hints for getting unstuck. |
+| `blocking` | Whether the component that emitted the alert blocked progress. |
+
+`expected` and `observed` are labels, not necessarily raw values. If raw values
+aid debugging, place them in `evidence` only after sanitisation.
+
+Each `remedies[]` item carries a required `label` and exactly one of:
+
+- `skill`: a suggested ClawBio skill alias to switch to,
+- `action`: a non-executed hint/action identifier.
+
+Other remedy fields are reserved for future use. In v1, remedies are displayed
+as hints only; the action-offer machinery does not execute them.
+
+Initial alert kinds are:
+
+| Kind | Use |
+|------|-----|
+| `planner.intent_input_mismatch` | The intended route and detected input type disagree. |
+| `planner.missing_required_slot` | A descriptor route matched, but required slot extraction failed. |
+| `planner.demo_requires_explicit_request` | Demo mode was requested only weakly or implicitly. |
+| `planner.unregistered_skill` | A descriptor route points to an unregistered skill alias. |
+| `runner.descriptor_security_skip` | Descriptor metadata was skipped by runner safety checks. |
+| `runner.input_contract_mismatch` | Runner-level input checks disagree with the selected contract. |
+| `skill.state_mismatch` | A state-aware action request no longer validates. |
+| `skill.version_drift` | A request or state schema version is not recognised. |
+| `skill.missing_required_input` | A skill received a structured request missing required fields. |
+| `policy.remote_execution_requires_consent` | A selected path would use remote execution without consent. |
+| `other` | Escape hatch; include a short `detail` field. |
+
+New kinds should be added by PR to this document. This keeps the alert stream
+aggregatable instead of collecting many spellings of the same mismatch.
+Some initial kinds are reserved for future emitters, so absence from today's
+code paths does not mean the kind is orphaned.
+
+Rendering order in chat adapters is:
+
+1. lifecycle header,
+2. `contract_alerts`, sorted by severity: `error`, `warning`, `info`,
+3. `chat_summary_lines`,
+4. report or raw output,
+5. action menu.
+
+Adapters do not implement special gating for `blocking: true`. They render the
+alert. The skill or planner enforces blocking by returning no executable
+action, returning `workflow_state.lifecycle: "expired"`, or not producing a run
+plan.
+
+In v1, planners may emit both unstructured `warnings` and structured
+`contract_alerts`. A future contract version may deprecate `warnings` after
+consumers migrate.
+
+### Local Discrepancy Log
+
+ClawBio may persist sanitised copies of contract alerts locally as append-only
+JSONL. This is not telemetry and is never uploaded by this contract.
+
+Preferred locations:
+
+- `<output_dir>/contract_alerts.jsonl` when a run output directory exists,
+- `output/contract_alerts.jsonl` for planner or pre-run alerts where no run
+  directory exists.
+
+Each line wraps one alert:
+
+```json
+{
+  "schema": "clawbio.contract_alert_log.v1",
+  "timestamp": "2026-05-25T14:12:00+00:00",
+  "run_id": "affprot_20260525_141200",
+  "skill": "affprot",
+  "intent_id": "optional-route-id",
+  "alert": {
+    "schema": "clawbio.contract_alert.v1",
+    "severity": "warning",
+    "kind": "skill.state_mismatch",
+    "message": "The selected action no longer matches the analysis state that produced it.",
+    "expected": "request state_id",
+    "observed": "recomputed state_id",
+    "blocking": true
+  }
+}
+```
+
+`timestamp`, `schema`, and `alert` are required. `run_id`, `skill`, and
+`intent_id` may be absent for pre-run alerts. `intent_id` is the routing intent
+identifier when an `INTENTS.json` planner picked the route; it is omitted for
+direct CLI/API invocation.
+
+Only already-normalised and sanitised alerts should be logged. Do not log raw
+user text, file contents, genomic or proteomic values, full absolute paths, API
+keys, tokens, or unredacted request payloads. Alert logging is best-effort and
+must never fail a skill run. v1 does not rotate or deduplicate logs; run-local
+logs are bounded by output-directory retention, while operators may archive the
+global fallback log manually. Analysers can aggregate by `kind` or `(kind,
+run_id)` if needed.
 
 ## Receiving an Action Request
 

--- a/skills/affinity-proteomics/affinity_proteomics.py
+++ b/skills/affinity-proteomics/affinity_proteomics.py
@@ -36,6 +36,11 @@ import numpy as np
 import pandas as pd
 
 SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT_DIR = SCRIPT_DIR.parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from clawbio.contract_alerts import make_contract_alert
 
 DISCLAIMER = (
     "ClawBio is a research and educational tool. It is not a medical device "
@@ -711,6 +716,27 @@ def _current_request_workflow_state(request: dict) -> dict:
     return _workflow_state_from_context(_request_context(request))
 
 
+def _stale_action_contract_alert(request: dict) -> dict:
+    if request.get("state_schema") != WORKFLOW_STATE_SCHEMA:
+        return make_contract_alert(
+            kind="skill.version_drift",
+            severity="warning",
+            message="The selected action uses a workflow-state schema this skill does not recognise.",
+            expected="current workflow_state schema",
+            observed="request workflow_state schema",
+            evidence=["schema mismatch"],
+            blocking=True,
+        )
+    return make_contract_alert(
+        kind="skill.state_mismatch",
+        severity="warning",
+        message="The selected action no longer matches the analysis state that produced it.",
+        expected="request state_id",
+        observed="recomputed state_id",
+        blocking=True,
+    )
+
+
 def _write_stale_action_result(request: dict, output_dir: Path, workflow_state: dict) -> dict:
     action = str(request.get("action") or "unknown")
     summary_lines = [
@@ -727,6 +753,7 @@ def _write_stale_action_result(request: dict, output_dir: Path, workflow_state: 
         "action": action,
         "workflow_state": workflow_state,
         "chat_summary_lines": summary_lines,
+        "contract_alerts": [_stale_action_contract_alert(request)],
         "preferred_artifacts": [{"path": "report.md", "label": "Follow-up report"}],
         "report_md": report_md,
         "disclaimer": DISCLAIMER,

--- a/skills/affinity-proteomics/tests/test_affinity_proteomics.py
+++ b/skills/affinity-proteomics/tests/test_affinity_proteomics.py
@@ -251,7 +251,31 @@ class TestOlinkDemo:
         assert result["action"] == "top-proteins"
         assert result["workflow_state"]["lifecycle"] == "expired"
         assert result["workflow_state"]["state_label"] == "stale-action-request"
+        assert result["contract_alerts"][0]["kind"] == "skill.state_mismatch"
+        assert result["contract_alerts"][0]["blocking"] is True
         assert any("stale or mismatched" in line for line in result["chat_summary_lines"])
+
+    def test_action_request_flags_schema_version_drift(self, tmp_path):
+        source_dir = tmp_path / "source"
+        run_pipeline(
+            platform="olink", input_path=SKILL_DIR / "example_data" / "olink_demo_npx.csv",
+            meta_path=SKILL_DIR / "example_data" / "olink_demo_meta.csv",
+            group_col="Group", contrast=("Case", "Control"),
+            output_dir=source_dir, demo=True,
+        )
+        source_result = json.loads((source_dir / "result.json").read_text())
+        action = next(
+            action for action in source_result["suggested_actions"]
+            if action["action_id"] == "show-top-proteins"
+        )
+        stale_request = {**action["request"], "state_schema": "affinity_proteomics.workflow_state.v0"}
+
+        output_dir = tmp_path / "schema-drift"
+        result = handle_action_request(stale_request, output_dir)
+
+        assert result["workflow_state"]["lifecycle"] == "expired"
+        assert result["contract_alerts"][0]["kind"] == "skill.version_drift"
+        assert result["contract_alerts"][0]["blocking"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_action_offers.py
+++ b/tests/test_action_offers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from clawbio.contract_alerts import render_contract_alerts as render_contract_alerts_core
 from bot.action_offers import (
     execute_stored_action,
     extract_action_offer,
@@ -11,6 +12,7 @@ from bot.action_offers import (
     make_pending_action_entry,
     parse_action_reply,
     render_action_offer,
+    render_contract_alerts,
     render_workflow_state_header,
 )
 
@@ -71,6 +73,32 @@ def test_render_action_offer_adds_state_header_and_estimate():
 def test_render_workflow_state_header_requires_explicit_lifecycle():
     assert render_workflow_state_header({"state_label": "implicit-ready"}) == ""
     assert render_workflow_state_header({"lifecycle": "expired"}) == "State: expired"
+
+
+def test_render_contract_alerts_uses_shared_helper_for_adapter_parity():
+    alerts = [
+        {
+            "severity": "warning",
+            "kind": "planner.missing_required_slot",
+            "message": "Missing gene symbol.",
+            "expected": "all required route slots",
+            "observed": "missing route slot",
+            "remedies": [{"label": "Provide a gene symbol", "action": "ask-for-gene"}],
+        },
+        {
+            "severity": "error",
+            "kind": "skill.state_mismatch",
+            "message": "The selected follow-up is stale.",
+            "blocking": True,
+        },
+    ]
+
+    rendered = render_contract_alerts(alerts)
+
+    assert rendered == render_contract_alerts_core(alerts)
+    assert rendered.splitlines()[0] == "Error: state mismatch"
+    assert "Warning: missing required slot" in rendered
+    assert "Remedies: Provide a gene symbol" in rendered
 
 
 def test_render_action_offer_can_render_state_without_actions():
@@ -197,6 +225,13 @@ def test_load_bundle_fields_promotes_structured_chat_fields(tmp_path: Path):
             "lifecycle": "ready",
             "state_label": "demo-ready",
         },
+        "contract_alerts": [
+            {
+                "severity": "warning",
+                "kind": "planner.missing_required_slot",
+                "message": "Need a gene symbol.",
+            }
+        ],
         "preferred_artifacts": [{"path": "generated/demo.png"}],
         "report_md": "# Embedded report\n",
     }
@@ -212,5 +247,7 @@ def test_load_bundle_fields_promotes_structured_chat_fields(tmp_path: Path):
     assert fields["chat_summary_lines"] == ["The skill found one follow-up action."]
     assert fields["suggested_actions"] == _demo_actions()
     assert fields["workflow_state"]["state_id"] == "sha256:abc"
+    assert fields["contract_alerts"][0]["schema"] == "clawbio.contract_alert.v1"
+    assert fields["contract_alerts"][0]["kind"] == "planner.missing_required_slot"
     assert fields["preferred_artifacts"] == [{"path": "generated/demo.png"}]
     assert fields["report_md"] == "# Embedded report\n"

--- a/tests/test_clawbio_runner_actions.py
+++ b/tests/test_clawbio_runner_actions.py
@@ -50,6 +50,14 @@ def test_run_skill_promotes_structured_result_fields(monkeypatch, tmp_path: Path
                         "lifecycle": "ready",
                         "state_label": "demo-ready",
                     },
+                    "contract_alerts": [
+                        {
+                            "severity": "warning",
+                            "kind": "skill.state_mismatch",
+                            "message": "A stored follow-up did not match the current state.",
+                            "blocking": True,
+                        }
+                    ],
                     "suggested_actions": [
                         {
                             "action_id": "show-demo-report",
@@ -88,5 +96,15 @@ def test_run_skill_promotes_structured_result_fields(monkeypatch, tmp_path: Path
     assert result["chat_summary_lines"] == ["The skill prepared a structured response."]
     assert result["preferred_artifacts"] == ["report.md", "result.json"]
     assert result["workflow_state"]["state_id"] == "sha256:abc"
+    assert result["contract_alerts"][0]["schema"] == "clawbio.contract_alert.v1"
+    assert result["contract_alerts"][0]["kind"] == "skill.state_mismatch"
     assert result["suggested_actions"][0]["action_id"] == "show-demo-report"
     assert result["skill_result_json"]["schema"] == "example.skill_result.v1"
+
+    log_path = output_dir / "contract_alerts.jsonl"
+    assert log_path.exists()
+    record = json.loads(log_path.read_text(encoding="utf-8"))
+    assert record["schema"] == "clawbio.contract_alert_log.v1"
+    assert record["run_id"] == "runner_out"
+    assert record["skill"] == "example-actions"
+    assert record["alert"]["kind"] == "skill.state_mismatch"

--- a/tests/test_contract_alerts.py
+++ b/tests/test_contract_alerts.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from clawbio.contract_alerts import (
+    CONTRACT_ALERT_LOG_SCHEMA,
+    CONTRACT_ALERT_SCHEMA,
+    append_contract_alert_log,
+    make_contract_alert,
+    normalise_contract_alerts,
+    render_contract_alerts,
+)
+
+
+def test_make_contract_alert_sanitises_and_clamps():
+    home_path = str(Path.home() / "secret" / "sample.vcf")
+    alert = make_contract_alert(
+        kind="planner.intent_input_mismatch",
+        message="x" * 250,
+        expected="genotype input",
+        observed=f"{home_path} token=super-secret-value",
+        evidence=[
+            home_path,
+            "api_key=abc123",
+            "sk-1234567890abcdef",
+            "extra1",
+            "extra2",
+            "extra3",
+        ],
+        remedies=[
+            {"label": "Use affinity-proteomics", "skill": "affprot"},
+            {"label": "Show compatible skills", "action": "list-compatible-skills"},
+            {"label": "Invalid both", "skill": "a", "action": "b"},
+        ],
+    )
+
+    assert alert["schema"] == CONTRACT_ALERT_SCHEMA
+    assert len(alert["message"]) <= 200
+    assert str(Path.home()) not in json.dumps(alert)
+    assert "super-secret-value" not in json.dumps(alert)
+    assert "abc123" not in json.dumps(alert)
+    assert "sk-1234567890abcdef" not in json.dumps(alert)
+    assert len(alert["evidence"]) == 5
+    assert alert["remedies"] == [
+        {"label": "Use affinity-proteomics", "skill": "affprot"},
+        {"label": "Show compatible skills", "action": "list-compatible-skills"},
+    ]
+
+
+def test_normalise_contract_alerts_drops_invalid_entries():
+    alerts = normalise_contract_alerts(
+        [
+            {"severity": "warning", "kind": "other", "message": "Valid"},
+            {"severity": "loud", "kind": "other", "message": "Invalid severity"},
+            {"severity": "warning", "kind": "unknown.kind", "message": "Invalid kind"},
+            {"severity": "warning", "kind": "other", "message": ""},
+            "not a dict",
+        ]
+    )
+
+    assert [alert["message"] for alert in alerts] == ["Valid"]
+
+
+def test_make_contract_alert_reports_invalid_fields():
+    with pytest.raises(ValueError, match="invalid contract alert kind"):
+        make_contract_alert(kind="not.a.kind", message="Bad kind")
+
+    with pytest.raises(ValueError, match="invalid contract alert severity"):
+        make_contract_alert(kind="other", message="Bad severity", severity="urgent")
+
+    with pytest.raises(ValueError, match="invalid contract alert message"):
+        make_contract_alert(kind="other", message="")
+
+
+def test_render_contract_alerts_sorts_by_severity():
+    rendered = render_contract_alerts(
+        [
+            {"severity": "info", "kind": "other", "message": "Later"},
+            {"severity": "error", "kind": "skill.state_mismatch", "message": "First"},
+            {"severity": "warning", "kind": "planner.missing_required_slot", "message": "Middle"},
+        ]
+    )
+
+    assert rendered.splitlines()[0] == "Error: state mismatch"
+    assert "Warning: missing required slot" in rendered
+    assert rendered.endswith("Later")
+
+
+def test_append_contract_alert_log_writes_sanitised_jsonl(tmp_path: Path):
+    alert = make_contract_alert(
+        kind="skill.state_mismatch",
+        message="State mismatch",
+        expected="request state_id",
+        observed="recomputed state_id",
+        blocking=True,
+    )
+
+    count = append_contract_alert_log(
+        tmp_path / "contract_alerts.jsonl",
+        [alert],
+        run_id="affprot_20260525_141200",
+        skill="affprot",
+        intent_id="top-proteins",
+        timestamp="2026-05-25T14:12:00+00:00",
+    )
+
+    assert count == 1
+    line = (tmp_path / "contract_alerts.jsonl").read_text(encoding="utf-8").strip()
+    record = json.loads(line)
+    assert record["schema"] == CONTRACT_ALERT_LOG_SCHEMA
+    assert record["run_id"] == "affprot_20260525_141200"
+    assert record["skill"] == "affprot"
+    assert record["intent_id"] == "top-proteins"
+    assert record["alert"]["kind"] == "skill.state_mismatch"
+
+
+def test_append_contract_alert_log_allows_pre_run_alerts(tmp_path: Path):
+    alert = make_contract_alert(
+        kind="planner.unregistered_skill",
+        message="The selected route points at an unregistered skill.",
+        severity="error",
+        blocking=True,
+    )
+
+    count = append_contract_alert_log(
+        tmp_path / "contract_alerts.jsonl",
+        [alert],
+        timestamp="2026-05-25T14:13:00+00:00",
+    )
+
+    assert count == 1
+    record = json.loads((tmp_path / "contract_alerts.jsonl").read_text(encoding="utf-8"))
+    assert record["schema"] == CONTRACT_ALERT_LOG_SCHEMA
+    assert record["timestamp"] == "2026-05-25T14:13:00+00:00"
+    assert record["alert"]["kind"] == "planner.unregistered_skill"
+    assert "run_id" not in record
+    assert "skill" not in record
+    assert "intent_id" not in record

--- a/tests/test_skill_intents_contract_alerts.py
+++ b/tests/test_skill_intents_contract_alerts.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from clawbio.skill_intents import SCHEMA, plan_skill_intent
+
+
+def _write_descriptor(skill_dir: Path, descriptor: dict) -> None:
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "INTENTS.json").write_text(
+        json.dumps(descriptor, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _registered_skill(script_path: Path) -> dict:
+    script_path.parent.mkdir(parents=True, exist_ok=True)
+    script_path.write_text("# placeholder\n", encoding="utf-8")
+    return {
+        "script": script_path,
+        "demo_args": ["--demo"],
+        "description": "Example skill",
+        "allowed_extra_flags": set(),
+    }
+
+
+def test_descriptor_plan_alerts_unregistered_skill(tmp_path: Path):
+    _write_descriptor(
+        tmp_path / "skills" / "router",
+        {
+            "schema": SCHEMA,
+            "skill": "router",
+            "description": "Routes to a missing skill.",
+            "routes": [
+                {
+                    "intent_id": "missing_skill_route",
+                    "trigger_terms": ["missing skill route"],
+                    "plan": [
+                        {
+                            "kind": "skill_run",
+                            "skill": "not-registered",
+                        }
+                    ],
+                }
+            ],
+        },
+    )
+
+    plan = plan_skill_intent(
+        "please run missing skill route",
+        requested_skill=None,
+        requested_mode=None,
+        attachments=[],
+        skill_registry={},
+        project_root=tmp_path,
+    )
+
+    assert plan.status == "needs_registration"
+    assert plan.warnings == ["Register not-registered before exposing it for execution."]
+    assert plan.contract_alerts[0]["kind"] == "planner.unregistered_skill"
+    assert plan.contract_alerts[0]["blocking"] is True
+
+
+def test_descriptor_plan_alerts_missing_required_slot(tmp_path: Path):
+    script_path = tmp_path / "skills" / "example" / "example.py"
+    _write_descriptor(
+        script_path.parent,
+        {
+            "schema": SCHEMA,
+            "skill": "example",
+            "description": "Runs an example gene route.",
+            "routes": [
+                {
+                    "intent_id": "gene_route",
+                    "trigger_terms": ["gene route"],
+                    "plan": [
+                        {
+                            "kind": "skill_run",
+                            "input_template": {"gene": "{gene_symbol}"},
+                            "slots": {
+                                "gene_symbol": {
+                                    "required": True,
+                                    "pattern": r"gene\s+([A-Z0-9]{3,12})",
+                                    "ignore_case": False,
+                                }
+                            },
+                        }
+                    ],
+                }
+            ],
+        },
+    )
+
+    plan = plan_skill_intent(
+        "please run gene route",
+        requested_skill=None,
+        requested_mode=None,
+        attachments=[],
+        skill_registry={"example": _registered_skill(script_path)},
+        project_root=tmp_path,
+    )
+
+    assert plan.status == "needs_input"
+    assert plan.warnings == ["Missing required slot(s): gene_symbol."]
+    assert plan.contract_alerts[0]["kind"] == "planner.missing_required_slot"
+    assert plan.contract_alerts[0]["evidence"] == ["slot: gene_symbol"]
+
+
+def test_legacy_fallback_alerts_implicit_demo_block(tmp_path: Path):
+    plan = plan_skill_intent(
+        "please run pharmacogenomics",
+        requested_skill="pharmgx",
+        requested_mode="demo",
+        attachments=[],
+        skill_registry={},
+        project_root=tmp_path,
+    )
+
+    assert plan.status == "needs_input"
+    assert plan.warnings == ["Demo mode is only planned when the user explicitly asks for a demo."]
+    assert plan.contract_alerts[0]["kind"] == "planner.demo_requires_explicit_request"
+    assert plan.contract_alerts[0]["blocking"] is True


### PR DESCRIPTION
## Backstory

I was about to revise the instructions for installing the Webchat interface and revisited the differences between OpenClaw and ClawBio over it. It then came to me that in an ideal world, with perfectly expressed user intents and tool descriptions, there would not be a need for ClawBio. And to make the agentic world a better place, we should learn about when the ClawBio formalisms kick in. We can then improve whatever needs improvement. Codex and Claude agreed. I put the plan that originated below. This may make an exciting resource for new ideas for the development of ClawBio and it should boost the confidence by the user to know better what is happening.

## Summary

This PR adds the missing feedback surface for structured ClawBio contracts.

`contract_alerts[]` are not biomedical findings; they describe places where routing, input assumptions, workflow state, schema version, or policy expectations diverge from the path ClawBio was about to take. The adapters now show those alerts to the user, and ClawBio also records sanitised local JSONL logs so repeated mismatch patterns can be reviewed later.

That gives us two useful loops:
- immediate UX: the user sees why ClawBio did not silently follow a questionable route;
- development feedback: recurring alert kinds can point to unclear descriptors, missing slots, weak routing rules, or future skill opportunities.

This keeps the system local-first and deterministic: alerts are rendered and logged, remedies are hints only, and executable follow-ups still use the existing structured-request path.

## Plan by Codex with updates from Claude

**Updated Plan: Contract Alerts + Local Discrepancy Log**

**Goal**  
Add `contract_alerts[]` as a structured, local result/planning field for cases where the intended route, input data, workflow state, policy, or contract version does not line up. In the perfect happy path, the field is absent. When present, it explains friction in a way the user can see, and ClawBio records a sanitised local trail so repeated discrepancies can motivate future improvements.

**Core Schema**

```json
{
  "contract_alerts": [
    {
      "schema": "clawbio.contract_alert.v1",
      "severity": "warning",
      "kind": "planner.intent_input_mismatch",
      "message": "The requested route expects genotype data, but the input looks like a proteomics table.",
      "expected": "genotype-style input",
      "observed": "proteomics-style table",
      "evidence": ["filename extension: .csv", "detected assay columns"],
      "remedies": [
        {"label": "Use affinity-proteomics", "skill": "affprot"},
        {"label": "Show compatible skills", "action": "list-compatible-skills"}
      ],
      "blocking": false
    }
  ]
}
```

Use `remedies`, not `suggested_actions`, inside alerts. Top-level `suggested_actions[]` remain state-continuation actions with executable nested requests. Alert `remedies[]` are route-correction hints and are not executed by the existing action-offer machinery in v1.

Each `remedies[]` item carries a required `label` and exactly one of:
- `skill`: a suggested ClawBio skill alias to switch to,
- `action`: a non-executed hint/action identifier.

Other remedy fields are reserved for future use.

`expected` and `observed` are short human-readable labels, not necessarily raw values. If raw values aid debugging, put them in `evidence` only after sanitisation.

**Alert Vocabulary**

Use namespaced `kind` strings. Drop a separate `source` field.

Initial vocabulary:
- `planner.intent_input_mismatch`
- `planner.missing_required_slot`
- `planner.demo_requires_explicit_request`
- `planner.unregistered_skill`
- `runner.descriptor_security_skip`
- `runner.input_contract_mismatch`
- `skill.state_mismatch`
- `skill.version_drift`
- `skill.missing_required_input`
- `policy.remote_execution_requires_consent`
- `other`

New kinds should be added by PR to `docs/skill-action-contract.md`. `other` may use a `detail` field for free text.

**Helper Module**

Add `clawbio/contract_alerts.py` with:
- `CONTRACT_ALERT_SCHEMA`
- `CONTRACT_ALERT_LOG_SCHEMA`
- `ALERT_KINDS`
- `ALERT_SEVERITIES`
- `make_contract_alert(...)`
- `normalise_contract_alerts(value)`
- `render_contract_alerts(alerts)`
- `append_contract_alert_log(...)`

The helper should enforce basic display/log safety:
- clamp `message` to about 200 chars;
- clamp `expected`/`observed` string fields;
- max 5 `evidence` items, each about 100 chars;
- redact obvious absolute paths under the user’s home directory;
- drop or redact obvious secrets/tokens/API keys;
- dependency-free and conservative.

Invalid alerts are dropped by `normalise_contract_alerts`, not passed through silently.

**Local Discrepancy Log**

Persist sanitised copies of `contract_alerts[]` locally as append-only JSONL. This is not telemetry.

Preferred locations:
- Run-local log whenever an output directory exists:
  - `<output_dir>/contract_alerts.jsonl`
- Global fallback only for planner/pre-run alerts where no output directory exists:
  - `output/contract_alerts.jsonl`

Each line:

```json
{
  "schema": "clawbio.contract_alert_log.v1",
  "timestamp": "2026-05-25T14:12:00Z",
  "run_id": "affprot_20260525_141200",
  "skill": "affprot",
  "intent_id": "optional-route-id",
  "alert": {
    "schema": "clawbio.contract_alert.v1",
    "severity": "warning",
    "kind": "skill.state_mismatch",
    "message": "The selected action no longer matches the analysis state that produced it.",
    "expected": "request state_id",
    "observed": "recomputed state_id",
    "blocking": true
  }
}
```

Rules:
- Log only normalised/sanitised alert payloads.
- Do not log raw user text, raw file contents, raw genomic/proteomic values, full absolute paths, API keys, tokens, or unredacted request payloads.
- Logging is local only. No upload, network, or telemetry.
- Logging must never fail a skill run. If writing fails, ignore it or emit an internal debug warning only.
- Keep this independent from biomedical report alerts.
- If a skill writes `contract_alerts[]` into `result.json`, the runner copies those alerts into the run-local log after promotion.
- If planner/adapters emit `contract_alerts[]` before a skill runs, they may write them to the global fallback log.

**Promotion And Rendering**

Promote `contract_alerts` through the same path as the other structured fields:
- `clawbio.py` `_promote_structured_result_fields`
- `bot/action_offers.py` output bundle extraction

Rendering order must be identical across chat adapters:
1. lifecycle header,
2. `contract_alerts`, sorted by severity: error, warning, info,
3. `chat_summary_lines`,
4. report/raw output,
5. action menu.

Telegram and Discord should use the same `render_contract_alerts()` helper. No special interaction model for remedies in v1.

Adapters do not implement special gating for `blocking: true`. They render the alert. The skill or planner enforces blocking by returning no executable action, returning `workflow_state.lifecycle: "expired"`, or not producing a run plan.

**Planner Integration**

`SkillExecutionPlan` currently has `warnings: list[str]`. Keep that field unchanged for backward compatibility, but add:

```python
contract_alerts: list[dict[str, Any]] = field(default_factory=list)
```

Convert important existing planner warnings into structured alerts while retaining `warnings`:
- missing required slots → `planner.missing_required_slot`
- unregistered/missing skill → `planner.unregistered_skill`
- demo blocked unless explicit → `planner.demo_requires_explicit_request`
- unsafe descriptor argument skip → `runner.descriptor_security_skip`

Do not remove or rename `warnings` in this PR. Document that v1 may emit both fields, and a future version may deprecate unstructured `warnings` after consumers migrate.

**First Skill Example**

Use `affinity-proteomics` stale-state rejection as the first skill-side example.

When a stored action request carries a mismatched `state_id` or `state_schema`, the existing expired result should also include:
- `skill.state_mismatch` for state hash mismatch,
- `skill.version_drift` for schema version mismatch, if easy without widening scope.

Example:

```json
{
  "schema": "clawbio.contract_alert.v1",
  "severity": "warning",
  "kind": "skill.state_mismatch",
  "message": "The selected action no longer matches the analysis state that produced it.",
  "expected": "request state_id",
  "observed": "recomputed state_id",
  "blocking": true
}
```

**Docs**

Update `docs/skill-action-contract.md` as the canonical schema reference. Add `contract_alerts` as a sibling of `workflow_state` and `suggested_actions`.

Include:
- contract alerts are not biomedical findings;
- they are exceptions to a coherent contract path;
- they should be absent on the happy path;
- `remedies` are non-executed hints in v1;
- `expected`/`observed` are labels unless sanitised raw values are placed in `evidence`;
- `warnings` and `contract_alerts` may coexist in v1;
- user-sensitive evidence must be redacted or omitted;
- local discrepancy logs are append-only JSONL and never telemetry.

Optionally add one pointer sentence in `docs/architecture.md`, but keep the schema reference in `skill-action-contract.md`.

**Tests**

Add focused tests for:
- helper normalisation, invalid-entry dropping, clamping, path/token redaction;
- severity sorting and rendering;
- runner promotion of `contract_alerts`;
- run-local `contract_alerts.jsonl` writing from promoted skill result;
- global fallback log writing for pre-run planner alerts if implemented in this slice;
- action bundle extraction;
- planner emits `contract_alerts` while retaining `warnings`;
- affinity stale-state rejection emits `skill.state_mismatch`;
- affinity wrong schema emits `skill.version_drift` if easy without widening scope;
- cross-adapter parity: Telegram and Discord/shared rendering paths produce byte-identical alert text for the same alert list.

**Non-Goals**

- No telemetry upload.
- No alert database.
- No central analytics.
- No automatic research dashboard.
- No new dependency planner.
- No broad input classifier rewrite.
- No execution of alert `remedies` in v1.
- No conversion of clinical/report findings into `contract_alerts`.
- No behavior change for existing successful skill runs.
- No failure of skill runs solely because alert logging failed.

## Skill affected

Framework-level change; no new skill.

Touches the `affinity-proteomics` skill only as the first concrete example for stale state/action mismatch alerts:
- `skill.state_mismatch`
- `skill.version_drift`

## Checklist

- [x] SKILL.md is present and complete (existing affinity-proteomics skill unchanged in scope)
- [x] Tests included and passing (`pytest -v`)
- [x] Demo data included for reviewers to test (existing affinity-proteomics demo data)
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

Focused tests:

```bash
/opt/homebrew/bin/pytest \
  tests/test_contract_alerts.py \
  tests/test_action_offers.py \
  tests/test_clawbio_runner_actions.py \
  tests/test_skill_intents_contract_alerts.py \
  -q
```

Result:

```text
26 passed in 0.09s
```

Additional checks:

```bash
python3 -m py_compile \
  clawbio/contract_alerts.py \
  clawbio.py \
  clawbio/skill_intents.py \
  bot/action_offers.py \
  bot/roboterri.py \
  bot/roboterri_discord.py \
  skills/affinity-proteomics/affinity_proteomics.py

git diff --check
```
Both passed.