### PR TITLE
fix: regenerate uv.lock and add lockfile-check CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,19 @@ jobs:
           git diff --stat HEAD~1 HEAD >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
+  lockfile-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+
+      - name: Check lockfile is up to date
+        run: uv lock --check
+
   skill-lint:
     runs-on: ubuntu-latest
     steps:

--- a/uv.lock
+++ b/uv.lock
@@ -567,6 +567,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rocrate" },
     { name = "scikit-learn" },
+    { name = "scipy" },
 ]
 
 [package.dev-dependencies]
@@ -596,6 +597,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rocrate", specifier = ">=0.15.0" },
     { name = "scikit-learn", specifier = ">=1.3" },
+    { name = "scipy", specifier = ">=1.10" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

- Regenerate `uv.lock` to fix CI failure caused by lockfile drift after PR #300 merged
- Add a `lockfile-check` CI job that runs `uv lock --check` to catch lockfile/pyproject.toml mismatches on PRs before merge

## Skill affected

None — CI infrastructure only.

## Checklist

- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

```
$ uv lock --check
Resolved 143 packages in 1.47s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)