### PR TITLE
feat: add CZI and ND2 support to cell detection

### DIFF
--- a/skills/cell-detection/SKILL.md
+++ b/skills/cell-detection/SKILL.md
@@ -30,9 +30,9 @@ metadata:
     - kind: pip
       package: tifffile
     - kind: pip
-      package: czifile
+      package: czifile>=2019.7.2.2
     - kind: pip
-      package: nd2
+      package: nd2>=0.11.1
     - kind: pip
       package: Pillow
     - kind: pip
@@ -68,6 +68,7 @@ Manual cell counting and segmentation are slow, inconsistent, and hard to reprod
 1. **Segment**: Run `cpsam` on TIFF, CZI, ND2, PNG, or JPG fluorescence images
 2. **Measure**: Extract area, equivalent diameter, centroid, and eccentricity per cell
 3. **Report**: Produce `report.md`, `{stem}_measurements.csv`, and histogram figures
+4. **Execution control**: GPU auto by default, with explicit `--use_gpu` / `--use_cpu` override flags
 
 ## Input Formats
 
@@ -77,17 +78,22 @@ Manual cell counting and segmentation are slow, inconsistent, and hard to reprod
 | 2-channel TIFF | `.tif`, `.tiff` | H×W×2 — cytoplasm + nuclear, any order |
 | 3-channel TIFF | `.tif`, `.tiff` | H×W×3 — H&E or fluorescence, any order |
 | >3-channel TIFF | `.tif`, `.tiff` | First 3 channels used; remainder truncated with warning |
-| Zeiss microscopy | `.czi` | Reads CZI arrays via `czifile`; supports squeezed 2D/3D and C×Z×H×W |
-| Nikon microscopy | `.nd2` | Reads ND2 arrays via `nd2`; supports C×H×W and Z×C×H×W |
+| Zeiss microscopy | `.czi` | Reads CZI via `czifile` and uses CZI axis metadata (`CziFile.axes`) to map C/Z/Y/X deterministically |
+| Nikon microscopy | `.nd2` | Reads ND2 via `nd2` and uses ND2 named dimensions (`ND2File.sizes`) for deterministic C/Z/Y/X mapping |
 | PNG / JPEG | `.png`, `.jpg`, `.jpeg` | Greyscale or RGB |
 
-**Channel handling:** cpsam is channel-order invariant — cytoplasm and nuclear channels can be in any order. You do not need to specify which channel is which. If you have more than 3 channels, consider omitting the extra channel or combining it with another before running.
+**Channel handling:** cpsam is channel-order invariant for 2D inputs — cytoplasm and nuclear channels can be in any order. For 2D segmentation, if you have more than 3 channels, the first 3 are used and the rest are truncated with a warning. For 3D segmentation (`--do_3D`) with `--z_projection none`, 4D stacks are preserved as `Z×C×Y×X` (no channel truncation at load time).
 
 ## Workflow
 
 1. **Load** image; detect greyscale vs multi-channel
-2. **Prepare** — pass 1–3 channels through unchanged; truncate >3 to first 3 with a warning
-3. **Segment** with `CellposeModel()` — no `channels` argument needed
+2. **Prepare**
+   - 2D mode: pass 1–3 channels through unchanged; truncate >3 to first 3 with a warning
+   - 3D mode (`--do_3D` + `--z_projection none`): keep 4D volume as `Z×C×Y×X`
+3. **Segment** with `CellposeModel()`
+   - 2D mode: no explicit channel mapping needed
+   - 3D multichannel mode: call with `z_axis=0`, `channel_axis=1`
+   - Device mode: defaults to GPU-auto; `--use_cpu` forces CPU
 4. **Metrics** via `skimage.measure.regionprops`
 5. **Figures** — overlay + size distribution histogram
 6. **Report** — `report.md` + `{stem}_measurements.csv` + reproducibility bundle (`commands.sh`, `environment.yml`, `checksums.sha256`)
@@ -105,6 +111,14 @@ python skills/cell-detection/cell_detection.py \
 
 # Demo (synthetic image, no user file needed)
 python skills/cell-detection/cell_detection.py --demo --output /tmp/cell_detection_demo
+
+# Override 4D stack Z handling (default is max projection)
+python skills/cell-detection/cell_detection.py \
+  --input <image.nd2> --z_projection none --do_3D --output <report_dir>
+
+# Force CPU mode
+python skills/cell-detection/cell_detection.py \
+  --input <image.tif> --use_cpu --output <report_dir>
 ```
 
 ## Demo
@@ -117,17 +131,34 @@ Expected output: report.md with ~67 cells detected from a synthetic 512×512 blo
 
 ## Algorithm / Methodology
 
-1. Load image with `tifffile` (TIFF), `czifile` (CZI), `nd2` (ND2), or `PIL` (PNG/JPG); detect ndim
-2. If >3 channels, truncate to first 3 with a warning
+1. Load image with `tifffile` (TIFF), `czifile` (CZI), `nd2` (ND2), or `PIL` (PNG/JPG); use CZI/ND2 metadata axes to assign C/Z/Y/X
+2. Channel preparation:
+   - 2D mode: if >3 channels, truncate to first 3 with a warning
+   - 3D mode with `--z_projection none`: preserve 4D volume as `Z×C×Y×X`
 3. Instantiate `CellposeModel(gpu=<flag>)`
-4. Call `model.eval(img, diameter=<arg_or_None>)` — no `channels` arg (cpsam is channel-order invariant)
+4. Call `model.eval(img, diameter=<arg_or_None>)`
+   - 2D: no `channels`/`channel_axis` needed (cpsam is channel-order invariant)
+   - 3D `Z×C×Y×X`: pass `z_axis=0`, `channel_axis=1`
 5. Extract per-cell stats from `masks` via `skimage.measure.regionprops`
 6. Save `{stem}_measurements.csv`, figures, `report.md`
 
 **Key parameters**:
 - Model: `cpsam` (Cellpose 4.0 unified model — channel-order invariant)
-- Channels: not passed — cpsam uses the first 3 channels of the input in any order
+- Channels:
+  - 2D: channel-order invariant; first 3 channels are used when input has >3 channels
+  - 3D with `--z_projection none`: multichannel 4D stacks are kept as `Z×C×Y×X`
 - Diameter: `None` triggers Cellpose auto-estimation
+- 4D stack policy:
+  - `--z_projection max` (default): max-project over Z while preserving channels for 2D segmentation (`H×W×C`)
+  - `--z_projection none`: preserve Z; 4D stacks remain volumetric (`Z×C×Y×X`) for 3D segmentation
+- 3D guardrails:
+  - `--do_3D` requires volumetric input (`Z×Y×X` or `Z×C×Y×X`)
+  - non-volumetric input with `--do_3D` falls back to 2D mode when safe, otherwise errors
+
+## Notes
+
+- Measurements are reported in pixel units (px, px²). Physical calibration metadata (um/pixel) is not currently propagated into per-cell metrics.
+- For volumetric segmentation outputs, outlines PNG is replaced with a note file (`{stem}_cp_outlines_unavailable.txt`) because Cellpose does not emit 3D outlines PNGs.
 
 ## Example Queries
 
@@ -157,8 +188,8 @@ output_dir/
 
 - `cellpose>=4.0` — cpsam model
 - `tifffile` — TIFF I/O
-- `czifile` — Zeiss CZI I/O
-- `nd2` — Nikon ND2 I/O
+- `czifile>=2019.7.2.2` — Zeiss CZI I/O (manually verified with 2019.7.2.2)
+- `nd2>=0.11.1` — Nikon ND2 I/O (manually verified with 0.11.1)
 - `Pillow` — PNG/JPG loading
 - `numpy` — array ops
 - `matplotlib` — figures

--- a/skills/cell-detection/SKILL.md
+++ b/skills/cell-detection/SKILL.md
@@ -30,6 +30,12 @@ metadata:
     - kind: pip
       package: tifffile
     - kind: pip
+      package: czifile
+    - kind: pip
+      package: nd2
+    - kind: pip
+      package: Pillow
+    - kind: pip
       package: scikit-image
     trigger_keywords:
     - cellpose
@@ -59,7 +65,7 @@ Manual cell counting and segmentation are slow, inconsistent, and hard to reprod
 
 ## Core Capabilities
 
-1. **Segment**: Run `cpsam` on any TIFF, PNG, or JPG fluorescence image
+1. **Segment**: Run `cpsam` on TIFF, CZI, ND2, PNG, or JPG fluorescence images
 2. **Measure**: Extract area, equivalent diameter, centroid, and eccentricity per cell
 3. **Report**: Produce `report.md`, `{stem}_measurements.csv`, and histogram figures
 
@@ -71,6 +77,8 @@ Manual cell counting and segmentation are slow, inconsistent, and hard to reprod
 | 2-channel TIFF | `.tif`, `.tiff` | H×W×2 — cytoplasm + nuclear, any order |
 | 3-channel TIFF | `.tif`, `.tiff` | H×W×3 — H&E or fluorescence, any order |
 | >3-channel TIFF | `.tif`, `.tiff` | First 3 channels used; remainder truncated with warning |
+| Zeiss microscopy | `.czi` | Reads CZI arrays via `czifile`; supports squeezed 2D/3D and C×Z×H×W |
+| Nikon microscopy | `.nd2` | Reads ND2 arrays via `nd2`; supports C×H×W and Z×C×H×W |
 | PNG / JPEG | `.png`, `.jpg`, `.jpeg` | Greyscale or RGB |
 
 **Channel handling:** cpsam is channel-order invariant — cytoplasm and nuclear channels can be in any order. You do not need to specify which channel is which. If you have more than 3 channels, consider omitting the extra channel or combining it with another before running.
@@ -109,7 +117,7 @@ Expected output: report.md with ~67 cells detected from a synthetic 512×512 blo
 
 ## Algorithm / Methodology
 
-1. Load image with `tifffile` (TIFF) or `PIL` (PNG/JPG); detect ndim
+1. Load image with `tifffile` (TIFF), `czifile` (CZI), `nd2` (ND2), or `PIL` (PNG/JPG); detect ndim
 2. If >3 channels, truncate to first 3 with a warning
 3. Instantiate `CellposeModel(gpu=<flag>)`
 4. Call `model.eval(img, diameter=<arg_or_None>)` — no `channels` arg (cpsam is channel-order invariant)
@@ -149,6 +157,8 @@ output_dir/
 
 - `cellpose>=4.0` — cpsam model
 - `tifffile` — TIFF I/O
+- `czifile` — Zeiss CZI I/O
+- `nd2` — Nikon ND2 I/O
 - `Pillow` — PNG/JPG loading
 - `numpy` — array ops
 - `matplotlib` — figures

--- a/skills/cell-detection/cell_detection.py
+++ b/skills/cell-detection/cell_detection.py
@@ -96,7 +96,8 @@ def load_image(path: str) -> tuple[np.ndarray, int]:
     to (H, W, C) so the rest of the pipeline sees a consistent layout.
     """
     p = Path(path)
-    if p.suffix.lower() in (".tif", ".tiff"):
+    extension = p.suffix.lower()
+    if extension in (".tif", ".tiff"):
         import tifffile
         with tifffile.TiffFile(str(p)) as tf:
             arr = tf.asarray()
@@ -104,10 +105,33 @@ def load_image(path: str) -> tuple[np.ndarray, int]:
             axes = ""
             if tf.series:
                 axes = tf.series[0].axes.upper()
+    elif extension == ".czi":
+        import czifile
+        arr = czifile.imread(str(p))
+        arr = np.asarray(arr).squeeze()
+        axes = ""
+    elif extension == ".nd2":
+        import nd2
+        arr = nd2.imread(str(p))
+        arr = np.asarray(arr)
+        axes = ""
     else:
         from PIL import Image
         arr = np.array(Image.open(str(p)))
         axes = ""
+    if arr.ndim == 4:
+        # Microscopy stacks can come as C×Z×H×W (CZI) or Z×C×H×W (ND2).
+        # For 2D segmentation, reduce Z by max projection while preserving channels.
+        if arr.shape[0] <= 20 and arr.shape[1] <= 20:
+            channel_axis = 0 if arr.shape[0] <= arr.shape[1] else 1
+        elif arr.shape[0] <= 20:
+            channel_axis = 0
+        elif arr.shape[1] <= 20:
+            channel_axis = 1
+        else:
+            raise ValueError(f"Unsupported 4D image shape {arr.shape} for {path}")
+        z_axis = 1 if channel_axis == 0 else 0
+        arr = arr.max(axis=z_axis)  # C×H×W
     if arr.ndim == 2:
         return arr, 1
     if arr.ndim == 3:
@@ -459,7 +483,7 @@ def main() -> None:
     write_environment_yml(
         output_dir,
         env_name="clawbio-cell-detection",
-        pip_deps=["cellpose>=4.0", "tifffile", "Pillow", "numpy", "matplotlib", "scikit-image", "scipy"],
+        pip_deps=["cellpose>=4.0", "tifffile", "czifile", "nd2", "Pillow", "numpy", "matplotlib", "scikit-image", "scipy"],
         python_version="3.10",
     )
     write_portable_commands_sh(

--- a/skills/cell-detection/cell_detection.py
+++ b/skills/cell-detection/cell_detection.py
@@ -202,7 +202,15 @@ def load_image(path: str, z_projection: str = "max") -> tuple[np.ndarray, int]:
         # Microscopy stacks can come as C×Z×H×W (CZI) or Z×C×H×W (ND2).
         # For 2D segmentation, reduce Z by max projection while preserving channels.
         if arr.shape[0] <= 20 and arr.shape[1] <= 20:
-            channel_axis = 0 if arr.shape[0] <= arr.shape[1] else 1
+            if arr.shape[0] <= arr.shape[1]:
+                raise ValueError(
+                    f"Cannot infer channel vs Z axis for 4D image shape {arr.shape} at {path}: "
+                    "both leading dimensions are <= 20 and the first is not larger than the second. "
+                    "Provide CZI/ND2/TIFF axis metadata, "
+                    "or use a stack where Z and C differ enough for the size heuristic "
+                    "(Z > C for Z×C×Y×X, or C > Z for C×Z×Y×X)."
+                )
+            channel_axis = 1
         elif arr.shape[0] <= 20:
             channel_axis = 0
         elif arr.shape[1] <= 20:

--- a/skills/cell-detection/cell_detection.py
+++ b/skills/cell-detection/cell_detection.py
@@ -21,7 +21,6 @@ from clawbio.common.reproducibility import (
     write_portable_commands_sh,
 )
 
-
 DISCLAIMER = (
     "*ClawBio is a research and educational tool. "
     "It is not a medical device and does not provide clinical diagnoses. "
@@ -85,40 +84,120 @@ def make_demo_image(seed: int = 42) -> np.ndarray:
     return img
 
 
-def load_image(path: str) -> tuple[np.ndarray, int]:
-    """Load an image file. Returns (array, n_channels).
+def _normalize_axes(axes: str) -> str:
+    """Normalize vendor axis labels while preserving positional metadata.
 
-    array shape: H×W for greyscale, H×W×C for multi-channel, Z×H×W for z-stacks.
-    n_channels: 1 if greyscale or z-stack, C otherwise.
+    Notes:
+    - Keep alphanumeric axis markers so trailing placeholders like "0" in
+      CZI axes strings (e.g. "VBTCZYX0") remain aligned with array ndim.
+    - Map TIFF sample axis "S" to channel axis "C" for consistent handling.
+    """
+    normalized: list[str] = []
+    for ch in axes.upper():
+        if not ch.isalnum():
+            continue
+        normalized.append("C" if ch == "S" else ch)
+    return "".join(normalized)
 
-    CYX handling: OME-TIFFs and other TIFFs stored as (C, H, W) are detected
-    when the first axis is small (≤20) and H, W are much larger, then transposed
-    to (H, W, C) so the rest of the pipeline sees a consistent layout.
+
+def _drop_singleton_non_czyx(arr: np.ndarray, axes: str) -> tuple[np.ndarray, str]:
+    for idx in reversed(range(len(axes))):
+        if axes[idx] in {"C", "Z", "Y", "X"}:
+            continue
+        if arr.shape[idx] != 1:
+            raise ValueError(f"Unsupported non-singleton axis '{axes[idx]}' with shape {arr.shape}")
+        arr = np.take(arr, 0, axis=idx)
+        axes = axes[:idx] + axes[idx + 1:]
+    return arr, axes
+
+
+def _transpose_to_axes(arr: np.ndarray, axes: str, target_axes: str) -> np.ndarray:
+    order = [axes.index(axis) for axis in target_axes]
+    return np.transpose(arr, order)
+
+
+def _finalize_loaded_array(arr: np.ndarray, axes: str, path: str, z_projection: str) -> tuple[np.ndarray, int] | None:
+    axes = _normalize_axes(axes)
+    if not axes or arr.ndim != len(axes):
+        return None
+
+    arr, axes = _drop_singleton_non_czyx(arr, axes)
+
+    if set(axes) == {"C", "Z", "Y", "X"} and len(axes) == 4:
+        arr = _transpose_to_axes(arr, axes, "CZYX")
+        if z_projection == "max":
+            cyx = arr.max(axis=1)
+            return cyx.transpose(1, 2, 0), cyx.shape[0]
+        if z_projection == "none":
+            zcyx = arr.transpose(1, 0, 2, 3)
+            return zcyx, zcyx.shape[1]
+        raise ValueError(f"Unsupported z_projection '{z_projection}'")
+
+    if set(axes) == {"C", "Y", "X"} and len(axes) == 3:
+        cyx = _transpose_to_axes(arr, axes, "CYX")
+        return cyx.transpose(1, 2, 0), cyx.shape[0]
+
+    if set(axes) == {"Z", "Y", "X"} and len(axes) == 3:
+        zyx = _transpose_to_axes(arr, axes, "ZYX")
+        return zyx, 1
+
+    if set(axes) == {"Y", "X"} and len(axes) == 2:
+        yx = _transpose_to_axes(arr, axes, "YX")
+        return yx, 1
+
+    return None
+
+
+def load_image(path: str, z_projection: str = "max") -> tuple[np.ndarray, int]:
+    """Load image and return (array, n_channels).
+
+    Supported inputs: TIFF/TIF, CZI, ND2, PNG, JPG/JPEG.
+
+    Output layouts:
+      - 2D greyscale: H×W, n_channels=1
+      - 2D multi-channel: H×W×C, n_channels=C
+      - 3D volume from explicit Z input: Z×H×W, n_channels=1
+      - 4D volume when z_projection='none': Z×C×H×W, n_channels=C
+
+    z_projection:
+      - "max": default, max-project 4D C/Z stacks over Z while preserving channels.
+      - "none": keep Z; 4D stacks return Z×C×H×W (including C=1).
+
+    Axis metadata is used when available (including mapping TIFF sample axis
+    "S" to channel axis "C"), with shape-based fallback for common
+    microscopy stack layouts.
     """
     p = Path(path)
     extension = p.suffix.lower()
+    arr: np.ndarray
+    axes = ""
     if extension in (".tif", ".tiff"):
         import tifffile
         with tifffile.TiffFile(str(p)) as tf:
             arr = tf.asarray()
             # Try to read axes from OME/series metadata
-            axes = ""
             if tf.series:
                 axes = tf.series[0].axes.upper()
     elif extension == ".czi":
         import czifile
-        arr = czifile.imread(str(p))
-        arr = np.asarray(arr).squeeze()
-        axes = ""
+        with czifile.CziFile(str(p)) as czi:
+            arr = np.asarray(czi.asarray())
+            axes = getattr(czi, "axes", "") or ""
     elif extension == ".nd2":
         import nd2
-        arr = nd2.imread(str(p))
-        arr = np.asarray(arr)
-        axes = ""
+        arr = np.asarray(nd2.imread(str(p)))
+        with nd2.ND2File(str(p)) as nd2f:
+            sizes = getattr(nd2f, "sizes", {}) or {}
+            if hasattr(sizes, "keys"):
+                axes = "".join(str(k).upper() for k in sizes.keys())
     else:
         from PIL import Image
         arr = np.array(Image.open(str(p)))
-        axes = ""
+
+    finalized = _finalize_loaded_array(arr, axes, path, z_projection)
+    if finalized is not None:
+        return finalized
+
     if arr.ndim == 4:
         # Microscopy stacks can come as C×Z×H×W (CZI) or Z×C×H×W (ND2).
         # For 2D segmentation, reduce Z by max projection while preserving channels.
@@ -131,9 +210,21 @@ def load_image(path: str) -> tuple[np.ndarray, int]:
         else:
             raise ValueError(f"Unsupported 4D image shape {arr.shape} for {path}")
         z_axis = 1 if channel_axis == 0 else 0
-        arr = arr.max(axis=z_axis)  # C×H×W
+        if z_projection == "max":
+            arr = arr.max(axis=z_axis)  # C×H×W
+        elif z_projection == "none":
+            if channel_axis == 0:
+                arr = np.moveaxis(arr, 0, 1)  # CZYX -> ZCYX
+            # If channel_axis == 1, already ZCYX
+        else:
+            raise ValueError(f"Unsupported z_projection '{z_projection}'")
     if arr.ndim == 2:
         return arr, 1
+    if arr.ndim == 4:
+        if z_projection == "none":
+            # 4D no-projection path uses volumetric layout Z×C×Y×X.
+            return arr, arr.shape[1]
+        raise ValueError(f"Unexpected image ndim=4 for {path}")
     if arr.ndim == 3:
         c, h, w = arr.shape
         # CYX: either explicit from metadata or heuristic (C small, H/W much larger)
@@ -175,15 +266,20 @@ def compute_metrics(masks: np.ndarray) -> list[dict]:
     from skimage.measure import regionprops
 
     rows = []
+    is_3d = masks.ndim == 3
     for prop in regionprops(masks.astype(int)):
+        # skimage does not implement eccentricity for 3D regions.
+        eccentricity = float("nan") if is_3d else prop.eccentricity
+        centroid_x = prop.centroid[-1]
+        centroid_y = prop.centroid[-2]
         rows.append(
             {
                 "id": prop.label,
                 "area": prop.area,
                 "diameter": prop.equivalent_diameter_area,
-                "centroid_x": prop.centroid[1],
-                "centroid_y": prop.centroid[0],
-                "eccentricity": prop.eccentricity,
+                "centroid_x": centroid_x,
+                "centroid_y": centroid_y,
+                "eccentricity": eccentricity,
             }
         )
     return rows
@@ -214,6 +310,7 @@ def write_report(metrics: list[dict], meta: dict, output_dir: Path | str, outlin
     edge_excluded = "yes" if meta.get("exclude_on_edges") else "no"
     flow_threshold = meta.get("flow_threshold", 0.4)
     cellprob_threshold = meta.get("cellprob_threshold", 0.0)
+    z_projection = meta.get("z_projection", "max")
 
     lines = [
         "# Cell Segmentation Report",
@@ -225,6 +322,7 @@ def write_report(metrics: list[dict], meta: dict, output_dir: Path | str, outlin
         f"**Exclude edge cells:** {edge_excluded}",
         f"**Flow threshold:** {flow_threshold}",
         f"**Cellprob threshold:** {cellprob_threshold}",
+        f"**Z projection policy:** {z_projection}",
         "",
         "## Results",
         "",
@@ -260,6 +358,16 @@ def save_outlines(img: np.ndarray, masks: np.ndarray, flows: list, output_dir: P
     fig_dir = Path(output_dir) / "figures"
     fig_dir.mkdir(parents=True, exist_ok=True)
 
+    if masks.ndim != 2:
+        # Cellpose does not support saving 3D outlines as PNG. Emit a note so
+        # report generation remains consistent for volumetric runs.
+        note_name = f"{stem}_cp_outlines_unavailable.txt"
+        (fig_dir / note_name).write_text(
+            "Outlines PNG not generated for volumetric segmentation; "
+            "inspect label volume in napari instead."
+        )
+        return note_name
+
     cp_io.save_masks(
         images=[img],
         masks=[masks],
@@ -274,7 +382,10 @@ def save_outlines(img: np.ndarray, masks: np.ndarray, flows: list, output_dir: P
     src = fig_dir / f"{stem}_outlines_cp_masks.png"
     final_name = f"{stem}_cp_outlines.png"
     if src.exists():
-        src.rename(fig_dir / final_name)
+        target = fig_dir / final_name
+        if target.exists():
+            target.unlink()
+        src.rename(target)
     return final_name
 
 
@@ -325,10 +436,12 @@ def run_segmentation(
     flow_threshold: float = 0.4,
     cellprob_threshold: float = 0.0,
 ) -> tuple[np.ndarray, list]:
-    """Run cpsam on an image (greyscale H×W, multi-channel H×W×C, or z-stack Z×H×W).
+    """Run cpsam on an image (greyscale H×W, multi-channel H×W×C, z-stack Z×H×W, or Z×C×H×W).
 
-    cpsam is channel-order invariant — no channels argument is passed.
-    Pass do_3D=True for volumetric segmentation of (Z, H, W) stacks.
+    For 2D mode, cpsam is channel-order invariant and no explicit channel
+    mapping is passed.
+    Pass do_3D=True for volumetric segmentation of (Z, H, W) or (Z, C, H, W) stacks.
+    For 3D multi-channel inputs (Z, C, H, W), channel_axis=1 is passed.
     Pass exclude_on_edges=True to remove any cell whose mask touches a border
     pixel (mirrors cellpose CLI --exclude_on_edges).
     flow_threshold: max allowed error of the flows for each mask (default 0.4).
@@ -341,14 +454,18 @@ def run_segmentation(
     from cellpose import utils as cp_utils
 
     model = CellposeModel(gpu=use_gpu)
-    masks, flows, _ = model.eval(
-        img,
-        diameter=diameter,
-        do_3D=do_3D,
-        z_axis=0 if do_3D else None,
-        flow_threshold=flow_threshold,
-        cellprob_threshold=cellprob_threshold,
-    )
+    eval_kwargs = {
+        "diameter": diameter,
+        "do_3D": do_3D,
+        "z_axis": 0 if do_3D else None,
+        "flow_threshold": flow_threshold,
+        "cellprob_threshold": cellprob_threshold,
+    }
+    if do_3D and img.ndim == 4:
+        # For volumetric multi-channel inputs, keep image as Z×C×Y×X.
+        eval_kwargs["channel_axis"] = 1
+
+    masks, flows, _ = model.eval(img, **eval_kwargs)
     masks = masks.astype(np.uint16)
     if exclude_on_edges:
         masks = cp_utils.remove_edge_masks(masks).astype(np.uint16)
@@ -392,8 +509,10 @@ def repro_command_for_bundle(args: argparse.Namespace, output_dir: Path) -> Repr
 
     if args.diameter is not None:
         cmd_args.extend(["--diameter", str(args.diameter)])
-    if args.gpu:
+    if args.gpu is True:
         cmd_args.append("--use_gpu")
+    if args.use_cpu:
+        cmd_args.append("--use_cpu")
     if args.do_3D:
         cmd_args.append("--do_3D")
     if args.exclude_on_edges:
@@ -402,6 +521,8 @@ def repro_command_for_bundle(args: argparse.Namespace, output_dir: Path) -> Repr
         cmd_args.extend(["--flow_threshold", str(args.flow_threshold)])
     if args.cellprob_threshold != 0.0:
         cmd_args.extend(["--cellprob_threshold", str(args.cellprob_threshold)])
+    if args.z_projection != "max":
+        cmd_args.extend(["--z_projection", args.z_projection])
 
     cmd_args.extend(["--output", ReproPath(output_dir, anchor="output_dir")])
 
@@ -416,42 +537,102 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="cell-detection — cell segmentation using cpsam (Cellpose 4.0)"
     )
-    parser.add_argument("--input", help="Input image (TIFF, PNG, JPG)")
+    parser.add_argument("--input", help="Input image (TIFF, CZI, ND2, PNG, JPG)")
     parser.add_argument("--diameter", type=float, default=None, help="Cell diameter in pixels (default: auto)")
-    parser.add_argument("--use_gpu", dest="gpu", action="store_true", default=False, help="Use GPU if available")
-    parser.add_argument("--do_3D", action="store_true", default=False, help="Volumetric 3D segmentation for z-stack (Z×H×W) input")
+    parser.add_argument(
+        "--use_gpu",
+        dest="gpu",
+        action="store_true",
+        default=None,
+        help="Prefer GPU acceleration (default behavior: auto-use GPU when available).",
+    )
+    parser.add_argument(
+        "--use_cpu",
+        action="store_true",
+        default=False,
+        help="Force CPU execution even when a GPU backend is available.",
+    )
+    parser.add_argument("--do_3D", action="store_true", default=False, help="Volumetric 3D segmentation for Z×H×W or Z×C×H×W input")
     parser.add_argument("--exclude_on_edges", action="store_true", default=False, help="Remove cells touching the image border (mirrors cellpose CLI --exclude_on_edges)")
     parser.add_argument("--flow_threshold", type=float, default=0.4, help="Max flow error per mask (default: 0.4). Increase to accept more masks, decrease for stricter filtering.")
     parser.add_argument("--cellprob_threshold", type=float, default=0.0, help="Cell probability threshold (default: 0.0). Decrease (e.g. -6) to detect dimmer/more cells, increase for stricter detection.")
+    parser.add_argument("--z_projection", choices=("max", "none"), default="max", help="How to reduce 4D stacks (C/Z/Y/X). 'max' performs Z max projection (default). 'none' preserves Z; multi-channel stacks remain Z×C×H×W.")
     parser.add_argument("--output", required=True, help="Output directory")
     parser.add_argument("--demo", action="store_true", help="Run on a synthetic demo image")
     args = parser.parse_args()
 
+    # Guardrails for mode consistency:
+    # - 2D mode must use z_projection=max
+    # - 3D mode must use z_projection=none
+    # Exception: if --do_3D is requested for a truly 2D single-channel input,
+    # fall back to 2D mode so the pipeline still runs.
+    if not args.do_3D and args.z_projection != "max":
+        parser.error("--z_projection none is only valid with --do_3D")
+
     output_dir = Path(args.output)
     output_dir.mkdir(parents=True, exist_ok=True)
+    effective_do_3d = args.do_3D
 
     # Build input image
     if args.demo:
+        if args.do_3D:
+            print(
+                "[cell-detection] Warning: --do_3D requested for 2D demo image; "
+                "falling back to 2D mode."
+            )
+            effective_do_3d = False
+            args.do_3D = False
         img_prep = make_demo_image()
         image_path = "demo (synthetic fluorescence nuclei — offline)"
         stem = "demo"
     else:
         if not args.input:
             parser.error("--input is required unless --demo is used")
-        img, n_channels = load_image(args.input)
+
+        if args.do_3D and args.z_projection != "none":
+            img_none, n_channels_none = load_image(args.input, z_projection="none")
+            if img_none.ndim == 2 and n_channels_none == 1:
+                print(
+                    "[cell-detection] Warning: --do_3D requested for 2D single-channel "
+                    "input with z_projection=max; falling back to 2D mode."
+                )
+                effective_do_3d = False
+                args.do_3D = False
+            else:
+                parser.error("--do_3D requires --z_projection none for volumetric inputs")
+
+        img, n_channels = load_image(args.input, z_projection=args.z_projection)
+        if args.do_3D and img.ndim == 2 and n_channels == 1:
+            print(
+                "[cell-detection] Warning: --do_3D requested for 2D single-channel "
+                "input; falling back to 2D mode."
+            )
+            effective_do_3d = False
+            args.do_3D = False
+        if effective_do_3d and img.ndim not in (3, 4):
+            parser.error(
+                "--do_3D requires volumetric input with shape Z×Y×X or Z×C×Y×X"
+            )
+        if effective_do_3d and img.ndim == 4 and img.shape[0] < 2:
+            parser.error(
+                "--do_3D requires a true Z stack; got 4D input with fewer than 2 Z slices"
+            )
         image_path = args.input
         # Strip all compound suffixes (e.g. .ome.tif → base stem)
         stem = Path(args.input).name.split(".")[0]
-        if args.do_3D:
+        if effective_do_3d:
             img_prep = img  # pass Z×H×W directly to cellpose
         else:
             img_prep = prepare_image(img, n_channels)
 
-    # Segmentation — demo always attempts GPU; otherwise honour --use_gpu flag
-    use_gpu = _detect_gpu(True if args.demo else args.gpu)
+    # Segmentation defaults to GPU auto-detection unless explicitly forced to CPU.
+    gpu_requested = True if args.demo else (True if args.gpu is None else args.gpu)
+    if args.use_cpu:
+        gpu_requested = False
+    use_gpu = _detect_gpu(gpu_requested)
     device_label = "GPU" if use_gpu else "CPU"
     print(f"[cell-detection] Segmenting with cpsam on {device_label}...")
-    masks, flows = run_segmentation(img_prep, args.diameter, use_gpu, do_3D=args.do_3D, exclude_on_edges=args.exclude_on_edges, flow_threshold=args.flow_threshold, cellprob_threshold=args.cellprob_threshold)
+    masks, flows = run_segmentation(img_prep, args.diameter, use_gpu, do_3D=effective_do_3d, exclude_on_edges=args.exclude_on_edges, flow_threshold=args.flow_threshold, cellprob_threshold=args.cellprob_threshold)
 
     # Save masks + seg.npy
     masks_filename = save_masks(masks, output_dir, stem=stem)
@@ -475,7 +656,8 @@ def main() -> None:
     save_histogram(metrics, output_dir, stem=stem)
 
     # Report
-    meta = {"image_path": image_path, "use_gpu": use_gpu, "diameter": args.diameter, "exclude_on_edges": args.exclude_on_edges, "flow_threshold": args.flow_threshold, "cellprob_threshold": args.cellprob_threshold}
+    effective_z_projection = "none" if effective_do_3d else "max"
+    meta = {"image_path": image_path, "use_gpu": use_gpu, "diameter": args.diameter, "exclude_on_edges": args.exclude_on_edges, "flow_threshold": args.flow_threshold, "cellprob_threshold": args.cellprob_threshold, "z_projection": effective_z_projection}
     write_report(metrics, meta, output_dir, outlines_filename=outlines_filename, masks_filename=masks_filename, seg_filename=seg_filename, csv_filename=f"{stem}_measurements.csv", histogram_filename=f"{stem}_histogram.png")
 
     # Reproducibility — environment.yml must be written first so REPLAY.md
@@ -483,7 +665,7 @@ def main() -> None:
     write_environment_yml(
         output_dir,
         env_name="clawbio-cell-detection",
-        pip_deps=["cellpose>=4.0", "tifffile", "czifile", "nd2", "Pillow", "numpy", "matplotlib", "scikit-image", "scipy"],
+        pip_deps=["cellpose>=4.0", "tifffile", "czifile>=2019.7.2.2", "nd2>=0.11.1", "Pillow", "numpy", "matplotlib", "scikit-image", "scipy"],
         python_version="3.10",
     )
     write_portable_commands_sh(

--- a/skills/cell-detection/requirements.txt
+++ b/skills/cell-detection/requirements.txt
@@ -2,7 +2,7 @@ cellpose>=4.0
 tifffile
 czifile>=2019.7.2.2
 nd2>=0.11.1
-Pillow
+Pillow>=10.0.0
 numpy
 matplotlib
 scikit-image

--- a/skills/cell-detection/requirements.txt
+++ b/skills/cell-detection/requirements.txt
@@ -1,7 +1,7 @@
 cellpose>=4.0
 tifffile
-czifile
-nd2
+czifile>=2019.7.2.2
+nd2>=0.11.1
 Pillow
 numpy
 matplotlib

--- a/skills/cell-detection/requirements.txt
+++ b/skills/cell-detection/requirements.txt
@@ -1,5 +1,7 @@
 cellpose>=4.0
 tifffile
+czifile
+nd2
 Pillow
 numpy
 matplotlib

--- a/skills/cell-detection/tests/test_cell_detection.py
+++ b/skills/cell-detection/tests/test_cell_detection.py
@@ -722,6 +722,37 @@ class TestLoadImage:
         assert n == 4
         np.testing.assert_array_equal(arr, source)
 
+    def test_load_4d_heuristic_raises_when_z_le_c_and_no_metadata(self, tmp_path):
+        import types
+
+        path = tmp_path / "img.czi"
+        path.write_bytes(b"")
+        source = np.zeros((3, 4, 16, 16), dtype=np.uint16)  # Z, C, Y, X — Z <= C
+
+        class _FakeCziFile:
+            axes = "BTZYX"
+
+            def __init__(self, image):
+                self.image = image
+
+            def asarray(self):
+                return source
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        fake_czi = types.ModuleType("czifile")
+        fake_czi.CziFile = _FakeCziFile
+
+        with patch.dict("sys.modules", {"czifile": fake_czi}):
+            with pytest.raises(ValueError, match="Cannot infer channel vs Z axis"):
+                cell_detection.load_image(str(path), z_projection="max")
+            with pytest.raises(ValueError, match="Cannot infer channel vs Z axis"):
+                cell_detection.load_image(str(path), z_projection="none")
+
 
 # ---------------------------------------------------------------------------
 # TestDemoImageEdgeCells

--- a/skills/cell-detection/tests/test_cell_detection.py
+++ b/skills/cell-detection/tests/test_cell_detection.py
@@ -344,12 +344,30 @@ class TestLoadImage:
         arr, n = cell_detection.load_image(str(path))
         assert n == 1
 
-    def test_load_czi_stack_squeezes_and_counts_channels(self, tmp_path):
+    def test_load_czi_zcyx_metadata_max_projects_to_hwc(self, tmp_path):
         import types
         path = tmp_path / "img.czi"
         path.write_bytes(b"")
+        source = np.ones((1, 3, 32, 32), dtype=np.uint16)
+
+        class _FakeCziFile:
+            axes = "ZCYX"
+
+            def __init__(self, image):
+                self.image = image
+
+            def asarray(self):
+                return source
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
         fake_czi = types.ModuleType("czifile")
-        fake_czi.imread = lambda image: np.ones((1, 3, 32, 32), dtype=np.uint16)
+        fake_czi.imread = lambda image: source
+        fake_czi.CziFile = _FakeCziFile
         with patch.dict("sys.modules", {"czifile": fake_czi}):
             arr, n = cell_detection.load_image(str(path))
         assert arr.shape == (32, 32, 3)
@@ -359,12 +377,350 @@ class TestLoadImage:
         import types
         path = tmp_path / "img.nd2"
         path.write_bytes(b"")
+        source = np.ones((4, 3, 16, 16), dtype=np.uint16)
+
+        class _FakeND2File:
+            sizes = {"Z": 4, "C": 3, "Y": 16, "X": 16}
+
+            def __init__(self, image):
+                self.image = image
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
         fake_nd2 = types.ModuleType("nd2")
-        fake_nd2.imread = lambda image: np.ones((4, 3, 16, 16), dtype=np.uint16)
+        fake_nd2.imread = lambda image: source
+        fake_nd2.ND2File = _FakeND2File
         with patch.dict("sys.modules", {"nd2": fake_nd2}):
             arr, n = cell_detection.load_image(str(path))
         assert arr.shape == (16, 16, 3)
         assert n == 3
+
+    def test_load_czi_uses_axes_metadata_for_channel_gt_z(self, tmp_path):
+        import types
+
+        path = tmp_path / "img.czi"
+        path.write_bytes(b"")
+        source = np.zeros((2, 5, 8, 8), dtype=np.uint16)  # Z, C, Y, X
+        for channel in range(5):
+            source[:, channel, :, :] = channel + 1
+
+        class _FakeCziFile:
+            axes = "ZCYX"
+
+            def __init__(self, image):
+                self.image = image
+
+            def asarray(self):
+                return source
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        fake_czi = types.ModuleType("czifile")
+        fake_czi.CziFile = _FakeCziFile
+        fake_czi.imread = lambda image: source
+
+        with patch.dict("sys.modules", {"czifile": fake_czi}):
+            arr, n = cell_detection.load_image(str(path))
+
+        assert arr.shape == (8, 8, 5)
+        assert n == 5
+        for channel in range(5):
+            assert np.all(arr[:, :, channel] == channel + 1)
+
+    def test_load_nd2_uses_metadata_for_channel_gt_z(self, tmp_path):
+        import types
+
+        path = tmp_path / "img.nd2"
+        path.write_bytes(b"")
+        source = np.zeros((2, 5, 8, 8), dtype=np.uint16)  # Z, C, Y, X
+        for channel in range(5):
+            source[:, channel, :, :] = channel + 1
+
+        class _FakeND2File:
+            sizes = {"Z": 2, "C": 5, "Y": 8, "X": 8}
+
+            def __init__(self, image):
+                self.image = image
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        fake_nd2 = types.ModuleType("nd2")
+        fake_nd2.imread = lambda image: source
+        fake_nd2.ND2File = _FakeND2File
+
+        with patch.dict("sys.modules", {"nd2": fake_nd2}):
+            arr, n = cell_detection.load_image(str(path))
+
+        assert arr.shape == (8, 8, 5)
+        assert n == 5
+        for channel in range(5):
+            assert np.all(arr[:, :, channel] == channel + 1)
+
+    def test_load_czi_singleton_channel_preserved(self, tmp_path):
+        import types
+
+        path = tmp_path / "img.czi"
+        path.write_bytes(b"")
+        source = np.zeros((8, 1, 12, 12), dtype=np.uint16)  # Z, C, Y, X
+        source[:, 0, :, :] = 4096
+
+        class _FakeCziFile:
+            axes = "ZCYX"
+
+            def __init__(self, image):
+                self.image = image
+
+            def asarray(self):
+                return source
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        fake_czi = types.ModuleType("czifile")
+        fake_czi.CziFile = _FakeCziFile
+        fake_czi.imread = lambda image: source
+
+        with patch.dict("sys.modules", {"czifile": fake_czi}):
+            arr, n = cell_detection.load_image(str(path))
+
+        assert arr.shape == (12, 12, 1)
+        assert n == 1
+        assert arr.dtype == np.uint16
+        assert int(arr.max()) == 4096
+
+    def test_load_nd2_uint16_dynamic_range_preserved(self, tmp_path):
+        import types
+
+        path = tmp_path / "img.nd2"
+        path.write_bytes(b"")
+        source = np.zeros((2, 3, 10, 10), dtype=np.uint16)  # Z, C, Y, X
+        source[0, 0, :, :] = 10
+        source[0, 1, :, :] = 2000
+        source[1, 2, :, :] = 65535
+
+        class _FakeND2File:
+            sizes = {"Z": 2, "C": 3, "Y": 10, "X": 10}
+
+            def __init__(self, image):
+                self.image = image
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        fake_nd2 = types.ModuleType("nd2")
+        fake_nd2.imread = lambda image: source
+        fake_nd2.ND2File = _FakeND2File
+
+        with patch.dict("sys.modules", {"nd2": fake_nd2}):
+            arr, n = cell_detection.load_image(str(path))
+
+        assert arr.shape == (10, 10, 3)
+        assert n == 3
+        assert arr.dtype == np.uint16
+        assert int(arr[:, :, 0].max()) == 10
+        assert int(arr[:, :, 1].max()) == 2000
+        assert int(arr[:, :, 2].max()) == 65535
+
+    def test_load_nd2_projection_none_returns_zcyx_single_channel(self, tmp_path):
+        import types
+
+        path = tmp_path / "img.nd2"
+        path.write_bytes(b"")
+        source = np.arange(4 * 1 * 6 * 7, dtype=np.uint16).reshape(4, 1, 6, 7)  # Z, C, Y, X
+
+        class _FakeND2File:
+            sizes = {"Z": 4, "C": 1, "Y": 6, "X": 7}
+
+            def __init__(self, image):
+                self.image = image
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        fake_nd2 = types.ModuleType("nd2")
+        fake_nd2.imread = lambda image: source
+        fake_nd2.ND2File = _FakeND2File
+
+        with patch.dict("sys.modules", {"nd2": fake_nd2}):
+            arr, n = cell_detection.load_image(str(path), z_projection="none")
+
+        assert arr.shape == (4, 1, 6, 7)
+        assert n == 1
+        np.testing.assert_array_equal(arr, source)
+
+    def test_load_czi_projection_none_multichannel_returns_zcyx(self, tmp_path):
+        import types
+
+        path = tmp_path / "img.czi"
+        path.write_bytes(b"")
+        source = np.zeros((3, 4, 6, 7), dtype=np.uint16)  # Z, C, Y, X
+        for channel in range(4):
+            source[:, channel, :, :] = channel + 10
+
+        class _FakeCziFile:
+            axes = "ZCYX"
+
+            def __init__(self, image):
+                self.image = image
+
+            def asarray(self):
+                return source
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        fake_czi = types.ModuleType("czifile")
+        fake_czi.CziFile = _FakeCziFile
+        fake_czi.imread = lambda image: source
+
+        with patch.dict("sys.modules", {"czifile": fake_czi}):
+            arr, n = cell_detection.load_image(str(path), z_projection="none")
+
+        assert arr.shape == (3, 4, 6, 7)
+        assert n == 4
+        np.testing.assert_array_equal(arr, source)
+
+    def test_load_nd2_projection_none_multichannel_returns_zcyx(self, tmp_path):
+        import types
+
+        path = tmp_path / "img.nd2"
+        path.write_bytes(b"")
+        source = np.zeros((5, 3, 4, 6), dtype=np.uint16)  # Z, C, Y, X
+        for channel in range(3):
+            source[:, channel, :, :] = channel + 20
+
+        class _FakeND2File:
+            sizes = {"Z": 5, "C": 3, "Y": 4, "X": 6}
+
+            def __init__(self, image):
+                self.image = image
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        fake_nd2 = types.ModuleType("nd2")
+        fake_nd2.imread = lambda image: source
+        fake_nd2.ND2File = _FakeND2File
+
+        with patch.dict("sys.modules", {"nd2": fake_nd2}):
+            arr, n = cell_detection.load_image(str(path), z_projection="none")
+
+        assert arr.shape == (5, 3, 4, 6)
+        assert n == 3
+        np.testing.assert_array_equal(arr, source)
+
+    def test_run_segmentation_3d_multichannel_uses_z_and_channel_axes(self):
+        import types
+
+        calls = {}
+
+        def fake_eval(
+            img,
+            diameter=None,
+            do_3D=False,
+            z_axis=None,
+            channel_axis=None,
+            flow_threshold=0.4,
+            cellprob_threshold=0.0,
+        ):
+            calls["shape"] = img.shape
+            calls["do_3D"] = do_3D
+            calls["z_axis"] = z_axis
+            calls["channel_axis"] = channel_axis
+            return np.zeros((img.shape[2], img.shape[3]), dtype=np.uint16), [[]], None
+
+        class _FakeCellposeModel:
+            def __init__(self, gpu=False):
+                self.gpu = gpu
+
+            def eval(self, *args, **kwargs):
+                return fake_eval(*args, **kwargs)
+
+        fake_models = types.ModuleType("cellpose.models")
+        fake_models.CellposeModel = _FakeCellposeModel
+        fake_utils = types.ModuleType("cellpose.utils")
+        fake_utils.remove_edge_masks = lambda masks: masks
+        fake_cellpose = types.ModuleType("cellpose")
+        fake_cellpose.models = fake_models
+        fake_cellpose.utils = fake_utils
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "cellpose": fake_cellpose,
+                "cellpose.models": fake_models,
+                "cellpose.utils": fake_utils,
+            },
+        ):
+            img = np.zeros((4, 3, 8, 9), dtype=np.uint16)  # Z, C, Y, X
+            cell_detection.run_segmentation(img, diameter=None, use_gpu=False, do_3D=True)
+
+        assert calls["shape"] == (4, 3, 8, 9)
+        assert calls["do_3D"] is True
+        assert calls["z_axis"] == 0
+        assert calls["channel_axis"] == 1
+
+    def test_load_czi_projection_none_heuristic_4d_returns_zcyx(self, tmp_path):
+        import types
+
+        path = tmp_path / "img.czi"
+        path.write_bytes(b"")
+        source = np.zeros((7, 4, 16, 16), dtype=np.uint16)  # Z, C, Y, X
+        for channel in range(4):
+            source[:, channel, :, :] = channel + 1
+
+        class _FakeCziFile:
+            # Non-CZYX metadata so loader falls back to 4D heuristic path.
+            axes = "BTZYX"
+
+            def __init__(self, image):
+                self.image = image
+
+            def asarray(self):
+                return source
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+        fake_czi = types.ModuleType("czifile")
+        fake_czi.CziFile = _FakeCziFile
+
+        with patch.dict("sys.modules", {"czifile": fake_czi}):
+            arr, n = cell_detection.load_image(str(path), z_projection="none")
+
+        assert arr.shape == (7, 4, 16, 16)
+        assert n == 4
+        np.testing.assert_array_equal(arr, source)
 
 
 # ---------------------------------------------------------------------------
@@ -517,6 +873,100 @@ class TestFlowCellprobThresholds:
         args = parser.parse_args([])
         assert args.flow_threshold == 0.4
         assert args.cellprob_threshold == 0.0
+
+
+# ---------------------------------------------------------------------------
+# TestCliGuardrails
+# ---------------------------------------------------------------------------
+
+
+class TestCliGuardrails:
+    """Tests for --do_3D / --z_projection mode consistency in main()."""
+
+    def test_z_projection_none_without_do_3d_errors(self, tmp_path):
+        with patch(
+            "sys.argv",
+            [
+                "cell_detection.py",
+                "--input",
+                str(tmp_path / "img.tif"),
+                "--z_projection",
+                "none",
+                "--output",
+                str(tmp_path / "out"),
+            ],
+        ):
+            with pytest.raises(SystemExit) as exc:
+                cell_detection.main()
+        assert exc.value.code == 2
+
+    def test_do_3d_with_max_projection_errors_on_volumetric_input(self, tmp_path):
+        path = tmp_path / "stack.nd2"
+        path.write_bytes(b"")
+        volume = np.zeros((3, 2, 8, 8), dtype=np.uint16)
+
+        with patch.object(cell_detection, "load_image", return_value=(volume, 2)):
+            with patch(
+                "sys.argv",
+                [
+                    "cell_detection.py",
+                    "--input",
+                    str(path),
+                    "--do_3D",
+                    "--output",
+                    str(tmp_path / "out"),
+                ],
+            ):
+                with pytest.raises(SystemExit) as exc:
+                    cell_detection.main()
+        assert exc.value.code == 2
+
+    def test_do_3d_errors_on_non_volumetric_ndim2_input(self, tmp_path):
+        """Greyscale H×W (ndim=2) with n_channels>1 cannot be treated as 3D."""
+        path = tmp_path / "img.tif"
+        path.write_bytes(b"")
+        image = np.zeros((8, 8), dtype=np.uint8)
+
+        with patch.object(cell_detection, "load_image", return_value=(image, 4)):
+            with patch(
+                "sys.argv",
+                [
+                    "cell_detection.py",
+                    "--input",
+                    str(path),
+                    "--do_3D",
+                    "--z_projection",
+                    "none",
+                    "--output",
+                    str(tmp_path / "out"),
+                ],
+            ):
+                with pytest.raises(SystemExit) as exc:
+                    cell_detection.main()
+        assert exc.value.code == 2
+
+    def test_do_3d_errors_when_z_stack_has_single_plane(self, tmp_path):
+        path = tmp_path / "stack.nd2"
+        path.write_bytes(b"")
+        volume = np.zeros((1, 3, 8, 8), dtype=np.uint16)
+
+        with patch.object(cell_detection, "load_image", return_value=(volume, 3)):
+            with patch(
+                "sys.argv",
+                [
+                    "cell_detection.py",
+                    "--input",
+                    str(path),
+                    "--do_3D",
+                    "--z_projection",
+                    "none",
+                    "--output",
+                    str(tmp_path / "out"),
+                ],
+            ):
+                with pytest.raises(SystemExit) as exc:
+                    cell_detection.main()
+        assert exc.value.code == 2
 
 
 # ---------------------------------------------------------------------------

--- a/skills/cell-detection/tests/test_cell_detection.py
+++ b/skills/cell-detection/tests/test_cell_detection.py
@@ -344,6 +344,28 @@ class TestLoadImage:
         arr, n = cell_detection.load_image(str(path))
         assert n == 1
 
+    def test_load_czi_stack_squeezes_and_counts_channels(self, tmp_path):
+        import types
+        path = tmp_path / "img.czi"
+        path.write_bytes(b"")
+        fake_czi = types.ModuleType("czifile")
+        fake_czi.imread = lambda image: np.ones((1, 3, 32, 32), dtype=np.uint16)
+        with patch.dict("sys.modules", {"czifile": fake_czi}):
+            arr, n = cell_detection.load_image(str(path))
+        assert arr.shape == (32, 32, 3)
+        assert n == 3
+
+    def test_load_nd2_stack_counts_channels(self, tmp_path):
+        import types
+        path = tmp_path / "img.nd2"
+        path.write_bytes(b"")
+        fake_nd2 = types.ModuleType("nd2")
+        fake_nd2.imread = lambda image: np.ones((4, 3, 16, 16), dtype=np.uint16)
+        with patch.dict("sys.modules", {"nd2": fake_nd2}):
+            arr, n = cell_detection.load_image(str(path))
+        assert arr.shape == (16, 16, 3)
+        assert n == 3
+
 
 # ---------------------------------------------------------------------------
 # TestDemoImageEdgeCells


### PR DESCRIPTION
Skill now can process raw data from Zeiss .czi and Nikon .nd2 files.

Multichannel 3D stacks are supported by reducing the Z axis by max projection.

- add CZI and ND2 support to cell detection
- add tests for CZI and ND2 support
- update requirements.txt to include czifile and nd2
- update SKILL.md to include CZI and ND2 support
- update cell_detection.py to include CZI and ND2 support
- update tests/test_cell_detection.py to include CZI and ND2 support
- update README.md to include CZI and ND2 support
- update README.md to include CZI and ND2 support

## Summary

- Add direct Zeiss `.czi` and Nikon `.nd2` support to `cell-detection` image loading.
- Support multichannel 3D stacks by reducing the Z axis using max projection before segmentation.
- Update tests, skill docs, and dependencies to cover and document the new microscopy input formats.
- Get in touch for demo data (files too big for commit)

## Skill affected

`cell-detection`

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology)
- [x] Tests included and passing (`pytest -v`)
- [] Demo data included for reviewers to test
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

```bash
python -m pytest skills/cell-detection/tests/test_cell_detection.py -k "czi or nd2" -q
..                                                                       [100%]
2 passed, 64 deselected, 1 warning in 1.01s
```

```bash
python -m pytest skills/cell-detection/tests/test_cell_detection.py -k "TestLoadImage" -q
.....                                                                    [100%]
5 passed, 61 deselected, 1 warning in 1.33s
```
