### PR TITLE
Fix nf-core wrapper test harness after the clawbio CLI package split

### DIFF
--- a/skills/nfcore-rnaseq-wrapper/tests/conftest.py
+++ b/skills/nfcore-rnaseq-wrapper/tests/conftest.py
@@ -1,9 +1,23 @@
-"""
-conftest.py — pre-stub clawbio package to avoid loading runner.py
-(runner.py loads clawbio.py which uses `str | None` syntax, Python 3.10+ only)
+"""conftest.py — pre-stub the ``clawbio`` package for this skill's tests.
+
+The stub maps ``clawbio`` / ``clawbio.common`` onto the real package directories
+via ``__path__`` and eagerly loads only the leaf helper modules the wrapper needs
+(``clawbio.common.checksums`` and friends). This keeps the test session light:
+importing the real ``clawbio`` package would execute ``clawbio/__init__.py`` ->
+``from .runner import ...`` -> ``from clawbio.cli import ...``, pulling the whole
+CLI engine into every test.
+
+The runner-allowlist tests do need ``clawbio.cli`` (for ``clawbio.cli.SKILLS``).
+Loading that module runs ``clawbio/cli.py``, whose first line is
+``from clawbio import __version__``. Because we deliberately skip executing
+``clawbio/__init__.py``, the stub must expose ``__version__`` itself, otherwise
+that import fails with ``ImportError: cannot import name '__version__'``. We read
+the value straight from ``clawbio/__init__.py`` so the stub never drifts from the
+real package version.
 """
 from __future__ import annotations
 
+import ast
 import importlib.util
 import sys
 import types
@@ -12,11 +26,34 @@ from pathlib import Path
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 
 
+def _read_clawbio_version() -> str:
+    """Return ``clawbio.__version__`` without importing (and thus executing) the
+    package ``__init__`` (which would trigger the heavy ``runner``/``cli`` chain)."""
+    init_path = _REPO_ROOT / "clawbio" / "__init__.py"
+    try:
+        tree = ast.parse(init_path.read_text(encoding="utf-8"))
+    except OSError:
+        return "0.0.0"
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "__version__":
+                    try:
+                        return ast.literal_eval(node.value)
+                    except ValueError:
+                        return "0.0.0"
+    return "0.0.0"
+
+
 def _ensure_clawbio_stubs() -> None:
     if "clawbio" not in sys.modules:
         pkg = types.ModuleType("clawbio")
         pkg.__path__ = [str(_REPO_ROOT / "clawbio")]  # type: ignore[attr-defined]
         pkg.__package__ = "clawbio"
+        # clawbio.cli does `from clawbio import __version__` at import time; expose
+        # it on the stub so the runner-allowlist tests can import clawbio.cli
+        # without executing clawbio/__init__.py.
+        pkg.__version__ = _read_clawbio_version()  # type: ignore[attr-defined]
         sys.modules["clawbio"] = pkg
     if "clawbio.common" not in sys.modules:
         common = types.ModuleType("clawbio.common")

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_audit_fixes.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_audit_fixes.py
@@ -676,12 +676,10 @@ def test_handoff_provenance_records_path_and_checksum(tmp_path):
 
 
 def test_clawbio_allowlist_is_subset_of_wrapper_flags():
-    import importlib.util
+    # The runner registry lives in clawbio.cli; clawbio.py is a thin shim that
+    # delegates to it.
+    import clawbio.cli as clawbio
 
-    clawbio_path = _SKILL_DIR.parent.parent / "clawbio.py"
-    spec = importlib.util.spec_from_file_location("clawbio_script", clawbio_path)
-    clawbio = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(clawbio)
     entry = clawbio.SKILLS["scrnaseq-pipeline"]
     allow = set(entry.get("allowed_extra_flags", set())) | set(
         entry.get("allowed_extra_flags_without_values", set())

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_audit_round2.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_audit_round2.py
@@ -301,13 +301,17 @@ def test_protocol_matrix_matches_sibling_protocols_json_if_present():
 
 
 def _load_clawbio():
-    import importlib.util
+    """Return the ClawBio runner engine.
 
-    clawbio_path = _SKILL_DIR.parent.parent / "clawbio.py"
-    spec = importlib.util.spec_from_file_location("clawbio_script", clawbio_path)
-    clawbio = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(clawbio)
-    return clawbio
+    The runner registry (``SKILLS``) and the ``run_skill`` / ``main`` callables
+    live in :mod:`clawbio.cli`; the top-level ``clawbio.py`` is a thin shim that
+    only re-exports and delegates to them. Tests inspect and monkeypatch the
+    engine, so they must target ``clawbio.cli`` directly — patching a name on the
+    shim would not change the binding ``main`` resolves inside ``clawbio.cli``.
+    """
+    import clawbio.cli as clawbio_cli
+
+    return clawbio_cli
 
 
 def test_runner_allowlist_includes_no_save_align_intermeds():


### PR DESCRIPTION
## Summary

On a clean checkout, the test suites for two of the nf-core wrappers fail — 12 tests in total (4 in `nfcore-rnaseq-wrapper`, 8 in `nfcore-scrnaseq-wrapper`). The failures all trace back to the `clawbio.py` → `clawbio/` package split: the runner registry (`SKILLS`) and `__version__` now live in `clawbio/cli.py`, but the two wrappers' test harnesses still referenced the pre-split locations.

The production code is already correct — every flag the tests assert on is present in the real allow-lists. Only the tests' import/access paths were stale, so this PR is **test-infrastructure only and changes no runtime behaviour**.

## Root cause & fix

### `nfcore-rnaseq-wrapper` (4 failures)

The test `conftest.py` pre-stubs the `clawbio` package — a deliberate optimisation that keeps the test session light by avoiding a full import of the CLI engine. That stub no longer exposed `__version__`. Because `clawbio/cli.py` begins with `from clawbio import __version__`, importing `clawbio.cli` to read `clawbio.cli.SKILLS` raised:

```
ImportError: cannot import name '__version__' from 'clawbio'
```

**Fix:** the stub now reads the real version straight from `clawbio/__init__.py` (parsed with `ast`, without executing the heavy `__init__`) and exposes it, so the stubbed value can never drift from the package version.

### `nfcore-scrnaseq-wrapper` (8 failures)

Two tests loaded the top-level `clawbio.py` shim by path and then read `clawbio.SKILLS` / monkeypatched `clawbio.run_skill`. After the split, both `SKILLS` and `run_skill` live in `clawbio.cli`; `clawbio.py` is a thin shim that only delegates to it. As a result:

- reading `SKILLS` off the shim raised `AttributeError: module 'clawbio_script' has no attribute 'SKILLS'`, and
- patching `run_skill` on the shim had no effect on the binding `main()` resolves internally, so the call was not intercepted and exited with "No input provided".

**Fix:** the tests now target `clawbio.cli` directly — the canonical home of the runner registry and callables. This both restores `SKILLS` access and makes the monkeypatch reach the function `main()` actually calls.

## Verification

Per-wrapper suites, run the way CI runs them (one wrapper at a time):

| Wrapper | Result |
|---|---|
| `nfcore-rnaseq-wrapper` | 441 passed |
| `nfcore-sarek-wrapper` | 321 passed (already green) |
| `nfcore-scrnaseq-wrapper` | 387 passed, 2 skipped |

(The 2 skips are intentional — they require a sibling `nf-core/scrnaseq` checkout to cross-check against.)

All three `--demo` pipelines were also run end-to-end and launch/execute correctly under Nextflow (`nf-core/rnaseq` 3.26.0, `nf-core/sarek` 3.8.1, `nf-core/scrnaseq`): containers run, processes complete, and the reproducibility bundle is written.

## Scope

Three files, all under the wrappers' `tests/` directories — no production module is modified:

- `skills/nfcore-rnaseq-wrapper/tests/conftest.py`
- `skills/nfcore-scrnaseq-wrapper/tests/test_audit_fixes.py`
- `skills/nfcore-scrnaseq-wrapper/tests/test_audit_round2.py`
