### PR TITLE
Add --version flag to clawbio CLI

### DIFF
--- a/clawbio/cli.py
+++ b/clawbio/cli.py
@@ -28,6 +28,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 
+from clawbio import __version__
 from clawbio.contract_alerts import append_contract_alert_log, normalise_contract_alerts
 
 # --------------------------------------------------------------------------- #
@@ -1683,6 +1684,9 @@ def main():
 
     parser = argparse.ArgumentParser(
         description="ClawBio — Bioinformatics Skills Runner",
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {__version__}"
     )
     sub = parser.add_subparsers(dest="command")
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -31,6 +31,14 @@ def test_upload_help_exits_zero():
     assert result.returncode == 0, result.stderr
 
 
+def test_version_flag_prints_version_and_exits_zero():
+    from clawbio import __version__
+
+    result = _run("--version")
+    assert result.returncode == 0, result.stderr
+    assert __version__ in result.stdout
+
+
 def test_skill_flags_pass_through():
     """Unknown flags must reach the skill, not be rejected by clawbio.py."""
     result = _run("run", "pharmgx", "--unknown-future-flag", "value", "--help")


### PR DESCRIPTION
## Summary

- Add a top-level `--version` flag to the `clawbio` CLI (`clawbio --version` / `python clawbio.py --version`)
- Reads from `clawbio.__version__`, which is hatchling's canonical version source (`[tool.hatch.version] path = "clawbio/__init__.py"`), so it stays in sync with the published package version

## Skill affected

CLI only — `clawbio/cli.py` (not a skill change)

## Checklist

- [x] Tests included and passing (`pytest -q`)
- [x] No patient/sensitive data committed
- [x] Follows CONTRIBUTING.md conventions
- [ ] SKILL.md is present and complete — n/a, not a skill
- [ ] Demo data included for reviewers to test — n/a, no demo data needed

## Test output

```
$ pytest -q tests/test_cli_smoke.py
.....                                                                    [100%]
5 passed in 0.37s
```