### PR TITLE
docs(gi-skills): consolidate auth into single Authentication section

### DIFF
--- a/clawbio/gi/gi_runner.py
+++ b/clawbio/gi/gi_runner.py
@@ -34,7 +34,7 @@ def _parse_args(task: str) -> argparse.Namespace:
     p.add_argument("--demo", action="store_true", help="Run with the bundled example FASTA")
     p.add_argument("--model", type=str, default=None, help="Override default model name")
     p.add_argument("--description", type=str, default=None, help="Cell type / assay context (required by gi-expression; ignored by other tasks)")
-    p.add_argument("--api-key", type=str, default=None, help="Override GI_API_KEY env (otherwise uses env or bundled hackathon key)")
+    p.add_argument("--api-key", type=str, default=None, help="Override GI_API_KEY env (otherwise uses env; raises if unset — see each SKILL.md Authentication section)")
     p.add_argument("--base-url", type=str, default=None, help="Override GI_BASE_URL (default: https://api.genomicintelligence.ai)")
     return p.parse_args()
 

--- a/skills/gi-annotation/SKILL.md
+++ b/skills/gi-annotation/SKILL.md
@@ -75,7 +75,7 @@ metadata:
 
 You are **gi-annotation**, a ClawBio agent that calls the **Genomic Intelligence** DNA annotation pipeline. Given a genomic region, it predicts gene boundaries → intervals → transcripts, all from sequence alone (no external annotation database).
 
-> ⚠️ **Remote inference — opt-in required.** Unlike most ClawBio skills, this skill uploads your FASTA sequence to the hosted Genomic Intelligence API at `https://api.genomicintelligence.ai`. The skill refuses to run unless `GI_API_KEY` is set — `cp .env.example .env && set -a && source .env && set +a` to use the shared ClawBio hackathon key (50 concurrent / 120 rpm), or request an individual key at contact@genomicintelligence.ai. Prefer a browser? The same models run interactively at <https://genomicintelligence.ai>. **Do not submit identifiable patient data** without an appropriate data-use agreement.
+> ⚠️ **Remote inference — opt-in required.** Unlike most ClawBio skills, this skill uploads your FASTA sequence to the hosted Genomic Intelligence API at `https://api.genomicintelligence.ai`. Prefer a browser? The same models run interactively at <https://genomicintelligence.ai>. **Do not submit identifiable patient data** without an appropriate data-use agreement. Key setup: see [Authentication](#authentication) below.
 
 ## Trigger
 
@@ -103,10 +103,9 @@ You are **gi-annotation**, a ClawBio agent that calls the **Genomic Intelligence
 ## Workflow
 
 1. **Parse**: single-record FASTA.
-2. **Authenticate**: `--api-key` → `GI_API_KEY` → hackathon fallback.
-3. **Submit async**: `POST /v1/tasks/annotation/predict` with `Prefer: respond-async` → 202 + `job_id`.
-4. **Poll**: stream progress (`percent`, `message`) until terminal.
-5. **Render**: `report.md` (transcripts table) + `result.json` (full response) + `reproducibility/`.
+2. **Submit async**: `POST /v1/tasks/annotation/predict` with `Prefer: respond-async` → 202 + `job_id`.
+3. **Poll**: stream progress (`percent`, `message`) until terminal.
+4. **Render**: `report.md` (transcripts table) + `result.json` (full response) + `reproducibility/`.
 
 ## CLI Reference
 
@@ -119,6 +118,32 @@ python skills/gi-annotation/gi_annotation.py --input my_region.fa --output repor
 
 # Via ClawBio runner
 python clawbio.py run gi-annotation --demo
+```
+
+## Authentication
+
+The skill requires a Genomic Intelligence partner key in `GI_API_KEY`. Resolution order:
+
+1. `--api-key <value>` CLI flag (explicit override).
+2. `GI_API_KEY` environment variable.
+3. Otherwise: the skill raises a `RuntimeError` pointing here.
+
+### Quick start — ClawBio hackathon key
+
+A shared hackathon-tier key ships in `.env.example` at the repo root (50 concurrent / 120 rpm, opt-in only). From wherever the ClawBio files live on your machine:
+
+```bash
+# Repo root (git clone) — or ~/.claude/plugins/cache/clawbio/clawbio/<version>/ for plugin installs
+cp .env.example .env
+set -a && source .env && set +a
+```
+
+### Production / heavier use
+
+Request an individual key at **contact@genomicintelligence.ai**, then:
+
+```bash
+export GI_API_KEY=gi_yourkeyhere
 ```
 
 ## Demo

--- a/skills/gi-chromatin/SKILL.md
+++ b/skills/gi-chromatin/SKILL.md
@@ -76,7 +76,7 @@ metadata:
 
 You are **gi-chromatin**, a ClawBio agent that calls the **Genomic Intelligence** chromatin-annotation model (DeepSEA-style, 919 tracks: histone marks + DNase + TF binding across ENCODE cell types).
 
-> ⚠️ **Remote inference — opt-in required.** Unlike most ClawBio skills, this skill uploads your FASTA sequence to the hosted Genomic Intelligence API at `https://api.genomicintelligence.ai`. The skill refuses to run unless `GI_API_KEY` is set — `cp .env.example .env && set -a && source .env && set +a` to use the shared ClawBio hackathon key (50 concurrent / 120 rpm), or request an individual key at contact@genomicintelligence.ai. Prefer a browser? The same models run interactively at <https://genomicintelligence.ai>. **Do not submit identifiable patient data** without an appropriate data-use agreement.
+> ⚠️ **Remote inference — opt-in required.** Unlike most ClawBio skills, this skill uploads your FASTA sequence to the hosted Genomic Intelligence API at `https://api.genomicintelligence.ai`. Prefer a browser? The same models run interactively at <https://genomicintelligence.ai>. **Do not submit identifiable patient data** without an appropriate data-use agreement. Key setup: see [Authentication](#authentication) below.
 
 ## Trigger
 
@@ -105,9 +105,8 @@ You are **gi-chromatin**, a ClawBio agent that calls the **Genomic Intelligence*
 ## Workflow
 
 1. **Parse**: single-record FASTA.
-2. **Authenticate**: `--api-key` → `GI_API_KEY` → hackathon fallback.
-3. **POST** to `/v1/tasks/chromatin/predict`.
-4. **Render**: `report.md` (window + total-annotation counts; per-track detail in `result.json`).
+2. **POST** to `/v1/tasks/chromatin/predict`.
+3. **Render**: `report.md` (window + total-annotation counts; per-track detail in `result.json`).
 
 ## CLI Reference
 
@@ -115,6 +114,32 @@ You are **gi-chromatin**, a ClawBio agent that calls the **Genomic Intelligence*
 python skills/gi-chromatin/gi_chromatin.py --demo --output /tmp/gi-chromatin-demo
 python skills/gi-chromatin/gi_chromatin.py --input my_region.fa --output report_dir
 python clawbio.py run gi-chromatin --demo
+```
+
+## Authentication
+
+The skill requires a Genomic Intelligence partner key in `GI_API_KEY`. Resolution order:
+
+1. `--api-key <value>` CLI flag (explicit override).
+2. `GI_API_KEY` environment variable.
+3. Otherwise: the skill raises a `RuntimeError` pointing here.
+
+### Quick start — ClawBio hackathon key
+
+A shared hackathon-tier key ships in `.env.example` at the repo root (50 concurrent / 120 rpm, opt-in only). From wherever the ClawBio files live on your machine:
+
+```bash
+# Repo root (git clone) — or ~/.claude/plugins/cache/clawbio/clawbio/<version>/ for plugin installs
+cp .env.example .env
+set -a && source .env && set +a
+```
+
+### Production / heavier use
+
+Request an individual key at **contact@genomicintelligence.ai**, then:
+
+```bash
+export GI_API_KEY=gi_yourkeyhere
 ```
 
 ## Demo

--- a/skills/gi-enhancer/SKILL.md
+++ b/skills/gi-enhancer/SKILL.md
@@ -75,7 +75,7 @@ metadata:
 
 You are **gi-enhancer**, a ClawBio agent that calls the **Genomic Intelligence** enhancer-activity model. Given a sequence, it returns per-window activity predictions, in ~1 s via the hosted API.
 
-> ⚠️ **Remote inference — opt-in required.** Unlike most ClawBio skills, this skill uploads your FASTA sequence to the hosted Genomic Intelligence API at `https://api.genomicintelligence.ai`. The skill refuses to run unless `GI_API_KEY` is set — `cp .env.example .env && set -a && source .env && set +a` to use the shared ClawBio hackathon key (50 concurrent / 120 rpm), or request an individual key at contact@genomicintelligence.ai. Prefer a browser? The same models run interactively at <https://genomicintelligence.ai>. **Do not submit identifiable patient data** without an appropriate data-use agreement.
+> ⚠️ **Remote inference — opt-in required.** Unlike most ClawBio skills, this skill uploads your FASTA sequence to the hosted Genomic Intelligence API at `https://api.genomicintelligence.ai`. Prefer a browser? The same models run interactively at <https://genomicintelligence.ai>. **Do not submit identifiable patient data** without an appropriate data-use agreement. Key setup: see [Authentication](#authentication) below.
 
 ## Trigger
 
@@ -104,9 +104,8 @@ You are **gi-enhancer**, a ClawBio agent that calls the **Genomic Intelligence**
 ## Workflow
 
 1. **Parse**: single-record FASTA.
-2. **Authenticate**: `--api-key` → `GI_API_KEY` → hackathon fallback.
-3. **POST** to `/v1/tasks/enhancer/predict`; the API windows internally.
-4. **Render**: `report.md` + `result.json` + `reproducibility/`.
+2. **POST** to `/v1/tasks/enhancer/predict`; the API windows internally.
+3. **Render**: `report.md` + `result.json` + `reproducibility/`.
 
 ## CLI Reference
 
@@ -114,6 +113,32 @@ You are **gi-enhancer**, a ClawBio agent that calls the **Genomic Intelligence**
 python skills/gi-enhancer/gi_enhancer.py --demo --output /tmp/gi-enhancer-demo
 python skills/gi-enhancer/gi_enhancer.py --input my_region.fa --output report_dir
 python clawbio.py run gi-enhancer --demo
+```
+
+## Authentication
+
+The skill requires a Genomic Intelligence partner key in `GI_API_KEY`. Resolution order:
+
+1. `--api-key <value>` CLI flag (explicit override).
+2. `GI_API_KEY` environment variable.
+3. Otherwise: the skill raises a `RuntimeError` pointing here.
+
+### Quick start — ClawBio hackathon key
+
+A shared hackathon-tier key ships in `.env.example` at the repo root (50 concurrent / 120 rpm, opt-in only). From wherever the ClawBio files live on your machine:
+
+```bash
+# Repo root (git clone) — or ~/.claude/plugins/cache/clawbio/clawbio/<version>/ for plugin installs
+cp .env.example .env
+set -a && source .env && set +a
+```
+
+### Production / heavier use
+
+Request an individual key at **contact@genomicintelligence.ai**, then:
+
+```bash
+export GI_API_KEY=gi_yourkeyhere
 ```
 
 ## Demo

--- a/skills/gi-expression/SKILL.md
+++ b/skills/gi-expression/SKILL.md
@@ -74,7 +74,7 @@ metadata:
 
 You are **gi-expression**, a ClawBio agent that calls the **Genomic Intelligence** sequence-to-expression model. Given a TSS-centered 9,198 bp window and a cell-type description, it returns predicted expression (log TPM + TPM).
 
-> ⚠️ **Remote inference — opt-in required.** Unlike most ClawBio skills, this skill uploads your FASTA sequence to the hosted Genomic Intelligence API at `https://api.genomicintelligence.ai`. The skill refuses to run unless `GI_API_KEY` is set — `cp .env.example .env && set -a && source .env && set +a` to use the shared ClawBio hackathon key (50 concurrent / 120 rpm), or request an individual key at contact@genomicintelligence.ai. Prefer a browser? The same models run interactively at <https://genomicintelligence.ai>. **Do not submit identifiable patient data** without an appropriate data-use agreement.
+> ⚠️ **Remote inference — opt-in required.** Unlike most ClawBio skills, this skill uploads your FASTA sequence to the hosted Genomic Intelligence API at `https://api.genomicintelligence.ai`. Prefer a browser? The same models run interactively at <https://genomicintelligence.ai>. **Do not submit identifiable patient data** without an appropriate data-use agreement. Key setup: see [Authentication](#authentication) below.
 
 ## Trigger
 
@@ -103,9 +103,8 @@ You are **gi-expression**, a ClawBio agent that calls the **Genomic Intelligence
 
 1. **Parse**: single-record FASTA (must be 9,198 bp, TSS-centered, gene-sense).
 2. **Build options**: `{"description": "assay term name is polyA plus RNA-seq. biosample summary is Homo sapiens K562."}` by default; override via `--description "..."`.
-3. **Authenticate**: `--api-key` → `GI_API_KEY` → hackathon fallback.
-4. **POST** to `/v1/tasks/expression/predict`.
-5. **Render**: `report.md` (headline log TPM) + `result.json` + `reproducibility/`.
+3. **POST** to `/v1/tasks/expression/predict`.
+4. **Render**: `report.md` (headline log TPM) + `result.json` + `reproducibility/`.
 
 ## CLI Reference
 
@@ -121,6 +120,32 @@ python skills/gi-expression/gi_expression.py \
 
 # Via ClawBio runner
 python clawbio.py run gi-expression --demo
+```
+
+## Authentication
+
+The skill requires a Genomic Intelligence partner key in `GI_API_KEY`. Resolution order:
+
+1. `--api-key <value>` CLI flag (explicit override).
+2. `GI_API_KEY` environment variable.
+3. Otherwise: the skill raises a `RuntimeError` pointing here.
+
+### Quick start — ClawBio hackathon key
+
+A shared hackathon-tier key ships in `.env.example` at the repo root (50 concurrent / 120 rpm, opt-in only). From wherever the ClawBio files live on your machine:
+
+```bash
+# Repo root (git clone) — or ~/.claude/plugins/cache/clawbio/clawbio/<version>/ for plugin installs
+cp .env.example .env
+set -a && source .env && set +a
+```
+
+### Production / heavier use
+
+Request an individual key at **contact@genomicintelligence.ai**, then:
+
+```bash
+export GI_API_KEY=gi_yourkeyhere
 ```
 
 ## Demo

--- a/skills/gi-promoter/SKILL.md
+++ b/skills/gi-promoter/SKILL.md
@@ -74,7 +74,7 @@ metadata:
 
 You are **gi-promoter**, a ClawBio agent that calls the **Genomic Intelligence** promoter-prediction model. Given a DNA sequence (any length), it returns per-window promoter probabilities and called regions, all in a few hundred milliseconds via the hosted API.
 
-> ⚠️ **Remote inference — opt-in required.** Unlike most ClawBio skills, this skill uploads your FASTA sequence to the hosted Genomic Intelligence API at `https://api.genomicintelligence.ai`. The skill refuses to run unless `GI_API_KEY` is set — `cp .env.example .env && set -a && source .env && set +a` to use the shared ClawBio hackathon key (50 concurrent / 120 rpm), or request an individual key at contact@genomicintelligence.ai. Prefer a browser? The same models run interactively at <https://genomicintelligence.ai>. **Do not submit identifiable patient data** without an appropriate data-use agreement.
+> ⚠️ **Remote inference — opt-in required.** Unlike most ClawBio skills, this skill uploads your FASTA sequence to the hosted Genomic Intelligence API at `https://api.genomicintelligence.ai`. Prefer a browser? The same models run interactively at <https://genomicintelligence.ai>. **Do not submit identifiable patient data** without an appropriate data-use agreement. Key setup: see [Authentication](#authentication) below.
 
 ## Trigger
 
@@ -95,7 +95,7 @@ You are **gi-promoter**, a ClawBio agent that calls the **Genomic Intelligence**
 ## Why This Exists
 
 - **Without it**: A user with a multi-kbp sequence has to spin up a GPU, download the GENA-LM weights, tokenize, window, and run inference themselves.
-- **With it**: One CLI call → annotated report in <1 s for typical sequences. The model is hosted; the partner key is bundled for the ClawBio hackathon (`GI_API_KEY` env overrides).
+- **With it**: One CLI call → annotated report in <1 s for typical sequences. The model is hosted; see [Authentication](#authentication) for key setup.
 - **Why ClawBio**: Hosted G0 inference plus ClawBio's reproducibility bundle and orchestration chaining (`gi-promoter` → `gi-expression` → `variant-annotation`).
 
 ## API Backed
@@ -105,9 +105,8 @@ You are **gi-promoter**, a ClawBio agent that calls the **Genomic Intelligence**
 ## Workflow
 
 1. **Parse**: read single-record FASTA via the shared `clawbio.gi.gi_client.read_fasta` helper (uppercase, strip non-ACGTN).
-2. **Authenticate**: resolve key — `--api-key` → `GI_API_KEY` env → bundled hackathon key (concurrent=50, rpm=120).
-3. **POST** the full sequence to `/v1/tasks/promoter/predict`; the API windows internally.
-4. **Render**: write `report.md` (summary + region table), `result.json` (full `{data, meta}` envelope), `reproducibility/`.
+2. **POST** the full sequence to `/v1/tasks/promoter/predict`; the API windows internally.
+3. **Render**: write `report.md` (summary + region table), `result.json` (full `{data, meta}` envelope), `reproducibility/`.
 
 ## CLI Reference
 
@@ -135,11 +134,28 @@ Bundled fixture is the TP53 locus (19 kbp, GRCh38). Expect ~20 windows, near-zer
 
 ## Authentication
 
-The skill ships with a hackathon partner key. For production / heavier use, request your own key (contact@genomicintelligence.ai) and:
+The skill requires a Genomic Intelligence partner key in `GI_API_KEY`. Resolution order:
+
+1. `--api-key <value>` CLI flag (explicit override).
+2. `GI_API_KEY` environment variable.
+3. Otherwise: the skill raises a `RuntimeError` pointing here.
+
+### Quick start — ClawBio hackathon key
+
+A shared hackathon-tier key ships in `.env.example` at the repo root (50 concurrent / 120 rpm, opt-in only). From wherever the ClawBio files live on your machine:
+
+```bash
+# Repo root (git clone) — or ~/.claude/plugins/cache/clawbio/clawbio/<version>/ for plugin installs
+cp .env.example .env
+set -a && source .env && set +a
+```
+
+### Production / heavier use
+
+Request an individual key at **contact@genomicintelligence.ai**, then:
 
 ```bash
 export GI_API_KEY=gi_yourkeyhere
-python skills/gi-promoter/gi_promoter.py --demo
 ```
 
 ## Gotchas

--- a/skills/gi-splice/SKILL.md
+++ b/skills/gi-splice/SKILL.md
@@ -75,7 +75,7 @@ metadata:
 
 You are **gi-splice**, a ClawBio agent that calls the **Genomic Intelligence** splice-site model. Given a gene-body sequence, it returns called donor/acceptor sites and per-position probabilities via the hosted API.
 
-> ⚠️ **Remote inference — opt-in required.** Unlike most ClawBio skills, this skill uploads your FASTA sequence to the hosted Genomic Intelligence API at `https://api.genomicintelligence.ai`. The skill refuses to run unless `GI_API_KEY` is set — `cp .env.example .env && set -a && source .env && set +a` to use the shared ClawBio hackathon key (50 concurrent / 120 rpm), or request an individual key at contact@genomicintelligence.ai. Prefer a browser? The same models run interactively at <https://genomicintelligence.ai>. **Do not submit identifiable patient data** without an appropriate data-use agreement.
+> ⚠️ **Remote inference — opt-in required.** Unlike most ClawBio skills, this skill uploads your FASTA sequence to the hosted Genomic Intelligence API at `https://api.genomicintelligence.ai`. Prefer a browser? The same models run interactively at <https://genomicintelligence.ai>. **Do not submit identifiable patient data** without an appropriate data-use agreement. Key setup: see [Authentication](#authentication) below.
 
 ## Trigger
 
@@ -104,9 +104,8 @@ You are **gi-splice**, a ClawBio agent that calls the **Genomic Intelligence** s
 ## Workflow
 
 1. **Parse**: single-record FASTA via `clawbio.gi.gi_client.read_fasta`.
-2. **Authenticate**: `--api-key` → `GI_API_KEY` → bundled hackathon key.
-3. **POST** the full gene body to `/v1/tasks/splice/predict`.
-4. **Render**: `report.md` + `result.json` + `reproducibility/`.
+2. **POST** the full gene body to `/v1/tasks/splice/predict`.
+3. **Render**: `report.md` + `result.json` + `reproducibility/`.
 
 ## CLI Reference
 
@@ -131,7 +130,29 @@ Bundled fixture is HBB (β-globin) gene body, reverse-complemented to gene-sense
 
 ## Authentication
 
-Same as other gi-* skills: `GI_API_KEY` env overrides the bundled hackathon key.
+The skill requires a Genomic Intelligence partner key in `GI_API_KEY`. Resolution order:
+
+1. `--api-key <value>` CLI flag (explicit override).
+2. `GI_API_KEY` environment variable.
+3. Otherwise: the skill raises a `RuntimeError` pointing here.
+
+### Quick start — ClawBio hackathon key
+
+A shared hackathon-tier key ships in `.env.example` at the repo root (50 concurrent / 120 rpm, opt-in only). From wherever the ClawBio files live on your machine:
+
+```bash
+# Repo root (git clone) — or ~/.claude/plugins/cache/clawbio/clawbio/<version>/ for plugin installs
+cp .env.example .env
+set -a && source .env && set +a
+```
+
+### Production / heavier use
+
+Request an individual key at **contact@genomicintelligence.ai**, then:
+
+```bash
+export GI_API_KEY=gi_yourkeyhere
+```
 
 ## Gotchas
 


### PR DESCRIPTION
## Summary

Docs-only follow-up to #260. No code or behavior changes.

- Consolidates GI auth instructions into a single canonical Authentication section per skill (previously spread across the opt-in callout, a Workflow bullet, and an inconsistent stub).
- Removes stale "hackathon fallback" / "bundled hackathon key" wording from Workflow bullets and the gi_runner.py --help string. 

## Skill affected

All six hosted-inference skills: gi-promoter, gi-splice, gi-enhancer, gi-chromatin, gi-expression, gi-annotation. Plus one help string in clawbio/gi/gi_runner.py. Docs-only changes.

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology)
- [x] Tests included and passing (pytest -v)
- [x] Demo data included for reviewers to test
- [x] No patient/sensitive data committed
- [x] Follows CONTRIBUTING.md conventions

## Test output

```
$ python scripts/lint_skills.py
... all 6 gi-* skills Pass on darwin, linux ...

$ pytest skills/gi-*/tests/ -m "not integration"
12 passed, 6 deselected in 1.42s
```

Integration tests are untouched — no code on the API path changed. Docs-only changes.
