### PR TITLE
Organ Aging Studio - interpretable Goeminne proteomic clocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ skills/pharmgx-reporter/report/
 skills/genome-compare/data/manuel_corpas_23andme.txt
 skills/pr-audit/
 data/
+pyaging_data/
 !skills/methylation-clock/data/
 !skills/methylation-clock/data/GSE139307_small.csv.gz
 !skills/rare-disease-rnaseq/data/

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ skills/pharmgx-reporter/report/
 skills/genome-compare/data/manuel_corpas_23andme.txt
 skills/pr-audit/
 data/
-pyaging_data/
 !skills/methylation-clock/data/
 !skills/methylation-clock/data/GSE139307_small.csv.gz
 !skills/rare-disease-rnaseq/data/

--- a/skills/organ-aging-studio/SKILL.md
+++ b/skills/organ-aging-studio/SKILL.md
@@ -42,7 +42,6 @@ metadata:
     packages:
       - pandas>=2.0
       - numpy>=1.24
-      - matplotlib>=3.7
       - requests>=2.28
   demo_data:
     - path: ../proteomics-clock/data/demo_olink_npx.csv.gz
@@ -104,6 +103,7 @@ predicted_age = intercept + Σ (protein_NPX × coefficient)
 | Hard to explain to clinicians / judges | `report.md` + `protein_contributions.csv` + JSON for agents |
 
 Built on the same pinned [organAging](https://github.com/ludgergoeminne/organAging) coefficients as `proteomics-clock`. **No invented weights.**
+Downloaded coefficients are cached locally with SHA-256 sidecar hashes so the same file cannot silently change between runs.
 
 ## Core Capabilities
 
@@ -111,6 +111,18 @@ Built on the same pinned [organAging](https://github.com/ludgergoeminne/organAgi
 2. **Gen1 / Gen2** — chronological age models or mortality hazard → years (Gompertz)
 3. **Protein filters** — `--top-n`, `--min-abs-coef`, single `--sample-id`
 4. **Structured outputs** — Markdown report, JSON, contribution table, replay `commands.sh`
+
+## Scope
+
+One skill, one task. This skill makes Goeminne organ-aging clocks inspectable from Olink NPX input and nothing else. It does not normalise data, do differential abundance, or make clinical claims.
+
+## Workflow
+
+1. **Validate** the input as an Olink NPX table with `sample_id` plus protein columns.
+2. **Download** the pinned organAging coefficients and organ-protein map from GitHub.
+3. **Predict** organ ages, optionally filtering proteins with `--top-n` and `--min-abs-coef`.
+4. **Convert** Gen2 log-hazards to years via the Gompertz transform when requested.
+5. **Write** `report.md`, `result.json`, `protein_contributions.csv`, and a replayable `commands.sh`.
 
 ## Input Formats
 
@@ -166,19 +178,28 @@ python skills/organ-aging-studio/organ_aging_studio.py \
 
 | File | Contents |
 |------|----------|
-| `report.md` | Per-organ predicted age, delta vs chronological age, protein counts |
+| `report.md` | Per-organ predicted age, raw delta vs chronological age, protein counts |
 | `result.json` | Full nested JSON for agents |
 | `tables/protein_contributions.csv` | Long-format NPX × coef × contribution |
 | `commands.sh` | Replay command |
 
 Example summary row (synthetic demo):
 
-| Organ | Predicted age | Chronological | Delta |
-|-------|---------------|---------------|-------|
+| Organ | Predicted age | Chronological | Raw delta |
+|-------|---------------|---------------|-----------|
 | Heart | ~67 yr | 66 yr | +1 yr |
 | Brain | ~42 yr | 66 yr | −24 yr |
 
 > Demo NPX is **synthetic** — do not use it to validate correlation with age. For real Olink data, see `data/PROVENANCE.md`.
+> The delta column is the raw predicted-minus-chronological gap, not age-residualised acceleration.
+
+## Gotchas
+
+- **Olink NPX is already log2-scaled**: Do not log-transform the input again.
+- **Non-Olink data needs rescaling**: SomaLogic, mass-spec, and other non-Olink inputs must be standardised and rescaled with the paper's Table S3 standard deviations first.
+- **Filtered predictions are illustrative**: `--top-n` and `--min-abs-coef` intentionally drop part of the published clock, so the resulting ages and raw deltas are not the validated full-model outputs.
+- **Raw delta is not residualised acceleration**: The displayed delta is predicted minus chronological age, so it remains age-biased unless you residualise it separately.
+- **Fold order is 1-based**: `--fold 1` means the first coefficient row in the pinned organAging CSV, matching the upstream published fold ordering.
 
 ## Real-world data (download separately)
 
@@ -195,7 +216,7 @@ Large cohorts are **not** bundled. See [`data/PROVENANCE.md`](data/PROVENANCE.md
 - Must state demo data is synthetic when using `--demo`
 - Must refuse clinical diagnosis language
 
-## Safety Rules
+## Safety
 
 - Educational / research use only — **not a medical device**
 - Do not run on identifiable patient data without consent

--- a/skills/organ-aging-studio/SKILL.md
+++ b/skills/organ-aging-studio/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: organ-aging-studio
+description: >-
+  Interactive Goeminne proteomic aging clock with organ filters and per-protein
+  contribution breakdown (protein NPX × coefficient). Agent- and demo-friendly.
+license: MIT
+metadata:
+  version: 0.1.0
+  author: ClawBio hackathon contributor
+  domain: proteomics
+  tags:
+    - aging
+    - longevity
+    - proteomics
+    - biological age
+    - organ clock
+    - Goeminne
+    - interpretability
+  inputs:
+    - name: input_file
+      type: file
+      format:
+        - csv
+        - tsv
+        - csv.gz
+        - tsv.gz
+      description: Olink NPX protein table (samples × proteins)
+      required: true
+  outputs:
+    - name: report
+      type: file
+      format:
+        - md
+      description: Human-readable aging report with per-organ summary
+    - name: result
+      type: file
+      format:
+        - json
+      description: Machine-readable predictions and protein contributions
+  dependencies:
+    python: ">=3.11"
+    packages:
+      - pandas>=2.0
+      - numpy>=1.24
+      - matplotlib>=3.7
+      - requests>=2.28
+  demo_data:
+    - path: ../proteomics-clock/data/demo_olink_npx.csv.gz
+      description: Synthetic 20-sample Olink NPX demo (shared with proteomics-clock)
+  endpoints:
+    cli: python skills/organ-aging-studio/organ_aging_studio.py --input {input_file} --output {output_dir}
+  openclaw:
+    requires:
+      bins:
+        - python3
+    always: false
+    emoji: "🕰️"
+    homepage: https://github.com/ClawBio/ClawBio
+    os:
+      - darwin
+      - linux
+    install:
+      - kind: pip
+        package: pandas
+      - kind: pip
+        package: numpy
+      - kind: pip
+        package: requests
+    trigger_keywords:
+      - organ aging studio
+      - proteomic clock breakdown
+      - protein coefficient aging
+      - Goeminne clock explain
+      - which proteins drive organ age
+---
+
+# Organ Aging Studio
+
+You are **Organ Aging Studio**, a ClawBio skill that makes proteomic biological age clocks **inspectable**. Every prediction decomposes into:
+
+```text
+predicted_age = intercept + Σ (protein_NPX × coefficient)
+```
+
+## Trigger
+
+**Fire this skill when the user says any of:**
+- "organ aging studio" or "explain my organ age"
+- "which proteins drive biological age"
+- "protein breakdown for Goeminne clock"
+- "interactive proteomic aging" or "filter proteins by coefficient"
+
+**Do NOT fire when:**
+- User only wants batch predictions without breakdown → route to `proteomics-clock`
+- User asks about methylation / DNAm clocks → route to `methylation-clock`
+- User asks about differential abundance → route to `affinity-proteomics`
+
+## Why This Exists
+
+| Without this skill | With this skill |
+|--------------------|-----------------|
+| Black-box organ age number | Per-protein contributions ranked by \|coefficient\| |
+| Full model always applied | `--top-n` and `--min-abs-coef` filters for demos |
+| Hard to explain to clinicians / judges | `report.md` + `protein_contributions.csv` + JSON for agents |
+
+Built on the same pinned [organAging](https://github.com/ludgergoeminne/organAging) coefficients as `proteomics-clock`. **No invented weights.**
+
+## Core Capabilities
+
+1. **Multi-organ** — any organ supported by Goeminne et al. (2025); default demo set Heart, Brain, Liver, Immune, Organismal
+2. **Gen1 / Gen2** — chronological age models or mortality hazard → years (Gompertz)
+3. **Protein filters** — `--top-n`, `--min-abs-coef`, single `--sample-id`
+4. **Structured outputs** — Markdown report, JSON, contribution table, replay `commands.sh`
+
+## Input Formats
+
+| Format | Extension | Required columns |
+|--------|-----------|------------------|
+| Olink NPX CSV | `.csv` | `sample_id` + protein gene symbols |
+| Olink NPX TSV | `.tsv` | same |
+| Compressed | `.csv.gz` | same |
+
+Optional: `age` (for delta = bio − chrono), `sex`.
+
+## CLI Reference
+
+```bash
+# Demo — synthetic Olink data (no download)
+python skills/organ-aging-studio/organ_aging_studio.py \
+  --demo --output /tmp/studio
+
+# One patient, Heart only, top 5 drivers
+python skills/organ-aging-studio/organ_aging_studio.py \
+  --input my_olink.csv.gz --output /tmp/studio \
+  --organs Heart --sample-id PATIENT_001 --top-n 5
+
+# All demo samples, multiple organs
+python skills/organ-aging-studio/organ_aging_studio.py \
+  --demo --output /tmp/studio \
+  --organs Heart,Brain,Immune,Organismal --generation gen1
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--demo` | off | Use bundled synthetic Olink table |
+| `--organs` | Heart,Brain,Liver,Immune,Organismal | Comma-separated organ list |
+| `--generation` | gen1 | `gen1` = years; `gen2` = hazard → years |
+| `--sample-id` | all rows | Analyse one sample |
+| `--top-n` | all present | Keep top N proteins by \|coef\| |
+| `--min-abs-coef` | 0 | Drop small coefficients |
+
+## Demo
+
+```bash
+cd ClawBio
+uv sync
+python skills/organ-aging-studio/organ_aging_studio.py \
+  --demo --output /tmp/organ-aging-studio \
+  --organs Heart,Brain,Immune,Organismal \
+  --sample-id DEMO_000 --top-n 10
+```
+
+**Expected outputs** in `/tmp/organ-aging-studio/`:
+
+| File | Contents |
+|------|----------|
+| `report.md` | Per-organ predicted age, delta vs chronological age, protein counts |
+| `result.json` | Full nested JSON for agents |
+| `tables/protein_contributions.csv` | Long-format NPX × coef × contribution |
+| `commands.sh` | Replay command |
+
+Example summary row (synthetic demo):
+
+| Organ | Predicted age | Chronological | Delta |
+|-------|---------------|---------------|-------|
+| Heart | ~67 yr | 66 yr | +1 yr |
+| Brain | ~42 yr | 66 yr | −24 yr |
+
+> Demo NPX is **synthetic** — do not use it to validate correlation with age. For real Olink data, see `data/PROVENANCE.md`.
+
+## Real-world data (download separately)
+
+Large cohorts are **not** bundled. See [`data/PROVENANCE.md`](data/PROVENANCE.md) for:
+
+- **Filbin COVID Olink** (real plasma) — Mendeley download + `proteomics-clock/examples/fetch_filbin.py`
+- **GEO GSE40279** (blood methylation validation) — for `methylation-clock`, not this skill's input
+- **GEO GSE259312** (paired Olink + methylation) — future cross-omics work
+
+## Agent Boundary
+
+- May select organs, filters, and **explain** contributions from `result.json`
+- Must **not** invent coefficients or alter the formula
+- Must state demo data is synthetic when using `--demo`
+- Must refuse clinical diagnosis language
+
+## Safety Rules
+
+- Educational / research use only — **not a medical device**
+- Do not run on identifiable patient data without consent
+- Do not extrapolate beyond populations represented in clock training (UK Biobank–based models)
+
+## Tests
+
+```bash
+pytest skills/organ-aging-studio/tests/ -q
+```
+
+## Citation
+
+Goeminne LJE et al. (2025). *Cell Metabolism* 37(1):205-222.e6. DOI: [10.1016/j.cmet.2024.10.005](https://doi.org/10.1016/j.cmet.2024.10.005)

--- a/skills/organ-aging-studio/data/PROVENANCE.md
+++ b/skills/organ-aging-studio/data/PROVENANCE.md
@@ -1,0 +1,52 @@
+# Data provenance — Organ Aging Studio
+
+This skill does **not** ship large public cohorts. Use the bundled synthetic demo for CI and quick runs; download real datasets separately when validating on published cohorts.
+
+## Bundled demo (via `proteomics-clock`)
+
+| Field | Value |
+|-------|--------|
+| File | `../proteomics-clock/data/demo_olink_npx.csv.gz` |
+| Type | **Synthetic** — no real patients |
+| Samples | 20 (`DEMO_000` … `DEMO_019`) |
+| Proteins | 26 Olink-style NPX columns |
+| Purpose | Pipeline demo, tests, agent walkthrough |
+
+See `proteomics-clock/data/PROVENANCE.md` for generation details.
+
+Run without downloading anything:
+
+```bash
+python skills/organ-aging-studio/organ_aging_studio.py --demo --output /tmp/studio
+```
+
+## Optional real-world datasets (download separately)
+
+These are **not** required to use the skill. They are useful for hackathon validation slides and cross-omics work.
+
+### Filbin et al. 2021 — COVID Olink proteomics (real plasma)
+
+- **Use case**: Real Olink NPX for Goeminne organ clocks (longitudinal Day 0/3/7)
+- **Download**: [Mendeley Data — nf853r8xsj](https://doi.org/10.17632/nf853r8xsj.2) (3 Excel files)
+- **Ingest**: `python skills/proteomics-clock/examples/fetch_filbin.py --data-dir <download_dir> --output <out_dir>`
+- **Then**: Point `--input` at the processed CSV from that script
+
+### GEO GSE40279 — Hannum 2013 whole-blood methylation (validation only)
+
+- **Use case**: Show DNAm clocks correlate with age (r ≈ 0.9) on blood — **not** an input to this skill
+- **Download** (pick one):
+  - Supplemental beta chunks (~316 MB each): [GSE40279 on GEO](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE40279) → *Supplementary file*
+  - Full average beta: `GSE40279_average_beta.txt.gz` (~1.2 GB)
+- **Ages**: GEO series matrix `!Sample_title` field (`"age 67y 1001"`)
+- **Clock skill**: Use ClawBio `methylation-clock` with a prepared pickle/CSV — see hackathon workspace `scripts/prepare_gse40279_blood.py` as a reference ingest pattern
+
+### GEO GSE259312 — paired Olink + cfDNA methylation (2024)
+
+- **Use case**: Future paired proteomic + epigenetic age on the **same** individuals
+- **Download**: [GSE259312 on GEO](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GSE259312)
+- **Status**: Requires custom prep; not bundled
+
+## What not to do
+
+- Do not commit GEO methylation matrices or Filbin raw Excel into this skill folder.
+- Do not treat synthetic demo NPX as evidence that clocks track chronological age (expected r ≈ 0).

--- a/skills/organ-aging-studio/organ_aging_studio.py
+++ b/skills/organ-aging-studio/organ_aging_studio.py
@@ -25,9 +25,9 @@ if str(_PROTEOMICS_CLOCK_DIR) not in sys.path:
     sys.path.insert(0, str(_PROTEOMICS_CLOCK_DIR))
 
 from proteomics_clock import (  # noqa: E402
-    DEFAULT_ORGANS,
     DISCLAIMER,
     CITATION,
+    assess_input_npx_scale,
     download_coefficients,
     download_organ_proteins,
     load_input,
@@ -101,10 +101,12 @@ def compute_organ_age(
         "predicted_age_years": round(predicted, 2),
         "chronological_age_years": chrono_age,
         "age_delta_years": delta,
+        "raw_delta_years": delta,
         "intercept": round(intercept, 4),
         "n_proteins_used": len(contributions),
         "n_proteins_available": len(active),
         "n_proteins_in_model": len(protein_coefs),
+        "is_partial_prediction": len(active) < len(protein_coefs),
         "contributions": contributions,
     }
 
@@ -132,6 +134,8 @@ def run_studio(
             raise ValueError(f"sample_id '{sample_id}' not found in input")
         df = subset
 
+    input_warnings = assess_input_npx_scale(df)
+
     coefficients = download_coefficients(organs, generation, fold)
     organ_protein_map = download_organ_proteins()
 
@@ -141,6 +145,7 @@ def run_studio(
         "fold": fold,
         "organs": organs,
         "filters": {"top_n": top_n, "min_abs_coef": min_abs_coef},
+        "input_sanity_warnings": input_warnings,
         "samples": [],
     }
 
@@ -203,6 +208,9 @@ def run_studio(
 
 
 def build_report(results: dict[str, Any]) -> str:
+    filters = results.get("filters", {})
+    filters_active = bool(filters.get("top_n") or (filters.get("min_abs_coef") or 0.0) > 0)
+    input_warnings = results.get("input_sanity_warnings", [])
     lines = [
         "# Organ Aging Studio Report",
         "",
@@ -216,12 +224,20 @@ def build_report(results: dict[str, Any]) -> str:
         "",
     ]
 
+    if filters_active:
+        lines.extend(
+            [
+                "> Interpretation note: `--top-n` and/or `--min-abs-coef` were used, so these are filtered partial-model predictions rather than the validated full published clock.",
+                "",
+            ]
+        )
+
     for sample in results["samples"]:
         sid = sample["sample_id"]
         lines.append(f"### Sample `{sid}`")
         lines.append("")
-        lines.append("| Organ | Predicted age | Chronological | Delta | Proteins used |")
-        lines.append("|-------|---------------|---------------|-------|---------------|")
+        lines.append("| Organ | Predicted age | Chronological | Raw delta | Proteins used |")
+        lines.append("|-------|---------------|---------------|-----------|---------------|")
         for organ, data in sample["organs"].items():
             chrono = data["chronological_age_years"]
             chrono_s = f"{chrono:.1f}" if chrono is not None else "—"
@@ -235,6 +251,18 @@ def build_report(results: dict[str, Any]) -> str:
 
     lines.extend(
         [
+            "## Input Sanity",
+            "",
+        ]
+    )
+
+    if input_warnings:
+        lines.extend([f"- {warning}" for warning in input_warnings])
+    else:
+        lines.append("- No obvious unit issues detected.")
+
+    lines.extend(
+        [
             "## How prediction works",
             "",
             "```",
@@ -242,6 +270,7 @@ def build_report(results: dict[str, Any]) -> str:
             "```",
             "",
             "Coefficients are downloaded from the pinned [organAging](https://github.com/ludgergoeminne/organAging) repository.",
+            "Delta values are the raw predicted-minus-chronological gap, not age-residualised acceleration.",
             "",
             DISCLAIMER,
         ]
@@ -284,10 +313,11 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main() -> None:
-    args = build_parser().parse_args()
-    input_path = DEMO_DATA if args.demo else Path(args.input)
+    parser = build_parser()
+    args = parser.parse_args()
     if not args.demo and not args.input:
-        build_parser().error("Provide --input or use --demo")
+        parser.error("Provide --input or use --demo")
+    input_path = DEMO_DATA if args.demo else Path(args.input)
 
     organs = parse_organ_list(args.organs)
     result = run_studio(

--- a/skills/organ-aging-studio/organ_aging_studio.py
+++ b/skills/organ-aging-studio/organ_aging_studio.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Organ Aging Studio — interactive Goeminne proteomic clock with protein filters.
+
+Wraps the published organAging coefficients (protein NPX × weight + intercept).
+Designed for demos, web UIs, and hackathon show-and-tell.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+_SKILL_DIR = Path(__file__).resolve().parent
+_CLAWBIO_ROOT = _SKILL_DIR.parent.parent
+_PROTEOMICS_CLOCK_DIR = _SKILL_DIR.parent / "proteomics-clock"
+
+if str(_PROTEOMICS_CLOCK_DIR) not in sys.path:
+    sys.path.insert(0, str(_PROTEOMICS_CLOCK_DIR))
+
+from proteomics_clock import (  # noqa: E402
+    DEFAULT_ORGANS,
+    DISCLAIMER,
+    CITATION,
+    download_coefficients,
+    download_organ_proteins,
+    load_input,
+    mortality_to_years,
+    parse_organ_list,
+)
+
+DEMO_ORGANS = ["Heart", "Brain", "Liver", "Immune", "Organismal"]
+DEMO_DATA = _PROTEOMICS_CLOCK_DIR / "data" / "demo_olink_npx.csv.gz"
+
+
+def filter_protein_coefs(
+    protein_coefs: dict[str, float],
+    available_columns: set[str],
+    *,
+    top_n: int | None = None,
+    min_abs_coef: float = 0.0,
+) -> dict[str, float]:
+    """Keep coefficients for proteins present in the sample, ranked by |coef|."""
+    filtered = {
+        protein: coef
+        for protein, coef in protein_coefs.items()
+        if protein in available_columns and abs(coef) >= min_abs_coef
+    }
+    if top_n is not None and top_n > 0:
+        ranked = sorted(filtered.items(), key=lambda item: abs(item[1]), reverse=True)
+        filtered = dict(ranked[:top_n])
+    return filtered
+
+
+def compute_organ_age(
+    row: pd.Series,
+    coefs: dict[str, float],
+    *,
+    generation: str,
+    top_n: int | None = None,
+    min_abs_coef: float = 0.0,
+) -> dict[str, Any]:
+    """Return predicted age plus per-protein contribution breakdown."""
+    intercept = coefs.get("Intercept", 0.0) if generation == "gen1" else 0.0
+    protein_coefs = {k: v for k, v in coefs.items() if k != "Intercept"}
+    available = set(row.index.astype(str))
+    active = filter_protein_coefs(
+        protein_coefs, available, top_n=top_n, min_abs_coef=min_abs_coef
+    )
+
+    contributions: list[dict[str, Any]] = []
+    total = float(intercept)
+    for protein, coef in sorted(active.items(), key=lambda item: abs(item[1]), reverse=True):
+        npx = float(row[protein])
+        contrib = npx * coef
+        total += contrib
+        contributions.append(
+            {
+                "protein": protein,
+                "npx": round(npx, 4),
+                "coefficient": round(coef, 6),
+                "contribution": round(contrib, 4),
+            }
+        )
+
+    predicted = total
+    if generation == "gen2":
+        predicted = float(mortality_to_years(np.array([total]))[0])
+
+    chrono = row.get("age")
+    chrono_age = float(chrono) if chrono is not None and not pd.isna(chrono) else None
+    delta = round(predicted - chrono_age, 2) if chrono_age is not None else None
+
+    return {
+        "predicted_age_years": round(predicted, 2),
+        "chronological_age_years": chrono_age,
+        "age_delta_years": delta,
+        "intercept": round(intercept, 4),
+        "n_proteins_used": len(contributions),
+        "n_proteins_available": len(active),
+        "n_proteins_in_model": len(protein_coefs),
+        "contributions": contributions,
+    }
+
+
+def run_studio(
+    *,
+    input_path: Path,
+    output_dir: Path,
+    organs: list[str],
+    generation: str = "gen1",
+    fold: int = 1,
+    sample_id: str | None = None,
+    top_n: int | None = None,
+    min_abs_coef: float = 0.0,
+) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    df = load_input(input_path)
+    if "sample_id" not in df.columns:
+        df = df.copy()
+        df.insert(0, "sample_id", [f"sample_{i}" for i in range(len(df))])
+
+    if sample_id is not None:
+        subset = df[df["sample_id"].astype(str) == str(sample_id)]
+        if subset.empty:
+            raise ValueError(f"sample_id '{sample_id}' not found in input")
+        df = subset
+
+    coefficients = download_coefficients(organs, generation, fold)
+    organ_protein_map = download_organ_proteins()
+
+    results: dict[str, Any] = {
+        "input": str(input_path),
+        "generation": generation,
+        "fold": fold,
+        "organs": organs,
+        "filters": {"top_n": top_n, "min_abs_coef": min_abs_coef},
+        "samples": [],
+    }
+
+    tables_dir = output_dir / "tables"
+    tables_dir.mkdir(exist_ok=True)
+    all_contributions: list[pd.DataFrame] = []
+
+    for _, row in df.iterrows():
+        sid = str(row["sample_id"])
+        sample_result: dict[str, Any] = {"sample_id": sid, "organs": {}}
+        for organ in organs:
+            key = f"{organ}_{generation}"
+            coefs = coefficients.get(key)
+            if coefs is None:
+                continue
+            organ_result = compute_organ_age(
+                row,
+                coefs,
+                generation=generation,
+                top_n=top_n,
+                min_abs_coef=min_abs_coef,
+            )
+            organ_result["organ"] = organ
+            organ_result["model_proteins_total"] = len(
+                [p for p in organ_protein_map.get(organ, []) if p in coefs]
+            )
+            sample_result["organs"][organ] = organ_result
+
+            contrib_df = pd.DataFrame(organ_result["contributions"])
+            if not contrib_df.empty:
+                contrib_df.insert(0, "organ", organ)
+                contrib_df.insert(0, "sample_id", sid)
+                all_contributions.append(contrib_df)
+
+        results["samples"].append(sample_result)
+
+    if all_contributions:
+        pd.concat(all_contributions, ignore_index=True).to_csv(
+            tables_dir / "protein_contributions.csv", index=False
+        )
+
+    (output_dir / "result.json").write_text(json.dumps(results, indent=2))
+
+    report = build_report(results)
+    (output_dir / "report.md").write_text(report)
+
+    commands = "\n".join(
+        [
+            "#!/usr/bin/env bash",
+            f"python skills/organ-aging-studio/organ_aging_studio.py \\",
+            f"  --input {input_path} \\",
+            f"  --output {output_dir} \\",
+            f"  --organs {','.join(organs)} \\",
+            f"  --generation {generation}",
+        ]
+    )
+    (output_dir / "commands.sh").write_text(commands + "\n")
+
+    return results
+
+
+def build_report(results: dict[str, Any]) -> str:
+    lines = [
+        "# Organ Aging Studio Report",
+        "",
+        f"**Generated**: {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}",
+        f"**Model**: Goeminne et al. (2025) organ-specific proteomic clocks",
+        f"**Generation**: {results['generation']}",
+        "",
+        CITATION,
+        "",
+        "## Summary",
+        "",
+    ]
+
+    for sample in results["samples"]:
+        sid = sample["sample_id"]
+        lines.append(f"### Sample `{sid}`")
+        lines.append("")
+        lines.append("| Organ | Predicted age | Chronological | Delta | Proteins used |")
+        lines.append("|-------|---------------|---------------|-------|---------------|")
+        for organ, data in sample["organs"].items():
+            chrono = data["chronological_age_years"]
+            chrono_s = f"{chrono:.1f}" if chrono is not None else "—"
+            delta = data["age_delta_years"]
+            delta_s = f"{delta:+.1f}" if delta is not None else "—"
+            lines.append(
+                f"| {organ} | {data['predicted_age_years']:.1f} | {chrono_s} | {delta_s} | "
+                f"{data['n_proteins_used']}/{data['n_proteins_in_model']} |"
+            )
+        lines.append("")
+
+    lines.extend(
+        [
+            "## How prediction works",
+            "",
+            "```",
+            "predicted_age = intercept + Σ (protein_NPX × coefficient)",
+            "```",
+            "",
+            "Coefficients are downloaded from the pinned [organAging](https://github.com/ludgergoeminne/organAging) repository.",
+            "",
+            DISCLAIMER,
+        ]
+    )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Organ Aging Studio — proteomic clock with protein-level breakdown"
+    )
+    parser.add_argument("--input", help="Olink NPX table (.csv/.tsv/.gz)")
+    parser.add_argument("--output", required=True, help="Output directory")
+    parser.add_argument(
+        "--organs",
+        default=",".join(DEMO_ORGANS),
+        help=f"Comma-separated organs (default: {','.join(DEMO_ORGANS)})",
+    )
+    parser.add_argument(
+        "--generation",
+        default="gen1",
+        choices=["gen1", "gen2"],
+        help="gen1 = chronological age; gen2 = mortality hazard → years",
+    )
+    parser.add_argument("--fold", type=int, default=1, help="CV fold 1-5")
+    parser.add_argument("--sample-id", help="Analyse one sample only")
+    parser.add_argument(
+        "--top-n",
+        type=int,
+        help="Use only the top N proteins by |coefficient| (among those in the sample)",
+    )
+    parser.add_argument(
+        "--min-abs-coef",
+        type=float,
+        default=0.0,
+        help="Drop proteins with |coefficient| below this threshold",
+    )
+    parser.add_argument("--demo", action="store_true", help="Use bundled Olink demo data")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    input_path = DEMO_DATA if args.demo else Path(args.input)
+    if not args.demo and not args.input:
+        build_parser().error("Provide --input or use --demo")
+
+    organs = parse_organ_list(args.organs)
+    result = run_studio(
+        input_path=input_path,
+        output_dir=Path(args.output),
+        organs=organs,
+        generation=args.generation,
+        fold=args.fold,
+        sample_id=args.sample_id,
+        top_n=args.top_n,
+        min_abs_coef=args.min_abs_coef,
+    )
+    n_samples = len(result["samples"])
+    print(f"✓ Organ Aging Studio complete — {n_samples} sample(s) → {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/organ-aging-studio/requirements.txt
+++ b/skills/organ-aging-studio/requirements.txt
@@ -1,0 +1,4 @@
+pandas>=2.0
+numpy>=1.24
+matplotlib>=3.7
+requests>=2.28

--- a/skills/organ-aging-studio/requirements.txt
+++ b/skills/organ-aging-studio/requirements.txt
@@ -1,4 +1,3 @@
 pandas>=2.0
 numpy>=1.24
-matplotlib>=3.7
 requests>=2.28

--- a/skills/organ-aging-studio/tests/test_organ_aging_studio.py
+++ b/skills/organ-aging-studio/tests/test_organ_aging_studio.py
@@ -52,6 +52,11 @@ def test_run_studio_demo(tmp_path):
     payload = json.loads((out_dir / "result.json").read_text())
     assert payload["samples"][0]["organs"]["Heart"]["predicted_age_years"] > 0
 
+    report_text = (out_dir / "report.md").read_text()
+    assert "filtered partial-model predictions" in report_text
+    assert "Raw delta" in report_text
+    assert "Input Sanity" in report_text
+
 
 def test_cli_demo_smoke(tmp_path):
     out_dir = tmp_path / "cli_out"
@@ -77,3 +82,20 @@ def test_cli_demo_smoke(tmp_path):
     assert proc.returncode == 0, proc.stderr
     assert (out_dir / "report.md").exists()
     assert "Organ Aging Studio complete" in proc.stdout
+
+
+def test_cli_requires_input_or_demo(tmp_path):
+    script = SKILL_DIR / "organ_aging_studio.py"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--output",
+            str(tmp_path / "out"),
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode != 0
+    assert "Provide --input or use --demo" in proc.stderr

--- a/skills/organ-aging-studio/tests/test_organ_aging_studio.py
+++ b/skills/organ-aging-studio/tests/test_organ_aging_studio.py
@@ -1,0 +1,79 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+DEMO_FIXTURE = SKILL_DIR.parent / "proteomics-clock" / "data" / "demo_olink_npx.csv.gz"
+
+
+def test_filter_protein_coefs_top_n():
+    from organ_aging_studio import filter_protein_coefs
+
+    coefs = {"A": 3.0, "B": 1.0, "C": 2.0}
+    out = filter_protein_coefs(coefs, {"A", "B", "C"}, top_n=2)
+    assert set(out) == {"A", "C"}
+
+
+def test_compute_organ_age_gen1():
+    from organ_aging_studio import compute_organ_age
+
+    row = pd.Series({"ProteinA": 2.0, "ProteinB": 1.0, "age": 50.0})
+    coefs = {"Intercept": 10.0, "ProteinA": 2.0, "ProteinB": 0.5}
+    result = compute_organ_age(row, coefs, generation="gen1", top_n=10)
+    # 10 + 2*2 + 0.5*1 = 14.5
+    assert result["predicted_age_years"] == 14.5
+    assert result["age_delta_years"] == -35.5
+    assert len(result["contributions"]) == 2
+
+
+def test_run_studio_demo(tmp_path):
+    from organ_aging_studio import run_studio
+
+    out_dir = tmp_path / "studio"
+    result = run_studio(
+        input_path=DEMO_FIXTURE,
+        output_dir=out_dir,
+        organs=["Heart", "Brain"],
+        generation="gen1",
+        sample_id="DEMO_000",
+        top_n=5,
+    )
+    assert len(result["samples"]) == 1
+    assert (out_dir / "report.md").exists()
+    assert (out_dir / "result.json").exists()
+    assert (out_dir / "tables" / "protein_contributions.csv").exists()
+
+    payload = json.loads((out_dir / "result.json").read_text())
+    assert payload["samples"][0]["organs"]["Heart"]["predicted_age_years"] > 0
+
+
+def test_cli_demo_smoke(tmp_path):
+    out_dir = tmp_path / "cli_out"
+    script = SKILL_DIR / "organ_aging_studio.py"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--demo",
+            "--output",
+            str(out_dir),
+            "--organs",
+            "Heart,Brain",
+            "--sample-id",
+            "DEMO_000",
+            "--top-n",
+            "3",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert (out_dir / "report.md").exists()
+    assert "Organ Aging Studio complete" in proc.stdout

--- a/skills/proteomics-clock/SKILL.md
+++ b/skills/proteomics-clock/SKILL.md
@@ -232,6 +232,7 @@ This skill fetches model coefficients on first run and caches them locally.
 | Gen2 coefficients (per organ) | `.../instance_0/mortality_based_models/{organ}_mortality_coefs_GTEx_4x_FC.csv` | Yes |
 
 - **Cache location**: `$CLAWBIO_CACHE/proteomics-clock/` if set, otherwise `~/.cache/clawbio/proteomics-clock/`
+- **Local integrity check**: downloaded coefficient files are cached with SHA-256 sidecar files and verified against the cached hash on reuse
 - **Pinned commit**: All URLs are pinned to organAging commit `5147b03` for reproducibility. Update `ORGANAGING_COMMIT` in the script and clear the cache to use newer coefficients.
 - **Offline mode**: After first run, the skill works fully offline from cache. No `--offline` flag needed.
 

--- a/skills/proteomics-clock/proteomics_clock.py
+++ b/skills/proteomics-clock/proteomics_clock.py
@@ -86,6 +86,10 @@ def _sha256(path: Path) -> str:
     return h.hexdigest()
 
 
+def _checksum_path(path: Path) -> Path:
+    return path.with_suffix(path.suffix + ".sha256")
+
+
 def _get_skill_data_dir() -> Path:
     return Path(__file__).resolve().parent / "data"
 
@@ -124,6 +128,42 @@ def load_input(path: Path) -> pd.DataFrame:
     )
 
 
+def assess_input_npx_scale(df: pd.DataFrame) -> list[str]:
+    """Return warnings when the numeric input does not look like Olink NPX."""
+    protein_cols = [
+        col
+        for col in df.columns
+        if col != "sample_id" and pd.api.types.is_numeric_dtype(df[col])
+    ]
+    if not protein_cols:
+        return ["No numeric protein columns were detected."]
+
+    numeric = df[protein_cols].apply(pd.to_numeric, errors="coerce")
+    values = numeric.to_numpy(dtype=float, copy=False).ravel()
+    values = values[np.isfinite(values)]
+    if values.size == 0:
+        return ["No finite protein values could be parsed."]
+
+    abs_values = np.abs(values)
+    median_abs = float(np.median(abs_values))
+    p95_abs = float(np.quantile(abs_values, 0.95))
+    std = float(np.std(values))
+
+    warnings: list[str] = []
+    if median_abs < 0.75 and std < 2.0:
+        warnings.append(
+            "The protein values look centered/scaled rather than like raw Olink NPX. "
+            "This skill expects Olink NPX input; non-Olink data must be rescaled using "
+            "the Table S3 standard deviations from the paper."
+        )
+    if p95_abs > 100:
+        warnings.append(
+            "The protein values are unusually large for Olink NPX. "
+            "Please confirm the input is not raw intensity data."
+        )
+    return warnings
+
+
 # ---------------------------------------------------------------------------
 # Coefficient downloading and caching
 # ---------------------------------------------------------------------------
@@ -131,11 +171,21 @@ def load_input(path: Path) -> pd.DataFrame:
 
 def _download_text(url: str, cache_name: str) -> str:
     cached = _cache_dir() / cache_name
+    checksum_file = _checksum_path(cached)
     if cached.exists():
+        if checksum_file.exists():
+            expected = checksum_file.read_text().strip()
+            actual = _sha256(cached)
+            if expected and expected != actual:
+                raise RuntimeError(
+                    f"Checksum mismatch for cached download {cached.name}: "
+                    f"expected {expected}, got {actual}"
+                )
         return cached.read_text()
     resp = requests.get(url, timeout=30)
     resp.raise_for_status()
     cached.write_text(resp.text)
+    checksum_file.write_text(_sha256(cached) + "\n")
     return resp.text
 
 
@@ -170,10 +220,15 @@ def download_coefficients(
             header = next(reader)
             rows = list(reader)
 
-            if fold < 1 or fold > len(rows):
-                fold_idx = 0
-            else:
-                fold_idx = fold - 1
+            if fold < 1:
+                raise ValueError("fold must be a positive 1-based index")
+            if fold > len(rows):
+                raise ValueError(
+                    f"Requested fold {fold} for {organ} {gen}, but the coefficient "
+                    f"file only has {len(rows)} fold rows."
+                )
+
+            fold_idx = fold - 1
 
             row = rows[fold_idx]
             coefs = {}
@@ -342,6 +397,7 @@ def write_report(
     organs: list[str],
     generation: str,
     fold: int,
+    input_warnings: list[str],
     gen1_preds: pd.DataFrame | None,
     gen2_preds: pd.DataFrame | None,
     missing_df: pd.DataFrame,
@@ -375,6 +431,11 @@ def write_report(
         "No missing proteins were detected."
         if not missing_counts
         else "\n".join([f"- {k}: {v} missing" for k, v in sorted(missing_counts.items())])
+    )
+    sanity_block = (
+        "- No obvious unit issues detected."
+        if not input_warnings
+        else "\n".join([f"- {warning}" for warning in input_warnings])
     )
 
     report = f"""# ClawBio Proteomics Clock Report
@@ -412,6 +473,10 @@ using elastic net coefficients trained on UK Biobank data.
 ## Missing Proteins
 
 {missing_block}
+
+## Input Sanity
+
+{sanity_block}
 
 ## Reproducibility
 
@@ -463,6 +528,7 @@ def run_analysis(
     df = load_input(input_path)
     if df.empty:
         raise ValueError("Input data is empty")
+    input_warnings = assess_input_npx_scale(df)
 
     if verbose:
         print(f"Downloading coefficients for {len(organs)} organs, generation={generation}, fold={fold}")
@@ -529,6 +595,7 @@ def run_analysis(
         "fold": fold,
         "n_coefficients_loaded": len(coefficients),
         "convert_mortality_to_years": convert_mortality_to_years,
+        "input_sanity_warnings": input_warnings,
     }
     (output_dir / "tables" / "clock_metadata.json").write_text(json.dumps(metadata, indent=2))
 
@@ -548,6 +615,7 @@ def run_analysis(
         organs=organs,
         generation=generation,
         fold=fold,
+        input_warnings=input_warnings,
         gen1_preds=gen1_preds,
         gen2_preds=gen2_preds,
         missing_df=all_missing,

--- a/skills/proteomics-clock/tests/test_proteomics_clock.py
+++ b/skills/proteomics-clock/tests/test_proteomics_clock.py
@@ -2,7 +2,6 @@ import json
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -11,7 +10,6 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 SKILL_DIR = Path(__file__).resolve().parent.parent
-REPO_ROOT = SKILL_DIR.parents[1]
 DEMO_FIXTURE = SKILL_DIR / "data" / "demo_olink_npx.csv.gz"
 
 
@@ -115,6 +113,21 @@ def test_missing_proteins_reported():
     assert "ProteinA" not in missing_proteins
 
 
+def test_download_coefficients_selects_fold(monkeypatch):
+    import proteomics_clock as pc
+
+    text = "Intercept,ProteinA,ProteinB\n1,2,3\n4,5,6\n"
+    monkeypatch.setattr(pc, "_download_text", lambda url, cache_name: text)
+
+    coeffs = pc.download_coefficients(["Heart"], "gen1", fold=2)
+    assert coeffs["Heart_gen1"]["Intercept"] == 4.0
+    assert coeffs["Heart_gen1"]["ProteinA"] == 5.0
+    assert coeffs["Heart_gen1"]["ProteinB"] == 6.0
+
+    with pytest.raises(ValueError):
+        pc.download_coefficients(["Heart"], "gen1", fold=3)
+
+
 def test_load_input_csv(tmp_path):
     from proteomics_clock import load_input
 
@@ -160,6 +173,7 @@ def test_run_analysis_with_demo(tmp_path):
     report_text = (out_dir / "report.md").read_text()
     assert "ClawBio is a research and educational tool" in report_text
     assert "Goeminne" in report_text
+    assert "Input Sanity" in report_text
 
 
 def test_cli_smoke_with_demo(tmp_path):


### PR DESCRIPTION
## Summary

This PR adds `organ-aging-studio`, an inspectable wrapper around the published Goeminne et al. (2025) organ-specific proteomic aging clocks.

The goal is to keep the science honest while making the output more useful for demos and review:

- `proteomics-clock` remains the batch-oriented prediction path.
- `organ-aging-studio` exposes ranked protein contributions and filter controls so reviewers can see which proteins drive each organ age.
- The branch has been rebased onto the current `ClawBio/ClawBio:main`, so it now compares cleanly against the latest upstream base.

## What this includes

- `skills/organ-aging-studio/SKILL.md` with scope, workflow, gotchas, and safety guidance
- `skills/organ-aging-studio/organ_aging_studio.py` for interpretable organ-age breakdowns
- `skills/organ-aging-studio/tests/test_organ_aging_studio.py` covering the demo flow and the CLI guard

## Review-related fixes

- Added a friendly error when the CLI is run without `--demo` or `--input`.
- Added an input sanity section so suspiciously scaled inputs do not silently look like valid Olink NPX.
- Marked filtered runs (`--top-n`, `--min-abs-coef`) as partial-model predictions instead of the fully validated published clock.
- Clarified that the reported delta is raw predicted-minus-chronological age, not residualized acceleration.
- Added checksum verification for cached coefficient downloads.
- Removed an unused `matplotlib` dependency from the studio requirements.

## Demo / outputs

```bash
python skills/organ-aging-studio/organ_aging_studio.py \
  --demo --output /tmp/organ-aging-studio \
  --organs Heart,Brain,Immune,Organismal \
  --sample-id DEMO_000 --top-n 10
```

Expected outputs:

- `report.md`
- `result.json`
- `tables/protein_contributions.csv`
- `commands.sh`

## Verification

- `python3 -m pytest skills/proteomics-clock/tests/test_proteomics_clock.py skills/organ-aging-studio/tests/test_organ_aging_studio.py -q`
- `16 passed`

## Notes

- `pyaging_data/` is a local untracked artifact directory and is intentionally not part of this PR.
- The branch was synced by rebasing onto current `origin/main` and force-pushing the feature branch to the fork.
