### PR TITLE
chore(deps): add 7-day exclude-newer cutoff to mitigate supply chain attacks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,5 +34,8 @@ bot = [
     "python-dotenv>=1.0",
 ]
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.uv.build-backend]
 module-root = ""

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,10 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
+[options]
+exclude-newer = "2026-05-18T20:03:47.829916Z"
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
## Summary

- Adds `exclude-newer = "7 days"` to `[tool.uv]` in `pyproject.toml`
- Prevents uv's resolver from selecting any package version published in the last 7 days, reducing exposure to newly-injected malicious releases
- Regenerated `uv.lock` to reflect the new constraint

## Skill affected

None — dependency management / repo hygiene

## Checklist

- [ ] SKILL.md is present and complete (YAML frontmatter + methodology)
- [ ] Tests included and passing (`pytest -v`)
- [ ] Demo data included for reviewers to test
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

N/A — no code changes, resolver constraint only.