### PR TITLE
fix: Circumventing skill-lint YAML parsing deficiency

### DIFF
--- a/skills/de-summary/SKILL.md
+++ b/skills/de-summary/SKILL.md
@@ -19,10 +19,7 @@ metadata:
     - csv
     - tsv
     required: true
-    description: 'DESeq2, edgeR, or limma output table with columns: gene_id or gene_name, log2FoldChange, pvalue, padj (adjusted
-      p-value). Optional columns: baseMean, lfcSE, stat.
-
-      '
+    description: "DESeq2, edgeR, or limma output table with columns: gene_id or gene_name, log2FoldChange, pvalue, padj (adjusted p-value). Optional columns: baseMean, lfcSE, stat."
   outputs:
   - name: report
     type: file


### PR DESCRIPTION
## Summary

The true bug is with the regex that is used in scripts/lint_skills.py which cannot cope with the newline. As an immediate minimal fix I think this is fine. 

The SKILL.md YAML was valid, but its quoted multiline input description contained a blank line. In environments without PyYAML, `scripts/lint_skills.py` falls back to a simple regex parser, which stopped reading the `metadata:` block before it reached `metadata.openclaw`. CI therefore reported `No metadata.openclaw block`.

This PR keeps the same description text but writes it as a single-line scalar, so both real YAML parsers and the zero-dependency fallback parser see the existing `openclaw` block.

## Skill affected

de-summary
