### PR TITLE
Homogenize the nf-core scRNA-seq, Sarek, and RNA-seq wrappers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,7 @@ python clawbio.py run sarek-pipeline \
 python clawbio.py run sarek-pipeline --check \
   --input samplesheet.csv --output /tmp/sarek_check --genome GATK.GRCh38 --tools haplotypecaller
 python clawbio.py run sarek-pipeline --demo --output /tmp/sarek_demo
-# Full 176-flag surface (154 Sarek passthrough + 22 wrapper controls): python skills/nfcore-sarek-wrapper/nfcore_sarek_wrapper.py --help
+# Full 177-flag surface (154 Sarek passthrough + 23 wrapper controls): python skills/nfcore-sarek-wrapper/nfcore_sarek_wrapper.py --help
 
 # Upstream single-cell RNA-seq — nf-core/scrnaseq 4.1.0 (FASTQ → h5ad count matrix)
 python clawbio.py run scrnaseq-pipeline \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,7 @@ python clawbio.py run sarek-pipeline \
 python clawbio.py run sarek-pipeline --check \
   --input samplesheet.csv --output /tmp/sarek_check --genome GATK.GRCh38 --tools haplotypecaller
 python clawbio.py run sarek-pipeline --demo --output /tmp/sarek_demo
-# Full 173-flag surface (154 Sarek passthrough + 19 wrapper controls): python skills/nfcore-sarek-wrapper/nfcore_sarek_wrapper.py --help
+# Full 176-flag surface (154 Sarek passthrough + 22 wrapper controls): python skills/nfcore-sarek-wrapper/nfcore_sarek_wrapper.py --help
 
 # Upstream single-cell RNA-seq — nf-core/scrnaseq 4.1.0 (FASTQ → h5ad count matrix)
 python clawbio.py run scrnaseq-pipeline \

--- a/clawbio/cli.py
+++ b/clawbio/cli.py
@@ -571,6 +571,7 @@ SKILLS = {
             "--allow-dirty-pipeline",
             "--require-local-pipeline",
             "--allow-pipeline-version-override",
+            "--allow-remote-inputs",
             "--trust-config-params",
             "--preset",
             "--aligner",
@@ -639,6 +640,7 @@ SKILLS = {
             "--allow-dirty-pipeline",
             "--require-local-pipeline",
             "--allow-pipeline-version-override",
+            "--allow-remote-inputs",
             "--trust-config-params",
             "--resume",
             "--allow-conda-cellranger",
@@ -801,12 +803,14 @@ SKILLS = {
             "-c",
             "--config",
             "--work-dir",
+            "--allow-remote-inputs",
         },
         "allowed_extra_flags_without_values": {
             "--check",
             "-v",
             "--verbose",
             "--no-banner",
+            "--allow-remote-inputs",
             "--resume",
             "--prokaryotic",
             "--rapid-quant",
@@ -873,7 +877,7 @@ SKILLS = {
             --check --resume --arm --gpu --spark-profile --mutect-profile
             --run-downstream --downstream-skill --profile --nextflow-config -c --config
             --pipeline-version --allow-pipeline-version-override --pipeline-local --params-file --no-banner
-            --verbose --timeout-hours --work-dir --extra-param --step --tools --skip-tools --aligner
+            --verbose --timeout-hours --work-dir --allow-remote-inputs --extra-param --step --tools --skip-tools --aligner
             --no-intervals --wes --joint-germline --joint-mutect2
             --only-paired-variant-calling --ignore-soft-clipped-bases
             --filter-vcfs --normalize-vcfs --snv-consensus-calling

--- a/clawbio/cli.py
+++ b/clawbio/cli.py
@@ -560,8 +560,12 @@ SKILLS = {
         "max_output_files_listed": 50,
         "allowed_extra_flags": {
             "--check",
+            "-v",
+            "--verbose",
+            "--no-banner",
             "-c",
             "--config",
+            "--nextflow-config",
             "--profile",
             "--pipeline-version",
             "--allow-dirty-pipeline",
@@ -629,6 +633,9 @@ SKILLS = {
         },
         "allowed_extra_flags_without_values": {
             "--check",
+            "-v",
+            "--verbose",
+            "--no-banner",
             "--allow-dirty-pipeline",
             "--require-local-pipeline",
             "--allow-pipeline-version-override",
@@ -660,6 +667,9 @@ SKILLS = {
         "max_output_files_listed": 50,
         "allowed_extra_flags": {
             "--check",
+            "-v",
+            "--verbose",
+            "--no-banner",
             "--profile",
             "--pipeline-version",
             "--pipeline-local",
@@ -788,9 +798,15 @@ SKILLS = {
             "--umitools-dedup-stats",
             "--umitools-dedup-primary-only",
             "--nextflow-config",
+            "-c",
+            "--config",
+            "--work-dir",
         },
         "allowed_extra_flags_without_values": {
             "--check",
+            "-v",
+            "--verbose",
+            "--no-banner",
             "--resume",
             "--prokaryotic",
             "--rapid-quant",
@@ -855,9 +871,9 @@ SKILLS = {
         # Keep this allowlist aligned with nfcore_sarek_wrapper.build_parser().
         "allowed_extra_flags": set("""
             --check --resume --arm --gpu --spark-profile --mutect-profile
-            --run-downstream --downstream-skill --profile --nextflow-config
-            --pipeline-version --pipeline-local --params-file --no-banner
-            --verbose --extra-param --step --tools --skip-tools --aligner
+            --run-downstream --downstream-skill --profile --nextflow-config -c --config
+            --pipeline-version --allow-pipeline-version-override --pipeline-local --params-file --no-banner
+            --verbose --timeout-hours --work-dir --extra-param --step --tools --skip-tools --aligner
             --no-intervals --wes --joint-germline --joint-mutect2
             --only-paired-variant-calling --ignore-soft-clipped-bases
             --filter-vcfs --normalize-vcfs --snv-consensus-calling

--- a/skills/nfcore-rnaseq-wrapper/CHANGELOG.md
+++ b/skills/nfcore-rnaseq-wrapper/CHANGELOG.md
@@ -1,0 +1,52 @@
+# nfcore-rnaseq-wrapper — Changelog
+
+All notable changes to the `nfcore-rnaseq-wrapper` ClawBio skill are documented
+here. The format roughly follows [Keep a Changelog](https://keepachangelog.com)
+and the wrapper version is tracked in `SKILL.md` YAML frontmatter.
+
+## [Unreleased] — 0.1.0
+
+### Added
+
+- **Control-flag parity with the sibling wrappers.** Added `--work-dir` (Nextflow
+  work directory override; accepts a local path or an object-store URI for cloud
+  executors; was hardcoded to `<output>/upstream/work`) and `-c`/`--config` as
+  aliases of `--nextflow-config`. The executor/command-builder now accept a
+  `Path | str` work dir so remote URIs pass through verbatim.
+
+### Changed
+
+- **`--timeout-hours 0` now disables the wall-clock cap** (was rejected at
+  preflight). The default still applies a 12h cap; `0` is an explicit opt-out for
+  long HPC/cloud runs — parity with `nfcore-scrnaseq/sarek`. `_resolve_timeout_seconds`
+  returns `int | None`, the executor accepts `None`, negative values are still
+  rejected, and the macOS compatibility config falls back to the default ceiling
+  when the cap is disabled. A `[provenance]` stage log was added so all three
+  wrappers share the identical stage-prefix set.
+
+### Added
+
+- **Order-independent test suite (shared mechanism).** `tests/conftest.py` now
+  also carries the canonical-object bare-module isolation block shared verbatim
+  with the sibling wrappers (in addition to this skill's existing per-file
+  guards), so the cross-skill isolation mechanism is identical across all three.
+- **Converged CLI presentation with the sibling wrappers.** Added a startup
+  banner (`--no-banner`), `-v/--verbose`, and sarek-style staged progress logs
+  (`[preflight]`/`[execute]`/`[outputs]`/`[report]`/`[done]`) plus a
+  human-readable boxed error on stdout — while keeping the machine-readable JSON
+  error on stderr and `result.json` on disk. `--verbose`/`--no-banner` are
+  registered in the `clawbio.py` runner allowlist and the replay-drift guards.
+- **Robust `main()` entrypoint.** `main()` now returns exit code `130` on
+  `KeyboardInterrupt` (the SIGINT convention) instead of letting the interrupt
+  propagate as a traceback. Matches `nfcore-sarek-wrapper` and
+  `nfcore-scrnaseq-wrapper`.
+
+### Notes
+
+- This wrapper is the reference implementation for the cross-wrapper
+  **input-readability policy**: the launcher never pre-checks FASTQ/BAM
+  readability (`os.access(R_OK)`) because Nextflow reads the data in the true
+  execution context (often a root container under the default Docker profile),
+  where a launcher-side probe would false-block valid runs. Existence is
+  validated (`MISSING_FASTQ`); readability is deferred to Nextflow staging. The
+  rationale is documented inline in `errors.py`.

--- a/skills/nfcore-rnaseq-wrapper/CHANGELOG.md
+++ b/skills/nfcore-rnaseq-wrapper/CHANGELOG.md
@@ -8,6 +8,12 @@ and the wrapper version is tracked in `SKILL.md` YAML frontmatter.
 
 ### Added
 
+- **`--allow-remote-inputs` opt-in (local-first by default).** Remote samplesheet
+  inputs and reference paths (`s3://`, `gs://`, `https://`, `ftp://`, …) are now
+  rejected at preflight (`REMOTE_INPUT_NOT_ALLOWED`) unless the flag is passed, in
+  which case a runtime warning names every path fetched over the network. The
+  object-store `--work-dir` is not gated. Shared verbatim with
+  `nfcore-scrnaseq/sarek`.
 - **Control-flag parity with the sibling wrappers.** Added `--work-dir` (Nextflow
   work directory override; accepts a local path or an object-store URI for cloud
   executors; was hardcoded to `<output>/upstream/work`) and `-c`/`--config` as

--- a/skills/nfcore-rnaseq-wrapper/README.md
+++ b/skills/nfcore-rnaseq-wrapper/README.md
@@ -6,7 +6,7 @@ ClawBio wrapper for running `nf-core/rnaseq` bulk RNA-seq preprocessing from FAS
 
 - Upstream bulk RNA-seq preprocessing via Nextflow.
 - Supported aligners: `star_salmon`, `star_rsem`, `hisat2`, `bowtie2_salmon`.
-- Validated samplesheet input with normalized local FASTQ/BAM paths or preserved remote URIs.
+- Validated samplesheet input with normalized local FASTQ/BAM paths (local-first by default; remote URIs require `--allow-remote-inputs`).
 - Reproducibility bundle, provenance bundle, `report.md`, and `result.json`.
 - Canonical merged count matrix detection for downstream `rnaseq`.
 

--- a/skills/nfcore-rnaseq-wrapper/SKILL.md
+++ b/skills/nfcore-rnaseq-wrapper/SKILL.md
@@ -205,6 +205,16 @@ python clawbio.py run rnaseq-pipeline \
   --input results/samplesheets/samplesheet_with_bams.csv \
   --output ./rnaseq_reprocess \
   --skip-alignment
+
+# Wrapper runtime controls (parity with scrnaseq/sarek):
+#   --timeout-hours N   wall-clock cap (default 12h; 0 disables for HPC/cloud)
+#   --work-dir PATH     Nextflow work dir (local path or object-store URI; default <output>/upstream/work)
+#   --nextflow-config / -c / --config   extra Nextflow config file(s), repeatable
+#   --allow-pipeline-version-override    run a non-3.26.0 --pipeline-version at your own risk
+python clawbio.py run rnaseq-pipeline \
+  --input samplesheet.csv --output ./rnaseq_run \
+  --genome GRCh38 --aligner star_salmon \
+  --timeout-hours 0 --work-dir s3://my-bucket/rnaseq/work
 ```
 
 ## Demo
@@ -301,7 +311,7 @@ output/
 - `--aligner hisat2` is alignment-only for this handoff contract.
 - `--with-umi` requires a barcode pattern unless `--skip-umi-extract` is set. Conversely, UMI options (`--umitools-bc-pattern`, `--umi-dedup-tool`, etc.) set *without* `--with-umi` are inert — preflight warns so a run is not mistaken for UMI-deduplicated when it is not.
 - On macOS Docker, use an output directory under the home directory rather than `/tmp`. The wrapper writes a macOS Docker compatibility config whose per-process memory ceiling is derived from host RAM (75% share, floored at 8 GB, capped at 15 GB) and then capped to 90% of the actual Docker VM memory (`docker info`, when available) so a container process is never OOM-killed by requesting more than the VM has. Its per-process `time` ceiling tracks `--timeout-hours` (default 12, floored at 1 h) so raising the wrapper timeout does not leave processes capped at 12 h.
-- The local Nextflow run is killed after `--timeout-hours` (default 12). Raise it for large cohorts (e.g. `--timeout-hours 48`) so a long but healthy run is not terminated. The value must be > 0; HPC/cloud submitters that detach are unaffected. On a timeout the wrapper terminates Nextflow's process group, but containers started by the Docker/Singularity daemon are not in that group and may keep running — the timeout error reminds you to check for and remove leftover containers (e.g. `docker ps`).
+- The local Nextflow run is killed after `--timeout-hours` (default 12). Raise it for large cohorts (e.g. `--timeout-hours 48`) so a long but healthy run is not terminated, or pass `--timeout-hours 0` to disable the cap entirely for long HPC/cloud runs whose walltime is enforced by the scheduler (negative values are rejected). On a timeout the wrapper terminates Nextflow's process group, but containers started by the Docker/Singularity daemon are not in that group and may keep running — the timeout error reminds you to check for and remove leftover containers (e.g. `docker ps`).
 - Reference paths (`--fasta`/`--gtf`/`--gff`/`--transcript-fasta`/`--additional-fasta`/`--gene-bed`) must resolve to a path **without whitespace** — the nf-core schema pattern `^\S+` rejects spaces. Preflight catches a whitespace-containing resolved path early with a precise `REFERENCE_PATH_HAS_WHITESPACE` error (mirroring the samplesheet input guard) instead of letting Nextflow abort late. Move or symlink the reference into a space-free directory.
 - `--check` validates that Nextflow is present but defers the `>=25.04.3` version gate to the real run; it emits a warning so a passing check is not mistaken for confirmation of a compatible Nextflow version.
 - Results are written under a **relative** `upstream/results` because the wrapper launches Nextflow with `cwd=<output>`; the relative path keeps the nf-core `^\S+$` `outdir` schema valid even when `--output` contains spaces (common on macOS). This is a deliberate **local-first** design. Running against cloud executors that require an absolute publish path (e.g. `outdir` on `s3://`/`gs://`) is outside the wrapper's audited surface.
@@ -352,3 +362,16 @@ Use this skill to produce upstream bulk RNA-seq preprocessing outputs. Route dow
 ## Maintenance
 
 Pinned upstream: `nf-core/rnaseq` v3.26.0. Before changing the default version, audit `nextflow.config`, `assets/schema_input.json`, `nextflow_schema.json`, `docs/output.md`, and changed module configs, then update tests and `reproducibility/pinned_versions.json`.
+
+## Citations
+
+- [nf-core/rnaseq 3.26.0](https://nf-co.re/rnaseq/3.26.0)
+- [nf-core/rnaseq usage](https://nf-co.re/rnaseq/3.26.0/docs/usage/)
+- [nf-core/rnaseq parameters](https://nf-co.re/rnaseq/3.26.0/parameters/)
+- [nf-core/rnaseq output](https://nf-co.re/rnaseq/3.26.0/docs/output/)
+- [Nextflow](https://www.nextflow.io/)
+- [STAR](https://github.com/alexdobin/STAR)
+- [Salmon](https://salmon.readthedocs.io/)
+- [RSEM](https://github.com/deweylab/RSEM)
+- [HISAT2](https://daehwankimlab.github.io/hisat2/)
+- [Bowtie2](https://bowtie-bio.sourceforge.net/bowtie2/index.shtml)

--- a/skills/nfcore-rnaseq-wrapper/SKILL.md
+++ b/skills/nfcore-rnaseq-wrapper/SKILL.md
@@ -211,6 +211,7 @@ python clawbio.py run rnaseq-pipeline \
 #   --work-dir PATH     Nextflow work dir (local path or object-store URI; default <output>/upstream/work)
 #   --nextflow-config / -c / --config   extra Nextflow config file(s), repeatable
 #   --allow-pipeline-version-override    run a non-3.26.0 --pipeline-version at your own risk
+#   --allow-remote-inputs               opt in to remote inputs/refs (default local-first)
 python clawbio.py run rnaseq-pipeline \
   --input samplesheet.csv --output ./rnaseq_run \
   --genome GRCh38 --aligner star_salmon \
@@ -342,6 +343,7 @@ output/
 - No patient data is bundled.
 - Demo mode uses upstream test profile data.
 - The wrapper does not upload data.
+- **Local-first by default**: remote samplesheet inputs and reference paths are rejected (`REMOTE_INPUT_NOT_ALLOWED`) unless `--allow-remote-inputs` is explicitly passed, which also logs a runtime warning naming every path fetched over the network. The object-store `--work-dir` is not gated.
 - The wrapper does not pass arbitrary unvalidated Nextflow *parameters* via `--params-file`: only the audited CLI surface is translated to `params.yaml`. `--nextflow-config` forwards user-supplied `-c` config file(s) for trusted runtime settings such as process, executor, profiles, labels, institutional module tuning, and `params.genomes` custom genome catalogues. Configs that define `params` in any form — block (`params { … }`), property (`params.x`), assignment (`params = …`), subscript (`params['x']`), or map-merge (`params << …`) — are rejected so they cannot bypass the audited parameter surface (the documented `params.genomes` catalogue is the sole exception). Every locally-resolvable `includeConfig` target is audited recursively under the same rule; includes the wrapper cannot read (remote URIs, `${…}`-interpolated paths, or missing files) are surfaced as preflight **warnings** rather than silently trusted, so unaudited surface is always visible.
 - `--resume` is rejected when the pipeline source/version, profile, aligner, pseudo-aligner, `--prokaryotic`/`--arm` modifiers, params checksum, or samplesheet checksum drift.
 

--- a/skills/nfcore-rnaseq-wrapper/command_builder.py
+++ b/skills/nfcore-rnaseq-wrapper/command_builder.py
@@ -43,7 +43,7 @@ def build_nextflow_command(
     profile: str,
     params_path: Path,
     resume: bool,
-    work_dir: Path | None = None,
+    work_dir: Path | str | None = None,
     extra_configs: list[Path] | None = None,
     demo: bool = False,
     prokaryotic: bool = False,
@@ -63,7 +63,10 @@ def build_nextflow_command(
 
     command.extend(["-profile", composed_profile, "-params-file", params_path.as_posix()])
     if work_dir is not None:
-        command.extend(["-work-dir", work_dir.as_posix()])
+        # work_dir may be a local Path or a remote object-store URI (str, e.g.
+        # s3://bucket/work); preserve URIs verbatim, posix-normalise local paths.
+        work_dir_arg = work_dir if isinstance(work_dir, str) else work_dir.as_posix()
+        command.extend(["-work-dir", work_dir_arg])
     for cfg in extra_configs or []:
         command.extend(["-c", cfg.as_posix()])
     if resume:

--- a/skills/nfcore-rnaseq-wrapper/demo/README.md
+++ b/skills/nfcore-rnaseq-wrapper/demo/README.md
@@ -1,9 +1,9 @@
-This skill uses the upstream `nf-core/rnaseq` test profile for demo mode.
-
-Run:
+# nfcore-rnaseq-wrapper — demo
 
 ```bash
-python clawbio.py run rnaseq-pipeline --demo --output ./outputs/rnaseq_demo
+python clawbio.py run rnaseq-pipeline --demo --output /tmp/rnaseq_demo
 ```
 
-No real patient or sample data is bundled in this repository.
+Uses the upstream nf-core/rnaseq `-profile test` dataset (no local files
+required; no real patient or sample data is bundled in this repository).
+Requires Docker (running) + Nextflow >=25.04.3.

--- a/skills/nfcore-rnaseq-wrapper/errors.py
+++ b/skills/nfcore-rnaseq-wrapper/errors.py
@@ -38,6 +38,10 @@ class ErrorCode:
     # there. Existence of inputs is validated (MISSING_FASTQ); readability is deferred to
     # Nextflow's staging, which reads in the true execution context.
     INVALID_SAMPLESHEET = "INVALID_SAMPLESHEET"
+    # Remote input/reference URIs (s3://, gs://, https://, ftp://, …) are rejected by
+    # default (local-first); they are only allowed with --allow-remote-inputs, which
+    # also emits a runtime warning that data is being fetched over the network.
+    REMOTE_INPUT_NOT_ALLOWED = "REMOTE_INPUT_NOT_ALLOWED"
     OUTPUT_DIR_NOT_EMPTY = "OUTPUT_DIR_NOT_EMPTY"
     OUTPUT_DIR_NOT_WRITABLE = "OUTPUT_DIR_NOT_WRITABLE"
     MISSING_REFERENCE = "MISSING_REFERENCE"

--- a/skills/nfcore-rnaseq-wrapper/executor.py
+++ b/skills/nfcore-rnaseq-wrapper/executor.py
@@ -26,8 +26,11 @@ def execute_nextflow(
     *,
     cwd: Path,
     output_dir: Path,
-    timeout_seconds: int,
+    timeout_seconds: int | None,
 ) -> dict[str, object]:
+    # timeout_seconds=None disables the wall-clock cap entirely (long HPC/cloud
+    # runs whose walltime is enforced by the scheduler); proc.wait(timeout=None)
+    # blocks until completion.
     logs_dir = output_dir / "logs"
     logs_dir.mkdir(parents=True, exist_ok=True)
     stdout_path = logs_dir / "stdout.txt"

--- a/skills/nfcore-rnaseq-wrapper/nfcore_rnaseq_wrapper.py
+++ b/skills/nfcore-rnaseq-wrapper/nfcore_rnaseq_wrapper.py
@@ -119,6 +119,8 @@ class _RnaseqArgumentParser(argparse.ArgumentParser):
 
 def build_parser() -> argparse.ArgumentParser:
     parser = _RnaseqArgumentParser(description="Run nf-core/rnaseq through the ClawBio wrapper.")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose logging")
+    parser.add_argument("--no-banner", action="store_true", help="Suppress the startup banner")
     parser.add_argument("--input", help="Path to a valid nf-core/rnaseq samplesheet.csv")
     parser.add_argument("--output", required=True, help="Output directory for wrapper results")
     parser.add_argument("--demo", action="store_true", help="Run the upstream test profile without user FASTQs")
@@ -146,15 +148,21 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument("--pipeline-local", default=None, help="Optional local nf-core/rnaseq checkout override")
+    parser.add_argument(
+        "--work-dir",
+        default=None,
+        help="Nextflow work directory. Defaults to <output>/upstream/work; may be an object-store URI for cloud executors.",
+    )
     parser.add_argument("--resume", action="store_true", help="Attempt checksum-validated Nextflow resume")
     parser.add_argument(
         "--timeout-hours",
-        type=float,
+        type=_timeout_hours,
         default=DEFAULT_TIMEOUT_HOURS,
         help=(
             f"Wall-clock ceiling for the local Nextflow run before it is terminated "
             f"(default: {DEFAULT_TIMEOUT_HOURS}). Raise this for large cohorts so a long "
-            "but healthy run is not killed. Ignored for HPC/cloud submitters that detach."
+            "but healthy run is not killed. Use 0 to disable the cap for long HPC/cloud "
+            "runs whose walltime is enforced by the scheduler."
         ),
     )
 
@@ -340,11 +348,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--nextflow-config",
+        "-c",
+        "--config",
+        dest="nextflow_config",
         action="append",
         metavar="CONFIG",
         default=None,
         help=(
-            "Additional Nextflow config file(s) passed as -c to Nextflow. "
+            "Additional Nextflow config file(s) passed as -c to Nextflow (aliases: -c/--config). "
             "Can be repeated: --nextflow-config hpc.config --nextflow-config rsem.config. "
             "Use this for institution-specific settings, RSEM ext.args, or any non-parametric "
             "configuration not exposed via --params-file."
@@ -504,17 +515,42 @@ def _raise_if_expected_outputs_missing(
     )
 
 
+_BANNER = (
+    "==============================================\n"
+    f"  ClawBio :: {SKILL_NAME}\n"
+    f"  nf-core/rnaseq {DEFAULT_PIPELINE_VERSION} orchestrator\n"
+    "=============================================="
+)
+
+
+def _print(msg: str) -> None:
+    """Log a human-readable status line to stdout (progress/traceability)."""
+    print(msg, flush=True)
+
+
+def _indent(text: str, n: int) -> str:
+    pad = " " * n
+    return "\n".join(pad + line for line in text.splitlines())
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    if not getattr(args, "no_banner", False):
+        _print(_BANNER)
     output_dir = Path(args.output).expanduser().resolve()
     try:
         _check_pipeline_version_supported(args)
         return _run_wrapper(args, output_dir)
     except SkillError as exc:
-        return _handle_skill_error(output_dir, exc)
+        return _handle_skill_error(output_dir, exc, verbose=getattr(args, "verbose", False))
+    except KeyboardInterrupt:
+        _print("[abort] Interrupted by user.")
+        return 130
     except Exception as exc:
-        return _handle_unexpected_error(output_dir, exc)
+        return _handle_unexpected_error(
+            output_dir, exc, verbose=getattr(args, "verbose", False)
+        )
 
 
 def _record_aligner_explicit(args: argparse.Namespace) -> bool:
@@ -811,6 +847,10 @@ def _run_wrapper_with_staging(args: argparse.Namespace, output_dir: Path, *, sta
         staging_dir=staging_dir,
     )
     preflight_result = run_preflight(args, pipeline_source=pipeline_source, samplesheet_summary=samplesheet_summary)
+    _print(
+        "[preflight] passed "
+        f"(warnings: {len(preflight_result.get('warnings', []) or [])})"
+    )
     if args.check:
         if staged_samplesheet != normalized_samplesheet:
             _commit_validated_samplesheet(staged_samplesheet, normalized_samplesheet)
@@ -973,6 +1013,7 @@ def _write_check_mode_result(
         "pipeline_source": pipeline_source,
     }
     write_check_result(output_dir, payload)
+    _print("[check] Preflight passed. No pipeline was launched (--check).")
     print(json.dumps(payload, indent=2))
     return 0
 
@@ -1000,6 +1041,10 @@ def _run_execution_mode(
     command, command_str = _build_nextflow_invocation(args, output_dir, pipeline_source, params_path)
     nextflow_cwd = _nextflow_execution_cwd(output_dir)
     started = time.monotonic()
+    _print(
+        f"[execute] launching Nextflow "
+        f"({pipeline_source['source_kind']} → {pipeline_source['resolved_version']})"
+    )
     execution_result = execute_nextflow(
         command,
         cwd=nextflow_cwd,
@@ -1007,8 +1052,12 @@ def _run_execution_mode(
         timeout_seconds=_resolve_timeout_seconds(args),
     )
     duration_seconds = round(time.monotonic() - started, 3)
+    _print(f"[execute] completed in {duration_seconds:.1f}s")
+    _print("[outputs] parsing pipeline outputs")
     parsed_outputs = _parse_outputs_with_effective_aligner(output_dir, args)
     _raise_if_expected_outputs_missing(parsed_outputs, args=args, output_dir=output_dir)
+    _print("[report] writing report.md, result.json, commands.sh")
+    _print("[provenance] writing reproducibility bundle")
     if preflight_result.get("handoff_available") is False:
         parsed_outputs["handoff_available"] = False
     handoff_result = _run_downstream_handoff(args, parsed_outputs=parsed_outputs, output_dir=output_dir)
@@ -1027,7 +1076,7 @@ def _run_execution_mode(
         duration_seconds=duration_seconds,
         command_str=_nextflow_replay_command(command_str, nextflow_cwd),
     )
-    print(f"Wrapper completed successfully. Output: {output_dir}")
+    _print(f"[done] Wrapper completed successfully. Output: {output_dir}")
     return 0
 
 
@@ -1071,7 +1120,7 @@ def _build_nextflow_invocation(
         profile=args.profile,
         params_path=params_path,
         resume=args.resume,
-        work_dir=output_dir / "upstream" / "work",
+        work_dir=_resolve_nextflow_work_dir(args, output_dir),
         extra_configs=_build_extra_nextflow_configs(args, output_dir),
         demo=bool(getattr(args, "demo", False)),
         prokaryotic=bool(getattr(args, "prokaryotic", False)),
@@ -1179,7 +1228,9 @@ def _write_macos_docker_config(output_dir: Path, *, arm: bool = False, timeout_h
     # The per-process time ceiling tracks --timeout-hours (audit F-4) so a large-cohort
     # run raised above the 12h default is not capped back to 12h by this config. Floored
     # at 1h so a sub-hour --timeout-hours never emits an invalid '0.h' duration.
-    time_hours = max(1, int(timeout_hours))
+    # --timeout-hours 0 disables the wall-clock cap, so the per-process ceiling falls back
+    # to the pinned default rather than being floored to a misleading 1h.
+    time_hours = int(DEFAULT_TIMEOUT_HOURS) if timeout_hours == 0 else max(1, int(timeout_hours))
     config_path.write_text(
         "// macOS Docker compatibility for nf-core/rnaseq.\n"
         "process {\n"
@@ -1197,15 +1248,50 @@ def _write_macos_docker_config(output_dir: Path, *, arm: bool = False, timeout_h
     return config_path
 
 
+def _timeout_hours(value: str) -> float:
+    try:
+        hours = float(value)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError(
+            f"--timeout-hours must be a number, got {value!r}"
+        )
+    if hours < 0:
+        raise argparse.ArgumentTypeError(
+            "--timeout-hours must be >= 0 (0 disables the timeout)"
+        )
+    return hours
+
+
 def _resolve_timeout_hours(args: argparse.Namespace) -> float:
     """Return the effective --timeout-hours, falling back to the pinned default."""
     hours = getattr(args, "timeout_hours", DEFAULT_TIMEOUT_HOURS)
     return DEFAULT_TIMEOUT_HOURS if hours is None else float(hours)
 
 
-def _resolve_timeout_seconds(args: argparse.Namespace) -> int:
-    """Translate --timeout-hours into seconds, falling back to the pinned default."""
-    return int(_resolve_timeout_hours(args) * 60 * 60)
+def _resolve_nextflow_work_dir(args: argparse.Namespace, output_dir: Path) -> Path | str:
+    """Resolve the Nextflow work directory: default <output>/upstream/work, or the
+    user's --work-dir (a local path, or an object-store URI kept verbatim for cloud
+    executors). Parity with nfcore-scrnaseq/sarek."""
+    raw_work_dir = getattr(args, "work_dir", None)
+    if not raw_work_dir:
+        return output_dir / "upstream" / "work"
+    work_dir = str(raw_work_dir).strip()
+    if "://" in work_dir:
+        return work_dir
+    return Path(work_dir).expanduser().resolve()
+
+
+def _resolve_timeout_seconds(args: argparse.Namespace) -> int | None:
+    """Translate --timeout-hours into seconds; 0 disables the cap (returns None).
+
+    Parity with nfcore-scrnaseq/sarek: the default keeps a wall-clock cap, but an
+    explicit ``--timeout-hours 0`` opts out (long HPC/cloud runs governed by the
+    scheduler's walltime).
+    """
+    hours = _resolve_timeout_hours(args)
+    if hours == 0:
+        return None
+    return int(hours * 60 * 60)
 
 
 def _nextflow_execution_cwd(output_dir: Path) -> Path:
@@ -1441,14 +1527,31 @@ def _write_error_result_if_safe(output_dir: Path, payload: dict[str, object]) ->
         return
 
 
-def _handle_skill_error(output_dir: Path, exc: SkillError) -> int:
+def _handle_skill_error(
+    output_dir: Path, exc: SkillError, *, verbose: bool = False
+) -> int:
     payload = exc.to_dict()
     _write_error_result_if_safe(output_dir, payload)
+    # Human-readable box on stdout (sarek-style traceability).
+    _print("")
+    _print("================ SkillError ================")
+    _print(f"  stage:   {exc.stage}")
+    _print(f"  code:    {exc.error_code}")
+    _print(f"  message: {exc.message}")
+    _print(f"  fix:     {exc.fix}")
+    if exc.details and verbose:
+        _print("  details:")
+        _print(_indent(json.dumps(exc.details, indent=2, default=str), 4))
+    _print("============================================")
+    # Machine-readable error on stderr: always available even when result.json
+    # cannot be written (e.g. the output dir is a file or inside the repo).
     print(json.dumps(payload, indent=2), file=sys.stderr)
     return 1
 
 
-def _handle_unexpected_error(output_dir: Path, exc: Exception) -> int:
+def _handle_unexpected_error(
+    output_dir: Path, exc: Exception, *, verbose: bool = False
+) -> int:
     payload = {
         "ok": False,
         "stage": "internal",
@@ -1461,6 +1564,16 @@ def _handle_unexpected_error(output_dir: Path, exc: Exception) -> int:
         },
     }
     _write_error_result_if_safe(output_dir, payload)
+    _print("")
+    _print("================ Internal error ================")
+    _print(f"  type:    {type(exc).__name__}")
+    _print(f"  message: {exc}")
+    if verbose:
+        _print(_indent(traceback.format_exc(), 4))
+    else:
+        _print("  Re-run with --verbose for the full traceback.")
+    _print("================================================")
+    # Machine-readable error on stderr (always available; see _handle_skill_error).
     print(json.dumps(payload, indent=2), file=sys.stderr)
     return 1
 

--- a/skills/nfcore-rnaseq-wrapper/nfcore_rnaseq_wrapper.py
+++ b/skills/nfcore-rnaseq-wrapper/nfcore_rnaseq_wrapper.py
@@ -153,6 +153,16 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Nextflow work directory. Defaults to <output>/upstream/work; may be an object-store URI for cloud executors.",
     )
+    parser.add_argument(
+        "--allow-remote-inputs",
+        action="store_true",
+        help=(
+            "Opt in to remote samplesheet inputs and reference paths (s3://, gs://, "
+            "https://, ftp://, …). Default is local-first: remote URIs are rejected so "
+            "genetic data and references stay on the local machine. When enabled, a "
+            "runtime warning lists the paths fetched over the network."
+        ),
+    )
     parser.add_argument("--resume", action="store_true", help="Attempt checksum-validated Nextflow resume")
     parser.add_argument(
         "--timeout-hours",

--- a/skills/nfcore-rnaseq-wrapper/preflight.py
+++ b/skills/nfcore-rnaseq-wrapper/preflight.py
@@ -743,12 +743,16 @@ def _check_threshold_bounds(args) -> None:
             details={"field": "pseudo_aligner_kmer_size", "value": kmer, "minimum": 1, "maximum": 31},
         )
     timeout_hours = getattr(args, "timeout_hours", None)
-    if timeout_hours is not None and timeout_hours <= 0:
+    if timeout_hours is not None and timeout_hours < 0:
         raise SkillError(
             stage="preflight",
             error_code=ErrorCode.INVALID_PRESET_CONFIGURATION,
-            message="timeout_hours must be greater than 0.",
-            fix="Set --timeout-hours to a positive number of hours (default: 12).",
+            message="timeout_hours must be >= 0 (0 disables the wall-clock cap).",
+            fix=(
+                "Set --timeout-hours to a positive number of hours (default: 12), "
+                "or 0 to disable the cap for long HPC/cloud runs whose walltime is "
+                "enforced by the scheduler."
+            ),
             details={"field": "timeout_hours", "value": timeout_hours, "minimum": 0},
         )
     hbm = getattr(args, "hisat2_build_memory", None)

--- a/skills/nfcore-rnaseq-wrapper/preflight.py
+++ b/skills/nfcore-rnaseq-wrapper/preflight.py
@@ -500,8 +500,8 @@ def _check_remote_inputs(args, samplesheet_summary: dict[str, object]) -> None:
         for path in samplesheet_summary.get(key, []) or []:
             if "://" in str(path):
                 remote.append(str(path))
-    for field in _EXPLICIT_REFERENCE_FIELDS:
-        value = getattr(args, field, None)
+    for ref_field in _EXPLICIT_REFERENCE_FIELDS:
+        value = getattr(args, ref_field, None)
         if value and "://" in str(value):
             remote.append(str(value))
     if not remote:

--- a/skills/nfcore-rnaseq-wrapper/preflight.py
+++ b/skills/nfcore-rnaseq-wrapper/preflight.py
@@ -489,8 +489,51 @@ def _is_relative_to(path: Path, parent: Path) -> bool:
     return True
 
 
+def _check_remote_inputs(args, samplesheet_summary: dict[str, object]) -> None:
+    """Local-first by default: reject remote samplesheet inputs and reference paths
+    (s3://, gs://, https://, ftp://, …) unless ``--allow-remote-inputs`` is set, in
+    which case warn that genetic data will be fetched over the network. The
+    object-store ``--work-dir`` is a separate, intentionally-remote setting and is
+    not gated."""
+    remote: list[str] = []
+    for key in ("fastq_paths", "bam_paths"):
+        for path in samplesheet_summary.get(key, []) or []:
+            if "://" in str(path):
+                remote.append(str(path))
+    for field in _EXPLICIT_REFERENCE_FIELDS:
+        value = getattr(args, field, None)
+        if value and "://" in str(value):
+            remote.append(str(value))
+    if not remote:
+        return
+    unique = sorted(set(remote))
+    if getattr(args, "allow_remote_inputs", False):
+        print(
+            "WARNING: --allow-remote-inputs is set; "
+            f"{len(unique)} input/reference path(s) will be fetched over the network, "
+            "so genetic data may leave the local machine: " + ", ".join(unique),
+            file=sys.stderr,
+        )
+        return
+    raise SkillError(
+        stage="preflight",
+        error_code=ErrorCode.REMOTE_INPUT_NOT_ALLOWED,
+        message=(
+            "Remote input/reference URIs are not allowed by default (local-first); "
+            f"detected {len(unique)} remote path(s)."
+        ),
+        fix=(
+            "Download the data locally and use local paths, or pass "
+            "--allow-remote-inputs to fetch them over the network at your own risk "
+            "(genetic data will leave the local machine)."
+        ),
+        details={"remote_paths": unique},
+    )
+
+
 def run_preflight(args, *, pipeline_source: dict[str, object], samplesheet_summary: dict[str, object]) -> dict[str, object]:
     warnings: list[str] = []
+    _check_remote_inputs(args, samplesheet_summary)
     aligner_effective = _check_supported_options(args)
     _check_igenomes_genome(args, pipeline_source=pipeline_source, warnings=warnings)
     _check_email(getattr(args, "email", None))

--- a/skills/nfcore-rnaseq-wrapper/tests/conftest.py
+++ b/skills/nfcore-rnaseq-wrapper/tests/conftest.py
@@ -78,3 +78,66 @@ def _ensure_clawbio_stubs() -> None:
 
 
 _ensure_clawbio_stubs()
+
+
+# ── Cross-skill bare-module isolation (shared verbatim with nfcore-sarek /
+# nfcore-scrnaseq conftests) ─────────────────────────────────────────────────
+# Several nf-core wrapper skills ship modules under bare top-level names
+# (``errors``, ``schemas``, …). A single pytest session that collects more than
+# one wrapper suite can shadow them across skills. We force THIS skill's dir to
+# the front of sys.path and ensure each bare name resolves to this skill's
+# *canonical* module object — restoring the same object (not reimporting) when a
+# foreign copy is cached, so ``pytest.raises(SkillError)`` class identity holds.
+_ISO_SKILL_DIR = Path(__file__).resolve().parent.parent
+_ISO_TESTS_DIR = Path(__file__).resolve().parent
+_ISO_BARE_MODULES = (
+    "errors",
+    "schemas",
+    "preflight",
+    "params_builder",
+    "command_builder",
+    "samplesheet_builder",
+    "outputs_parser",
+    "provenance",
+    "reporting",
+    "executor",
+    "pipeline_source",
+    "remap_paths",
+    "repro_commands",
+    "nfcore_4_1_0_contract",
+    "_isolated_imports",
+)
+_ISO_CANONICAL: dict[str, object] = {}
+
+
+def _claim_local_modules() -> None:
+    for path in (_ISO_TESTS_DIR, _ISO_SKILL_DIR):
+        if str(path) in sys.path:
+            sys.path.remove(str(path))
+        sys.path.insert(0, str(path))
+    for name in _ISO_BARE_MODULES:
+        module = sys.modules.get(name)
+        if module is not None:
+            module_file = Path(getattr(module, "__file__", "") or "")
+            local = (
+                module_file == _ISO_SKILL_DIR / f"{name}.py"
+                or _ISO_SKILL_DIR in module_file.parents
+            )
+            if local:
+                _ISO_CANONICAL[name] = module
+                continue
+        if name in _ISO_CANONICAL:
+            sys.modules[name] = _ISO_CANONICAL[name]
+        elif module is not None:
+            sys.modules.pop(name, None)
+
+
+_claim_local_modules()
+
+
+def pytest_collectstart(collector):  # noqa: ARG001 - pytest hook signature
+    _claim_local_modules()
+
+
+def pytest_runtest_setup(item):  # noqa: ARG001 - pytest hook signature
+    _claim_local_modules()

--- a/skills/nfcore-rnaseq-wrapper/tests/test_audit_rnaseq_hardening.py
+++ b/skills/nfcore-rnaseq-wrapper/tests/test_audit_rnaseq_hardening.py
@@ -368,6 +368,27 @@ def test_resolve_timeout_seconds_uses_arg():
     assert wrapper._resolve_timeout_seconds(Namespace(timeout_hours=48)) == 48 * 3600
 
 
+def test_resolve_timeout_seconds_zero_disables_cap():
+    """--timeout-hours 0 disables the wall-clock cap (returns None) — parity with
+    nfcore-scrnaseq/sarek."""
+    assert wrapper._resolve_timeout_seconds(Namespace(timeout_hours=0)) is None
+
+
+def test_resolve_work_dir_default(tmp_path):
+    assert wrapper._resolve_nextflow_work_dir(Namespace(work_dir=None), tmp_path) == (
+        tmp_path / "upstream" / "work"
+    )
+
+
+def test_resolve_work_dir_object_store_uri_preserved(tmp_path):
+    """Remote object-store work dirs are preserved verbatim (cloud executors) —
+    parity with nfcore-scrnaseq/sarek."""
+    assert (
+        wrapper._resolve_nextflow_work_dir(Namespace(work_dir="s3://bucket/work"), tmp_path)
+        == "s3://bucket/work"
+    )
+
+
 def test_resolve_timeout_seconds_falls_back_to_default():
     assert (
         wrapper._resolve_timeout_seconds(Namespace(timeout_hours=None))

--- a/skills/nfcore-rnaseq-wrapper/tests/test_drift_guards.py
+++ b/skills/nfcore-rnaseq-wrapper/tests/test_drift_guards.py
@@ -69,6 +69,7 @@ _CONTROL_DESTS = frozenset({
     "verbose",            # launcher-only logging concern, not an nf-core param
     "no_banner",          # launcher-only display concern, not an nf-core param
     "work_dir",           # execution-environment path, not a scientific param
+    "allow_remote_inputs",  # data-governance gate, not an nf-core param
 })
 
 

--- a/skills/nfcore-rnaseq-wrapper/tests/test_drift_guards.py
+++ b/skills/nfcore-rnaseq-wrapper/tests/test_drift_guards.py
@@ -66,6 +66,9 @@ _CONTROL_DESTS = frozenset({
     "deseq2_vst",         # recorded explicitly via --deseq2-vst/--no-deseq2-vst
     "nextflow_config",    # recorded explicitly (list)
     "check",              # preflight-only, never reaches a real run
+    "verbose",            # launcher-only logging concern, not an nf-core param
+    "no_banner",          # launcher-only display concern, not an nf-core param
+    "work_dir",           # execution-environment path, not a scientific param
 })
 
 

--- a/skills/nfcore-rnaseq-wrapper/tests/test_nfcore_rnaseq_wrapper.py
+++ b/skills/nfcore-rnaseq-wrapper/tests/test_nfcore_rnaseq_wrapper.py
@@ -1050,3 +1050,16 @@ def test_clawbio_kallisto_index_forwarded_to_rnaseq_pipeline():
     """--kallisto-index must be forwardable (regression: absent from the forwarding loop)."""
     values, _ = _rnaseq_pipeline_allowlist()
     assert "--kallisto-index" in values, f"--kallisto-index missing from allowlist: {sorted(values)!r}"
+
+
+def test_main_keyboard_interrupt_returns_130(tmp_path, monkeypatch):
+    """Ctrl+C during a long-running pipeline must exit 130 (SIGINT convention),
+    not dump a traceback — parity with nfcore-sarek/scrnaseq."""
+    module = _load_skill_module()
+
+    def _boom(*_args, **_kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(module, "_run_wrapper", _boom)
+    rc = module.main(["--output", str(tmp_path), "--demo"])
+    assert rc == 130

--- a/skills/nfcore-rnaseq-wrapper/tests/test_preflight.py
+++ b/skills/nfcore-rnaseq-wrapper/tests/test_preflight.py
@@ -69,6 +69,7 @@ def _args(tmp_path: Path, **overrides) -> Namespace:
         output=str(tmp_path / "out"),
         resume=False,
         demo=False,
+        allow_remote_inputs=False,
         aligner="star_salmon",
         pseudo_aligner=None,
         trimmer="trimgalore",
@@ -434,9 +435,11 @@ def test_samplesheet_fastq_paths_are_revalidated(tmp_path, monkeypatch):
 
 
 def test_samplesheet_remote_fastq_uri_not_existence_checked(tmp_path, monkeypatch):
+    """With --allow-remote-inputs, a remote FASTQ URI passes preflight (existence is
+    deferred to Nextflow). Without the flag it is rejected (see the gate tests)."""
     _mock_env(monkeypatch)
     result = _run(
-        _args(tmp_path),
+        _args(tmp_path, allow_remote_inputs=True),
         _samplesheet(tmp_path, fastq_paths=["s3://bucket.example.org/reads/sample_R1.fastq.gz"]),
     )
     assert result["ok"] is True
@@ -470,7 +473,7 @@ def test_bam_reprocessing_skip_alignment_no_reference_is_allowed(tmp_path, monke
 def test_remote_bam_uri_skip_alignment_not_existence_checked(tmp_path, monkeypatch):
     _mock_env(monkeypatch)
     result = _run(
-        _args(tmp_path, skip_alignment=True, fasta=None, gtf=None, genome=None),
+        _args(tmp_path, skip_alignment=True, fasta=None, gtf=None, genome=None, allow_remote_inputs=True),
         _samplesheet(tmp_path, bam_paths=["s3://bucket.example.org/bams/sample.genome.bam"]),
     )
     assert result["samplesheet"]["bam_count"] == 1
@@ -717,10 +720,10 @@ def test_remote_fasta_url_passes_preflight(tmp_path, monkeypatch):
     _mock_env(monkeypatch)
     monkeypatch.setattr(preflight, "check_output_dir_available", lambda *a, **kw: None)
     result = _run(
-        _args(tmp_path, fasta="s3://example.org/genome.fa", gtf="s3://example.org/genes.gtf"),
+        _args(tmp_path, fasta="s3://example.org/genome.fa", gtf="s3://example.org/genes.gtf", allow_remote_inputs=True),
         _samplesheet(tmp_path),
     )
-    assert result["ok"] is True, f"Remote s3:// refs should pass preflight; got errors: {result}"
+    assert result["ok"] is True, f"Remote s3:// refs should pass preflight with --allow-remote-inputs; got: {result}"
 
 
 def test_local_ref_path_not_found_still_raises(tmp_path, monkeypatch):
@@ -1629,3 +1632,32 @@ def test_gtf_has_gencode_markers_detects_uppercase_gz_suffix(tmp_path):
     with gzip.open(gtf, "wt", encoding="utf-8") as handle:
         handle.write('chr1\tHAVANA\tgene\t1\t10\t.\t+\t.\tgene_id "ENSG1"; gene_type "protein_coding";\n')
     assert preflight._gtf_has_gencode_markers(gtf) is True
+
+
+# --- --allow-remote-inputs gate (local-first by default) ---------------------
+
+def test_remote_fastq_rejected_by_default():
+    from argparse import Namespace as _NS
+    with pytest.raises(SkillError) as exc:
+        preflight._check_remote_inputs(
+            _NS(allow_remote_inputs=False), {"fastq_paths": ["s3://bucket/n_R1.fastq.gz"], "bam_paths": []}
+        )
+    assert exc.value.error_code == ErrorCode.REMOTE_INPUT_NOT_ALLOWED
+
+
+def test_remote_reference_rejected_by_default():
+    from argparse import Namespace as _NS
+    with pytest.raises(SkillError) as exc:
+        preflight._check_remote_inputs(_NS(allow_remote_inputs=False, fasta="gs://bucket/genome.fa"), {})
+    assert exc.value.error_code == ErrorCode.REMOTE_INPUT_NOT_ALLOWED
+
+
+def test_remote_inputs_allowed_with_flag_warns(capsys):
+    from argparse import Namespace as _NS
+    preflight._check_remote_inputs(_NS(allow_remote_inputs=True), {"fastq_paths": ["https://x/n_R1.fastq.gz"]})
+    assert "--allow-remote-inputs" in capsys.readouterr().err
+
+
+def test_local_inputs_pass_the_remote_gate():
+    from argparse import Namespace as _NS
+    preflight._check_remote_inputs(_NS(allow_remote_inputs=False), {"fastq_paths": ["/d/n_R1.fastq.gz"]})

--- a/skills/nfcore-rnaseq-wrapper/tests/test_preflight.py
+++ b/skills/nfcore-rnaseq-wrapper/tests/test_preflight.py
@@ -979,12 +979,12 @@ def test_extra_star_align_args_rejected_for_hisat2(tmp_path, monkeypatch):
 # ── Audit follow-up: F-02 timeout bounds ──────────────────────────────────────
 
 
-def test_timeout_hours_zero_rejected(tmp_path, monkeypatch):
+def test_timeout_hours_zero_accepted_disables_cap(tmp_path, monkeypatch):
+    """--timeout-hours 0 is accepted: it disables the wall-clock cap (parity with
+    nfcore-scrnaseq/sarek). Only negative values are rejected at preflight."""
     _mock_env(monkeypatch)
-    with pytest.raises(SkillError) as exc:
-        _run(_args(tmp_path, timeout_hours=0), _samplesheet(tmp_path))
-    assert exc.value.error_code == ErrorCode.INVALID_PRESET_CONFIGURATION
-    assert exc.value.details["field"] == "timeout_hours"
+    result = _run(_args(tmp_path, timeout_hours=0), _samplesheet(tmp_path))
+    assert result["ok"] is True
 
 
 def test_timeout_hours_negative_rejected(tmp_path, monkeypatch):

--- a/skills/nfcore-rnaseq-wrapper/tests/test_reporting.py
+++ b/skills/nfcore-rnaseq-wrapper/tests/test_reporting.py
@@ -486,6 +486,7 @@ def test_commands_sh_replays_every_run_affecting_wrapper_flag(tmp_path):
         "-c",
         "--config",
         "--work-dir",
+        "--allow-remote-inputs",
     }
     missing = wrapper_flags - emitted - special
     assert missing == set(), f"wrapper flags not replayed in commands.sh: {sorted(missing)}"

--- a/skills/nfcore-rnaseq-wrapper/tests/test_reporting.py
+++ b/skills/nfcore-rnaseq-wrapper/tests/test_reporting.py
@@ -471,8 +471,22 @@ def test_commands_sh_replays_every_run_affecting_wrapper_flag(tmp_path):
     # Handled specially / intentionally not replayed verbatim:
     #  --input/--output → emitted in bundle-relative form by dedicated logic;
     #  --demo → off in this real-run scenario; --check → means "do not run";
-    #  --no-deseq2-vst → alternate store_false form of --deseq2-vst (mutually exclusive).
-    special = {"--input", "--output", "--demo", "--check", "--no-deseq2-vst"}
+    #  --no-deseq2-vst → alternate store_false form of --deseq2-vst (mutually exclusive);
+    #  -v/--verbose/--no-banner → launcher-only logging/display, not run-affecting;
+    #  -c/--config → aliases of --nextflow-config, replayed under that canonical name.
+    special = {
+        "--input",
+        "--output",
+        "--demo",
+        "--check",
+        "--no-deseq2-vst",
+        "-v",
+        "--verbose",
+        "--no-banner",
+        "-c",
+        "--config",
+        "--work-dir",
+    }
     missing = wrapper_flags - emitted - special
     assert missing == set(), f"wrapper flags not replayed in commands.sh: {sorted(missing)}"
 

--- a/skills/nfcore-sarek-wrapper/CHANGELOG.md
+++ b/skills/nfcore-sarek-wrapper/CHANGELOG.md
@@ -8,6 +8,13 @@ and the wrapper version is tracked in `SKILL.md` YAML frontmatter.
 
 ### Added
 
+- **`--allow-remote-inputs` opt-in (local-first by default).** Remote samplesheet
+  inputs and user-supplied reference paths (`s3://`, `gs://`, `https://`, `ftp://`,
+  …) are now rejected at preflight (`REMOTE_INPUT_NOT_ALLOWED`) unless the flag is
+  passed, in which case a runtime warning names every path fetched over the
+  network. The public iGenomes mirror base (`igenomes_base`) and the object-store
+  `--work-dir` are intentionally remote and are not gated. Shared verbatim with
+  `nfcore-scrnaseq/rnaseq`. (Flag surface 176 → 177.)
 - **Control-flag parity with the sibling wrappers.** Added `--work-dir`
   (Nextflow work directory override, accepts a local path or an object-store URI
   for cloud executors; was hardcoded to `<output>/upstream/work`),

--- a/skills/nfcore-sarek-wrapper/CHANGELOG.md
+++ b/skills/nfcore-sarek-wrapper/CHANGELOG.md
@@ -8,6 +8,51 @@ and the wrapper version is tracked in `SKILL.md` YAML frontmatter.
 
 ### Added
 
+- **Control-flag parity with the sibling wrappers.** Added `--work-dir`
+  (Nextflow work directory override, accepts a local path or an object-store URI
+  for cloud executors; was hardcoded to `<output>/upstream/work`),
+  `--allow-pipeline-version-override` plus a `_check_pipeline_version_supported`
+  guard (a non-pinned `--pipeline-version` is now blocked unless explicitly
+  overridden, so the 3.8.1-pinned validations can't silently run against a
+  different version), and `-c`/`--config` as aliases of `--nextflow-config`.
+  These bumped the flag surface to 176 (154 passthrough + 22 wrapper controls).
+- **`--timeout-hours` is now configurable** (was hardcoded to 24h). Accepts a
+  positive number of hours or `0` to disable the wall-clock cap for long
+  HPC/cloud runs whose walltime the scheduler enforces — parity with
+  `nfcore-scrnaseq/rnaseq`. The executor's `timeout_seconds` is now `int | None`.
+  This bumped the flag surface 173 → 174 (154 passthrough + 20 wrapper controls).
+
+### Changed
+
+- **Demo coercions now emit `WARNING:` on stderr** (were `[demo]` on stdout):
+  overriding a user-supplied flag is an advisory the user should notice, so it
+  belongs on stderr — parity with the sibling wrappers.
+- **Logging fully consistent with the siblings**: `_print` docstring unified and
+  a dedicated `[provenance]` stage line added, so all three wrappers emit the
+  identical stage-prefix set (`[preflight]`/`[execute]`/`[outputs]`/`[report]`/
+  `[provenance]`/`[done]`/`[check]`/`[abort]`).
+- **`SkillError` now exits `1`** (was `2`), matching `nfcore-scrnaseq/rnaseq`.
+  Exit `2` is reserved by argparse for CLI-usage errors, so reusing it for
+  validation/preflight failures made the two indistinguishable to machine
+  consumers. Internal/unexpected errors still exit `1`.
+- **Order-independent test suite.** `tests/conftest.py` now claims this skill's
+  bare modules (`errors`, `schemas`, …) via a canonical-object cache — at
+  collection and before each test — so `make test` (which collects all three
+  wrapper suites together) no longer hits cross-skill module shadowing. The same
+  block is shared verbatim across all three wrappers' conftests.
+
+### Added
+
+- **Cross-wrapper homogenization pass.** Centralized the import-isolation guard
+  into `_isolated_imports.py` (replacing per-module copy-pasted
+  `_purge_foreign_modules` and a buggy `if not in sys.path` path block that did
+  not force this skill's dir to the front), renamed the inner runner `_run` →
+  `_run_wrapper`, removed the dead `FASTQ_NOT_READABLE` error code (with the
+  shared readability-policy NOTE), gave the README the common Scope/Out-of-Scope/
+  Quick-Start skeleton, and added a machine-readable JSON error on **stderr**
+  (in addition to the human box and `result.json`) so a structured error is
+  available even when `result.json` cannot be written — matching
+  `nfcore-scrnaseq-wrapper` and `nfcore-rnaseq-wrapper`.
 - **Cross-OS reproducibility-bundle hardening.** The entire bundle is now
   byte-stable and portable across Linux, macOS, and Windows/WSL:
   - Every bundle text file (`commands.sh`, `report.md`, `result.json`,

--- a/skills/nfcore-sarek-wrapper/README.md
+++ b/skills/nfcore-sarek-wrapper/README.md
@@ -8,7 +8,7 @@ ClawBio wrapper around `nf-core/sarek` 3.8.1 covering mapping through annotation
 - Germline, tumor-only, and somatic tumor-normal paired analyses.
 - Supported callers: HaplotypeCaller, Mutect2, Strelka, ASCAT, ControlFREEC, Manta, TIDDIT, MSIsensor-pro, FreeBayes, DeepVariant, and Sentieon (TNscope/Haplotyper/DNAscope).
 - Annotation with VEP and/or SnpEff.
-- Validated samplesheet input (CSV/TSV/YAML/JSON) with normalized local paths or preserved remote URLs.
+- Validated samplesheet input (CSV/TSV/YAML/JSON) with normalized local paths (local-first by default; remote URLs require `--allow-remote-inputs`).
 - Reproducibility bundle, provenance bundle, `report.md`, and `result.json`.
 
 ## Out Of Scope
@@ -21,7 +21,7 @@ ClawBio wrapper around `nf-core/sarek` 3.8.1 covering mapping through annotation
 ## Quick Start
 
 ```bash
-# See every supported flag (176-flag surface: 154 Sarek passthrough + 22 wrapper controls)
+# See every supported flag (177-flag surface: 154 Sarek passthrough + 23 wrapper controls)
 python skills/nfcore-sarek-wrapper/nfcore_sarek_wrapper.py --help
 
 # Synthetic demo using the upstream -profile test dataset

--- a/skills/nfcore-sarek-wrapper/README.md
+++ b/skills/nfcore-sarek-wrapper/README.md
@@ -1,16 +1,44 @@
 # nfcore-sarek-wrapper
 
-ClawBio wrapper around `nf-core/sarek` 3.8.1 covering mapping through annotation for germline, tumor-only, and somatic paired variant-calling analyses.
+ClawBio wrapper around `nf-core/sarek` 3.8.1 covering mapping through annotation for germline, tumor-only, and somatic paired variant-calling analyses, with strict preflight, reproducibility artifacts, provenance, and explicit opt-in handoff to downstream ClawBio interpretation skills.
 
-## Quick start
+## Scope
+
+- Upstream variant calling via Nextflow across the 6-step pipeline (`mapping → markduplicates → prepare_recalibration → recalibrate → variant_calling → annotate`).
+- Germline, tumor-only, and somatic tumor-normal paired analyses.
+- Supported callers: HaplotypeCaller, Mutect2, Strelka, ASCAT, ControlFREEC, Manta, TIDDIT, MSIsensor-pro, FreeBayes, DeepVariant, and Sentieon (TNscope/Haplotyper/DNAscope).
+- Annotation with VEP and/or SnpEff.
+- Validated samplesheet input (CSV/TSV/YAML/JSON) with normalized local paths or preserved remote URLs.
+- Reproducibility bundle, provenance bundle, `report.md`, and `result.json`.
+
+## Out Of Scope
+
+- ACMG/AMP classification or clinical variant interpretation.
+- Moving, renaming, or post-processing Nextflow output files.
+- Automatic downstream chaining; handoff is opt-in via `--run-downstream --downstream-skill <name>`.
+- Arbitrary free-form Nextflow passthrough flags (any non-promoted sarek parameter goes through `--extra-param key=value`; custom config via `-c/--config`).
+
+## Quick Start
 
 ```bash
-# See every supported flag (173-flag surface: 154 Sarek passthrough + 19 wrapper controls)
+# See every supported flag (176-flag surface: 154 Sarek passthrough + 22 wrapper controls)
 python skills/nfcore-sarek-wrapper/nfcore_sarek_wrapper.py --help
 
 # Synthetic demo using the upstream -profile test dataset
 python clawbio.py run sarek-pipeline --demo --output /tmp/sarek_demo
 ```
+
+For real data:
+
+```bash
+python clawbio.py run sarek-pipeline \
+  --input samplesheet.csv \
+  --output ./sarek_run \
+  --genome GATK.GRCh38 \
+  --tools haplotypecaller,vep
+```
+
+Use `--check` to run preflight without launching Nextflow.
 
 `clawbio.py run sarek-pipeline` promotes the common flags to first-class options; any other sarek parameter is passed through with `--extra-param key=value`.
 

--- a/skills/nfcore-sarek-wrapper/SKILL.md
+++ b/skills/nfcore-sarek-wrapper/SKILL.md
@@ -146,8 +146,12 @@ This skill does not perform ACMG classification, does not interpret variants cli
 ## Input Formats
 
 The samplesheet may be `.csv`, `.tsv`, `.yaml`, `.yml`, or `.json` (CSV/TSV are
-delimited; YAML/JSON are a top-level list of row records). File-column values may
-be local paths or remote URLs (`https://`, `s3://`, `gs://`, `ftp://`, …).
+delimited; YAML/JSON are a top-level list of row records). File-column values
+must be local paths by default (local-first): remote URLs (`https://`, `s3://`,
+`gs://`, `ftp://`, …) — and remote reference paths — are rejected at preflight
+(`REMOTE_INPUT_NOT_ALLOWED`) unless you pass `--allow-remote-inputs`, which also
+logs a runtime warning naming every path fetched over the network. (The public
+iGenomes mirror base and the object-store `--work-dir` are not gated.)
 
 | Mode | Required Fields | Example |
 |--------|-----------------|---------|
@@ -247,6 +251,7 @@ python clawbio.py run sarek-pipeline \
 #   --work-dir PATH     Nextflow work dir (local path or object-store URI; default <output>/upstream/work)
 #   --nextflow-config / -c / --config   extra Nextflow config file(s), repeatable
 #   --allow-pipeline-version-override    run a non-3.8.1 --pipeline-version at your own risk
+#   --allow-remote-inputs               opt in to remote inputs/refs (default local-first)
 python clawbio.py run sarek-pipeline \
   --input samplesheet.csv --output ./sarek_run \
   --genome GATK.GRCh38 --tools haplotypecaller \
@@ -375,6 +380,7 @@ The wrapper writes exactly two child directories under the `output/` root: `upst
 - No patient data is bundled.
 - Demo mode uses upstream `-profile test` data.
 - The wrapper does not upload data.
+- **Local-first by default**: remote samplesheet inputs and reference paths are rejected (`REMOTE_INPUT_NOT_ALLOWED`) unless `--allow-remote-inputs` is explicitly passed, which also logs a runtime warning naming every path fetched over the network. The iGenomes mirror base and the object-store `--work-dir` are not gated.
 - The wrapper does not pass arbitrary unvalidated Nextflow parameters; unknown native keys via `--extra-param` are passed through but tracked in provenance, while `input`, `input_restart`, and `outdir` remain wrapper-managed so normalized input and output provenance cannot be bypassed.
 - `--resume` is rejected on manifest drift (pipeline source, profile, step, aligner, tools, skip_tools, analysis_mode, wes, joint_germline, joint_mutect2, effective params checksum, reference fingerprints, samplesheet checksum).
 

--- a/skills/nfcore-sarek-wrapper/SKILL.md
+++ b/skills/nfcore-sarek-wrapper/SKILL.md
@@ -241,6 +241,16 @@ python clawbio.py run sarek-pipeline \
   --tools haplotypecaller,vep \
   --genome GATK.GRCh38 \
   --run-downstream --downstream-skill clinical-variant-reporter
+
+# Wrapper runtime controls (parity with scrnaseq/rnaseq):
+#   --timeout-hours N   wall-clock cap (default 24h; 0 disables for HPC/cloud)
+#   --work-dir PATH     Nextflow work dir (local path or object-store URI; default <output>/upstream/work)
+#   --nextflow-config / -c / --config   extra Nextflow config file(s), repeatable
+#   --allow-pipeline-version-override    run a non-3.8.1 --pipeline-version at your own risk
+python clawbio.py run sarek-pipeline \
+  --input samplesheet.csv --output ./sarek_run \
+  --genome GATK.GRCh38 --tools haplotypecaller \
+  --timeout-hours 0 --work-dir s3://my-bucket/sarek/work
 ```
 
 ## Demo

--- a/skills/nfcore-sarek-wrapper/_isolated_imports.py
+++ b/skills/nfcore-sarek-wrapper/_isolated_imports.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SKILL_DIR = Path(__file__).resolve().parent
+
+
+def purge_foreign_bare_modules(*names: str) -> None:
+    """Drop cached top-level modules that do not belong to this skill.
+
+    The skill is executed as a bare script (``python nfcore_rnaseq_wrapper.py``),
+    so its modules are imported under top-level names like ``errors`` and
+    ``schemas``. A sibling skill that ships an identically-named ``errors.py`` /
+    ``schemas.py`` can therefore shadow ours when both run in one interpreter
+    (most visibly, the shared test session). Each module calls this guard before
+    importing its dependencies so the cache only ever holds *our* copy.
+
+    Centralised here (instead of copy-pasted into every module) so the isolation
+    rule has a single definition. Callers ``sys.modules.pop("_isolated_imports")``
+    before importing this module, so a foreign copy of this file cannot shadow it
+    either.
+    """
+    for name in names:
+        module = sys.modules.get(name)
+        module_file = Path(getattr(module, "__file__", "") or "")
+        if module is not None and _SKILL_DIR not in module_file.parents and module_file != _SKILL_DIR / f"{name}.py":
+            sys.modules.pop(name, None)

--- a/skills/nfcore-sarek-wrapper/command_builder.py
+++ b/skills/nfcore-sarek-wrapper/command_builder.py
@@ -45,7 +45,7 @@ def build_nextflow_command(
     profile: str,
     params_path: Path,
     resume: bool,
-    work_dir: Path | None = None,
+    work_dir: Path | str | None = None,
     extra_configs: list[Path] | None = None,
     demo: bool = False,
     arm: bool = False,
@@ -73,7 +73,10 @@ def build_nextflow_command(
 
     command.extend(["-profile", composed_profile, "-params-file", params_path.as_posix()])
     if work_dir is not None:
-        command.extend(["-work-dir", work_dir.as_posix()])
+        # work_dir may be a local Path or a remote object-store URI (str, e.g.
+        # s3://bucket/work); preserve URIs verbatim, posix-normalise local paths.
+        work_dir_arg = work_dir if isinstance(work_dir, str) else work_dir.as_posix()
+        command.extend(["-work-dir", work_dir_arg])
     for cfg in extra_configs or []:
         command.extend(["-c", cfg.as_posix()])
     if resume:

--- a/skills/nfcore-sarek-wrapper/demo/README.md
+++ b/skills/nfcore-sarek-wrapper/demo/README.md
@@ -1,7 +1,10 @@
-# nfcore-sarek-wrapper - demo
+# nfcore-sarek-wrapper — demo
 
 ```bash
 python clawbio.py run sarek-pipeline --demo --output /tmp/sarek_demo
 ```
 
-Uses the upstream nf-core/sarek `-profile test` dataset (no local files required). Takes ~5-10 minutes on a workstation with Docker + Nextflow >=25.10.2 installed.
+Uses the upstream nf-core/sarek `-profile test` dataset (no local files
+required; no real patient or sample data is bundled in this repository).
+Requires Docker (running) + Nextflow >=25.10.2. Takes ~5-10 minutes on a
+workstation.

--- a/skills/nfcore-sarek-wrapper/errors.py
+++ b/skills/nfcore-sarek-wrapper/errors.py
@@ -38,6 +38,10 @@ class ErrorCode:
     # there. Existence of inputs is validated (MISSING_FASTQ); readability is deferred to
     # Nextflow's staging, which reads in the true execution context.
     INVALID_SAMPLESHEET = "INVALID_SAMPLESHEET"
+    # Remote input/reference URIs (s3://, gs://, https://, ftp://, …) are rejected by
+    # default (local-first); they are only allowed with --allow-remote-inputs, which
+    # also emits a runtime warning that data is being fetched over the network.
+    REMOTE_INPUT_NOT_ALLOWED = "REMOTE_INPUT_NOT_ALLOWED"
     OUTPUT_DIR_NOT_EMPTY = "OUTPUT_DIR_NOT_EMPTY"
     OUTPUT_DIR_NOT_WRITABLE = "OUTPUT_DIR_NOT_WRITABLE"
     MISSING_REFERENCE = "MISSING_REFERENCE"

--- a/skills/nfcore-sarek-wrapper/errors.py
+++ b/skills/nfcore-sarek-wrapper/errors.py
@@ -30,7 +30,13 @@ class ErrorCode:
     MISSING_INPUT = "MISSING_INPUT"
     MISSING_FASTQ = "MISSING_FASTQ"
     INVALID_FASTQ = "INVALID_FASTQ"
-    FASTQ_NOT_READABLE = "FASTQ_NOT_READABLE"
+    # NOTE: input readability is intentionally NOT pre-checked. The wrapper does not
+    # read the FASTQ/BAM/CRAM data — Nextflow does, and under the default Docker profile
+    # the container often runs as root and can read files the launching user cannot, so an
+    # os.access(R_OK) pre-check by the launcher would false-block valid runs. Output
+    # *writability* IS checked (OUTPUT_DIR_NOT_WRITABLE) because the wrapper itself writes
+    # there. Existence of inputs is validated (MISSING_FASTQ); readability is deferred to
+    # Nextflow's staging, which reads in the true execution context.
     INVALID_SAMPLESHEET = "INVALID_SAMPLESHEET"
     OUTPUT_DIR_NOT_EMPTY = "OUTPUT_DIR_NOT_EMPTY"
     OUTPUT_DIR_NOT_WRITABLE = "OUTPUT_DIR_NOT_WRITABLE"

--- a/skills/nfcore-sarek-wrapper/executor.py
+++ b/skills/nfcore-sarek-wrapper/executor.py
@@ -8,19 +8,15 @@ import subprocess
 import sys
 
 _SKILL_DIR = Path(__file__).resolve().parent
-if str(_SKILL_DIR) not in sys.path:
-    sys.path.insert(0, str(_SKILL_DIR))
+if str(_SKILL_DIR) in sys.path:
+    sys.path.remove(str(_SKILL_DIR))
+sys.path.insert(0, str(_SKILL_DIR))
 
 
-def _purge_foreign_modules(*names: str) -> None:
-    for name in names:
-        module = sys.modules.get(name)
-        module_file = Path(getattr(module, "__file__", "") or "")
-        if module is not None and _SKILL_DIR not in module_file.parents and module_file != _SKILL_DIR / f"{name}.py":
-            sys.modules.pop(name, None)
+sys.modules.pop("_isolated_imports", None)
+from _isolated_imports import purge_foreign_bare_modules
 
-
-_purge_foreign_modules("errors")
+purge_foreign_bare_modules("errors")
 
 from errors import ErrorCode, SkillError
 
@@ -33,8 +29,11 @@ def execute_nextflow(
     *,
     cwd: Path,
     output_dir: Path,
-    timeout_seconds: int,
+    timeout_seconds: int | None,
 ) -> dict[str, object]:
+    # timeout_seconds=None disables the wall-clock cap entirely (long HPC/cloud
+    # runs whose walltime is enforced by the scheduler); proc.wait(timeout=None)
+    # blocks until completion.
     # Logs live inside the reproducibility bundle so the output root keeps to
     # exactly two children (upstream/, reproducibility/) and execution logs are
     # excluded from checksums.sha256 (the whole reproducibility/ tree is).

--- a/skills/nfcore-sarek-wrapper/nfcore_sarek_wrapper.py
+++ b/skills/nfcore-sarek-wrapper/nfcore_sarek_wrapper.py
@@ -38,15 +38,10 @@ if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
 
-def _purge_foreign_bare_modules(*names: str) -> None:
-    for name in names:
-        module = sys.modules.get(name)
-        module_file = Path(getattr(module, "__file__", "") or "")
-        if module is not None and _SKILL_DIR not in module_file.parents and module_file != _SKILL_DIR / f"{name}.py":
-            sys.modules.pop(name, None)
+sys.modules.pop("_isolated_imports", None)
+from _isolated_imports import purge_foreign_bare_modules
 
-
-_purge_foreign_bare_modules(
+purge_foreign_bare_modules(
     "command_builder",
     "errors",
     "executor",
@@ -333,8 +328,83 @@ _BANNER = (
 
 
 def _print(msg: str) -> None:
-    """Log to stdout (not stderr) for status messages."""
+    """Log a human-readable status line to stdout (progress/traceability)."""
     print(msg, flush=True)
+
+
+_DEFAULT_TIMEOUT_HOURS = DEFAULT_TIMEOUT_SECONDS / 3600
+
+
+def _timeout_hours(value: str) -> float:
+    try:
+        hours = float(value)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError(
+            f"--timeout-hours must be a number, got {value!r}"
+        )
+    if hours < 0:
+        raise argparse.ArgumentTypeError(
+            "--timeout-hours must be >= 0 (0 disables the timeout)"
+        )
+    return hours
+
+
+def _resolve_timeout_seconds(args: argparse.Namespace) -> int | None:
+    """Translate --timeout-hours into seconds; 0 disables the cap (returns None)."""
+    hours = getattr(args, "timeout_hours", _DEFAULT_TIMEOUT_HOURS)
+    if hours is None or hours == 0:
+        return None
+    return int(round(hours * 3600))
+
+
+def _check_pipeline_version_supported(args: argparse.Namespace) -> None:
+    """Keep execution on the pinned 3.8.1 contract unless explicitly overridden.
+
+    The wrapper's parameter set, profile matrix and output validations are
+    hardcoded for nf-core/sarek 3.8.1. Running a different remote tag/commit would
+    apply 3.8.1 rules to a pipeline that may differ, so any non-3.8.1
+    ``--pipeline-version`` is blocked by default; ``--allow-pipeline-version-override``
+    is a recorded, warned opt-in for advanced use. Parity with
+    nfcore-scrnaseq/rnaseq.
+    """
+    requested = str(getattr(args, "pipeline_version", "") or "").strip()
+    if requested == DEFAULT_PIPELINE_VERSION:
+        return
+    if getattr(args, "allow_pipeline_version_override", False):
+        print(
+            f"WARNING: --pipeline-version {requested!r} differs from the wrapper's pinned "
+            f"nf-core/sarek {DEFAULT_PIPELINE_VERSION} contract. Parameter, profile and "
+            f"output validations remain {DEFAULT_PIPELINE_VERSION}-specific and may not match.",
+            file=sys.stderr,
+        )
+        return
+    raise SkillError(
+        stage="validation",
+        error_code=ErrorCode.PIPELINE_SOURCE_INVALID,
+        message=(
+            f"--pipeline-version must be {DEFAULT_PIPELINE_VERSION} "
+            "(the version this wrapper's validations are pinned to)."
+        ),
+        fix=(
+            f"Use --pipeline-version {DEFAULT_PIPELINE_VERSION}, or pass "
+            "--allow-pipeline-version-override to run a different version at your own risk "
+            f"(validations stay {DEFAULT_PIPELINE_VERSION})."
+        ),
+        details={"requested": requested, "contract_version": DEFAULT_PIPELINE_VERSION},
+    )
+
+
+def _resolve_nextflow_work_dir(args: argparse.Namespace, output_dir: Path) -> Path | str:
+    """Resolve the Nextflow work directory: default <output>/upstream/work, or the
+    user's --work-dir (a local path, or an object-store URI kept verbatim for cloud
+    executors). Parity with nfcore-scrnaseq/rnaseq."""
+    raw_work_dir = getattr(args, "work_dir", None)
+    if not raw_work_dir:
+        return output_dir / "upstream" / "work"
+    work_dir = str(raw_work_dir).strip()
+    if "://" in work_dir:
+        return work_dir
+    return Path(work_dir).expanduser().resolve()
 
 
 # ---------------------------------------------------------------------------
@@ -371,16 +441,43 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--nextflow-config",
+        "-c",
+        "--config",
+        dest="nextflow_config",
         action="append",
         metavar="CONFIG",
         default=None,
-        help="Extra Nextflow -c config file(s). Can be repeated.",
+        help="Extra Nextflow -c config file(s) (aliases: -c/--config). Can be repeated.",
     )
     parser.add_argument("--pipeline-version", default=DEFAULT_PIPELINE_VERSION, help="Pinned nf-core/sarek tag/ref")
+    parser.add_argument(
+        "--allow-pipeline-version-override",
+        action="store_true",
+        help=(
+            f"Run a --pipeline-version other than the pinned {DEFAULT_PIPELINE_VERSION} "
+            "contract (recorded, warned). Validations stay "
+            f"{DEFAULT_PIPELINE_VERSION}-specific, so this is at your own risk."
+        ),
+    )
     parser.add_argument("--pipeline-local", default=None, help="Local nf-core/sarek checkout")
+    parser.add_argument(
+        "--work-dir",
+        default=None,
+        help="Nextflow work directory. Defaults to <output>/upstream/work; may be an object-store URI for cloud executors.",
+    )
     parser.add_argument("--params-file", default=None, help="Sarek-native --params-file (advanced)")
     parser.add_argument("--no-banner", action="store_true", help="Suppress console banner")
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose logging")
+    parser.add_argument(
+        "--timeout-hours",
+        type=_timeout_hours,
+        default=_DEFAULT_TIMEOUT_HOURS,
+        help=(
+            f"Wall-clock cap for the Nextflow run in hours (default {_DEFAULT_TIMEOUT_HOURS:g}). "
+            "Use 0 to disable the cap for long HPC/cloud runs whose walltime is enforced "
+            "by the scheduler."
+        ),
+    )
     parser.add_argument(
         "--extra-param",
         action="append",
@@ -431,7 +528,8 @@ def main(argv: list[str] | None = None) -> int:
         _print(_BANNER)
     output_dir = Path(args.output).expanduser().resolve()
     try:
-        return _run(args, output_dir)
+        _check_pipeline_version_supported(args)
+        return _run_wrapper(args, output_dir)
     except SkillError as exc:
         return _handle_skill_error(output_dir, exc, verbose=args.verbose)
     except KeyboardInterrupt:
@@ -441,7 +539,7 @@ def main(argv: list[str] | None = None) -> int:
         return _handle_unexpected_error(output_dir, exc, verbose=args.verbose)
 
 
-def _run(args: argparse.Namespace, output_dir: Path) -> int:
+def _run_wrapper(args: argparse.Namespace, output_dir: Path) -> int:
     # Materialise config-provided step/tools before input validation. In
     # particular, downstream Sarek steps may omit input and retrieve their CSV
     # handoff, whereas mapping may not.
@@ -535,7 +633,7 @@ def _run(args: argparse.Namespace, output_dir: Path) -> int:
 
     macos_cfg = _write_macos_docker_config(output_dir, args=args)
     extra_configs = _resolve_extra_configs(args, macos_cfg=macos_cfg)
-    work_dir = output_dir / "upstream" / "work"
+    work_dir = _resolve_nextflow_work_dir(args, output_dir)
 
     nextflow_command, command_str = build_nextflow_command(
         pipeline_source=pipeline_source,
@@ -558,7 +656,7 @@ def _run(args: argparse.Namespace, output_dir: Path) -> int:
         nextflow_command,
         cwd=output_dir,
         output_dir=output_dir,
-        timeout_seconds=DEFAULT_TIMEOUT_SECONDS,
+        timeout_seconds=_resolve_timeout_seconds(args),
     )
     elapsed = round(time.monotonic() - started, 3)
     _print(f"[execute] completed in {elapsed:.1f}s")
@@ -735,14 +833,27 @@ def _apply_demo_overrides(args: argparse.Namespace) -> None:
         for key in (*_DEMO_CLEARED_REFERENCE_FIELDS, "igenomes_ignore"):
             if extras.pop(key, None) is not None and key not in cleared:
                 cleared.append(key)
+    # Demo coercions override user-supplied flags, so they are advisories the user
+    # should notice → stderr WARNING (parity with nfcore-scrnaseq/rnaseq), not a
+    # stdout progress line.
     if cleared:
         flags = ", ".join("--" + f.replace("_", "-") for f in cleared)
-        _print(f"[demo] cleared reference flags: {flags}")
+        print(
+            f"WARNING: --demo ignores reference flags ({flags}); "
+            "the upstream test profile provides its own bundled references.",
+            file=sys.stderr,
+        )
     if args.input:
-        _print("[demo] ignoring --input; the upstream test profile provides its own samplesheet")
+        print(
+            "WARNING: --demo ignores --input; the upstream test profile provides its own samplesheet.",
+            file=sys.stderr,
+        )
         args.input = None
     if args.resume:
-        _print("[demo] disabling --resume; demo runs do not resume from prior synthetic state")
+        print(
+            "WARNING: --demo disables --resume; demo runs cannot resume from a prior synthetic run.",
+            file=sys.stderr,
+        )
         args.resume = False
 
 
@@ -1336,7 +1447,13 @@ def _handle_skill_error(output_dir: Path, exc: SkillError, *, verbose: bool) -> 
         _print(_indent(json.dumps(exc.details, indent=2, default=str), 4))
     _print("============================================")
     _write_error_result_if_safe(output_dir, payload)
-    return 2
+    # Machine-readable error on stderr: always available even when result.json
+    # cannot be written (e.g. the output dir is a file or inside the repo).
+    print(json.dumps(payload, indent=2), file=sys.stderr)
+    # Exit 1 for a SkillError (parity with nfcore-scrnaseq/rnaseq). Exit 2 is
+    # reserved for argparse CLI-usage errors, so reusing it for validation
+    # failures would make the two indistinguishable to machine consumers.
+    return 1
 
 
 def _handle_unexpected_error(output_dir: Path, exc: Exception, *, verbose: bool) -> int:
@@ -1358,6 +1475,8 @@ def _handle_unexpected_error(output_dir: Path, exc: Exception, *, verbose: bool)
         _print("  Re-run with --verbose for traceback.")
     _print("================================================")
     _write_error_result_if_safe(output_dir, payload)
+    # Machine-readable error on stderr (always available; see _handle_skill_error).
+    print(json.dumps(payload, indent=2), file=sys.stderr)
     return 1
 
 

--- a/skills/nfcore-sarek-wrapper/nfcore_sarek_wrapper.py
+++ b/skills/nfcore-sarek-wrapper/nfcore_sarek_wrapper.py
@@ -465,6 +465,17 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Nextflow work directory. Defaults to <output>/upstream/work; may be an object-store URI for cloud executors.",
     )
+    parser.add_argument(
+        "--allow-remote-inputs",
+        action="store_true",
+        help=(
+            "Opt in to remote samplesheet inputs and reference paths (s3://, gs://, "
+            "https://, ftp://, …). Default is local-first: remote URIs are rejected so "
+            "genetic data and references stay on the local machine. When enabled, a "
+            "runtime warning lists the paths fetched over the network. (The iGenomes "
+            "mirror base and object-store --work-dir are not gated.)"
+        ),
+    )
     parser.add_argument("--params-file", default=None, help="Sarek-native --params-file (advanced)")
     parser.add_argument("--no-banner", action="store_true", help="Suppress console banner")
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose logging")
@@ -605,6 +616,7 @@ def _run_wrapper(args: argparse.Namespace, output_dir: Path) -> int:
         repo_root=repo_root,
         resume=bool(args.resume),
         resume_manifest=resume_manifest,
+        allow_remote_inputs=bool(getattr(args, "allow_remote_inputs", False)),
     )
     _print(f"[preflight] passed (warnings: {len(preflight_result.warnings)})")
     if args.verbose:

--- a/skills/nfcore-sarek-wrapper/outputs_parser.py
+++ b/skills/nfcore-sarek-wrapper/outputs_parser.py
@@ -24,15 +24,10 @@ if str(_SKILL_DIR) in sys.path:
 sys.path.insert(0, str(_SKILL_DIR))
 
 
-def _purge_foreign_bare_modules(*names: str) -> None:
-    for name in names:
-        module = sys.modules.get(name)
-        module_file = Path(getattr(module, "__file__", "") or "")
-        if module is not None and _SKILL_DIR not in module_file.parents and module_file != _SKILL_DIR / f"{name}.py":
-            sys.modules.pop(name, None)
+sys.modules.pop("_isolated_imports", None)
+from _isolated_imports import purge_foreign_bare_modules
 
-
-_purge_foreign_bare_modules("errors", "schemas")
+purge_foreign_bare_modules("errors", "schemas")
 
 from errors import ErrorCode, SkillError  # noqa: E402
 

--- a/skills/nfcore-sarek-wrapper/params_builder.py
+++ b/skills/nfcore-sarek-wrapper/params_builder.py
@@ -13,15 +13,10 @@ if str(_SKILL_DIR) in sys.path:
 sys.path.insert(0, str(_SKILL_DIR))
 
 
-def _purge_foreign_bare_modules(*names: str) -> None:
-    for name in names:
-        module = sys.modules.get(name)
-        module_file = Path(getattr(module, "__file__", "") or "")
-        if module is not None and _SKILL_DIR not in module_file.parents and module_file != _SKILL_DIR / f"{name}.py":
-            sys.modules.pop(name, None)
+sys.modules.pop("_isolated_imports", None)
+from _isolated_imports import purge_foreign_bare_modules
 
-
-_purge_foreign_bare_modules("errors", "schemas")
+purge_foreign_bare_modules("errors", "schemas")
 
 from clawbio.common.textio import write_text_lf
 from errors import ErrorCode, SkillError

--- a/skills/nfcore-sarek-wrapper/pipeline_source.py
+++ b/skills/nfcore-sarek-wrapper/pipeline_source.py
@@ -6,19 +6,15 @@ import subprocess
 import sys
 
 _SKILL_DIR = Path(__file__).resolve().parent
-if str(_SKILL_DIR) not in sys.path:
-    sys.path.insert(0, str(_SKILL_DIR))
+if str(_SKILL_DIR) in sys.path:
+    sys.path.remove(str(_SKILL_DIR))
+sys.path.insert(0, str(_SKILL_DIR))
 
 
-def _purge_foreign_modules(*names: str) -> None:
-    for name in names:
-        module = sys.modules.get(name)
-        module_file = Path(getattr(module, "__file__", "") or "")
-        if module is not None and _SKILL_DIR not in module_file.parents and module_file != _SKILL_DIR / f"{name}.py":
-            sys.modules.pop(name, None)
+sys.modules.pop("_isolated_imports", None)
+from _isolated_imports import purge_foreign_bare_modules
 
-
-_purge_foreign_modules("errors", "schemas")
+purge_foreign_bare_modules("errors", "schemas")
 
 from errors import ErrorCode, SkillError
 from schemas import DEFAULT_LOCAL_PIPELINE_DIR, DEFAULT_REMOTE_PIPELINE, PIPELINE_REQUIRED_FILES

--- a/skills/nfcore-sarek-wrapper/preflight.py
+++ b/skills/nfcore-sarek-wrapper/preflight.py
@@ -195,6 +195,55 @@ class PreflightResult:
     notes: list[str] = field(default_factory=list)
 
 
+def _check_remote_inputs(
+    params: dict[str, Any],
+    samplesheet: dict[str, Any],
+    *,
+    allow_remote_inputs: bool,
+) -> None:
+    """Local-first by default: reject remote samplesheet inputs and user-supplied
+    reference paths (s3://, gs://, https://, ftp://, …) unless allow_remote_inputs
+    is set, in which case warn that genetic data is fetched over the network. The
+    object-store ``--work-dir`` and the public iGenomes mirror base (``igenomes_base``,
+    default ``s3://ngi-igenomes/``) are intentionally remote and are not gated."""
+    remote: list[str] = []
+    for key in ("fastq_paths", "bam_paths", "cram_paths"):
+        for path in samplesheet.get(key, []) or []:
+            if "://" in str(path):
+                remote.append(str(path))
+    for field in REFERENCE_PATH_PARAMS:
+        if field == "igenomes_base":
+            continue  # public reference-mirror base, remote by design
+        value = params.get(field)
+        if value and "://" in str(value):
+            remote.append(str(value))
+    if not remote:
+        return
+    unique = sorted(set(remote))
+    if allow_remote_inputs:
+        print(
+            "WARNING: --allow-remote-inputs is set; "
+            f"{len(unique)} input/reference path(s) will be fetched over the network, "
+            "so genetic data may leave the local machine: " + ", ".join(unique),
+            file=sys.stderr,
+        )
+        return
+    raise SkillError(
+        stage="preflight",
+        error_code=ErrorCode.REMOTE_INPUT_NOT_ALLOWED,
+        message=(
+            "Remote input/reference URIs are not allowed by default (local-first); "
+            f"detected {len(unique)} remote path(s)."
+        ),
+        fix=(
+            "Download the data locally and use local paths, or pass "
+            "--allow-remote-inputs to fetch them over the network at your own risk "
+            "(genetic data will leave the local machine)."
+        ),
+        details={"remote_paths": unique},
+    )
+
+
 def run_preflight(
     *,
     params: dict[str, Any],
@@ -204,6 +253,7 @@ def run_preflight(
     repo_root: Path,
     resume: bool = False,
     resume_manifest: dict | None = None,
+    allow_remote_inputs: bool = False,
 ) -> PreflightResult:
     """Run every preflight rule for the Sarek wrapper.
 
@@ -213,6 +263,9 @@ def run_preflight(
     """
     warnings_acc: list[str] = []
     notes_acc: list[str] = []
+
+    # Local-first gate: reject remote inputs/references unless opted in.
+    _check_remote_inputs(params, samplesheet, allow_remote_inputs=allow_remote_inputs)
 
     # §5.1 — cross-cutting checks ------------------------------------------
     _check_java()

--- a/skills/nfcore-sarek-wrapper/preflight.py
+++ b/skills/nfcore-sarek-wrapper/preflight.py
@@ -211,10 +211,10 @@ def _check_remote_inputs(
         for path in samplesheet.get(key, []) or []:
             if "://" in str(path):
                 remote.append(str(path))
-    for field in REFERENCE_PATH_PARAMS:
-        if field == "igenomes_base":
+    for ref_field in REFERENCE_PATH_PARAMS:
+        if ref_field == "igenomes_base":
             continue  # public reference-mirror base, remote by design
-        value = params.get(field)
+        value = params.get(ref_field)
         if value and "://" in str(value):
             remote.append(str(value))
     if not remote:

--- a/skills/nfcore-sarek-wrapper/preflight.py
+++ b/skills/nfcore-sarek-wrapper/preflight.py
@@ -30,15 +30,10 @@ if str(_SKILL_DIR) in sys.path:
 sys.path.insert(0, str(_SKILL_DIR))
 
 
-def _purge_foreign_bare_modules(*names: str) -> None:
-    for name in names:
-        module = sys.modules.get(name)
-        module_file = Path(getattr(module, "__file__", "") or "")
-        if module is not None and _SKILL_DIR not in module_file.parents and module_file != _SKILL_DIR / f"{name}.py":
-            sys.modules.pop(name, None)
+sys.modules.pop("_isolated_imports", None)
+from _isolated_imports import purge_foreign_bare_modules
 
-
-_purge_foreign_bare_modules("errors", "schemas")
+purge_foreign_bare_modules("errors", "schemas")
 
 from errors import ErrorCode, SkillError
 from schemas import (

--- a/skills/nfcore-sarek-wrapper/provenance.py
+++ b/skills/nfcore-sarek-wrapper/provenance.py
@@ -43,19 +43,10 @@ if str(_SKILL_DIR) in sys.path:
 sys.path.insert(0, str(_SKILL_DIR))
 
 
-def _purge_foreign_bare_modules(*names: str) -> None:
-    for name in names:
-        module = sys.modules.get(name)
-        module_file = Path(getattr(module, "__file__", "") or "")
-        if (
-            module is not None
-            and _SKILL_DIR not in module_file.parents
-            and module_file != _SKILL_DIR / f"{name}.py"
-        ):
-            sys.modules.pop(name, None)
+sys.modules.pop("_isolated_imports", None)
+from _isolated_imports import purge_foreign_bare_modules
 
-
-_purge_foreign_bare_modules("errors", "schemas", "preflight")
+purge_foreign_bare_modules("errors", "schemas", "preflight")
 
 from clawbio.common.textio import write_text_lf  # noqa: E402
 from schemas import DEFAULT_ALIGNER, DEFAULT_STEP, SKILL_NAME, SKILL_VERSION  # noqa: E402

--- a/skills/nfcore-sarek-wrapper/reporting.py
+++ b/skills/nfcore-sarek-wrapper/reporting.py
@@ -32,24 +32,18 @@ if str(_SKILL_DIR) in sys.path:
 sys.path.insert(0, str(_SKILL_DIR))
 
 
-def _purge_foreign_bare_modules(*names: str) -> None:
-    for name in names:
-        module = sys.modules.get(name)
-        module_file = Path(getattr(module, "__file__", "") or "")
-        if module is not None and _SKILL_DIR not in module_file.parents and module_file != _SKILL_DIR / f"{name}.py":
-            sys.modules.pop(name, None)
+sys.modules.pop("_isolated_imports", None)
+from _isolated_imports import purge_foreign_bare_modules
 
+purge_foreign_bare_modules("schemas")
 
-_purge_foreign_bare_modules("schemas")
-
+from clawbio.common.report import DISCLAIMER as _DISCLAIMER  # noqa: E402
 from clawbio.common.textio import write_text_lf  # noqa: E402
 from schemas import DEFAULT_ALIGNER, DEFAULT_STEP, SKILL_NAME, SKILL_VERSION  # noqa: E402
 
-_DISCLAIMER = (
-    "ClawBio is a research and educational tool. It is not a medical device "
-    "and does not provide clinical diagnoses. Consult a healthcare "
-    "professional before making any medical decisions."
-)
+# Disclaimer text is sourced from the single canonical constant in
+# clawbio.common.report (shared with nfcore-scrnaseq/rnaseq via
+# generate_report_footer) so the wording can never drift across skills.
 
 _EM_DASH = "-"  # ASCII placeholder for "not available"
 

--- a/skills/nfcore-sarek-wrapper/samplesheet_builder.py
+++ b/skills/nfcore-sarek-wrapper/samplesheet_builder.py
@@ -18,15 +18,10 @@ if str(_SKILL_DIR) in sys.path:
 sys.path.insert(0, str(_SKILL_DIR))
 
 
-def _purge_foreign_bare_modules(*names: str) -> None:
-    for name in names:
-        module = sys.modules.get(name)
-        module_file = Path(getattr(module, "__file__", "") or "")
-        if module is not None and _SKILL_DIR not in module_file.parents and module_file != _SKILL_DIR / f"{name}.py":
-            sys.modules.pop(name, None)
+sys.modules.pop("_isolated_imports", None)
+from _isolated_imports import purge_foreign_bare_modules
 
-
-_purge_foreign_bare_modules("errors", "schemas")
+purge_foreign_bare_modules("errors", "schemas")
 
 from errors import ErrorCode, SkillError
 from schemas import (

--- a/skills/nfcore-sarek-wrapper/tests/conftest.py
+++ b/skills/nfcore-sarek-wrapper/tests/conftest.py
@@ -1,4 +1,20 @@
-"""conftest.py — ensure the skill directory is importable for tests."""
+"""conftest.py — make this wrapper's test suite order-independent.
+
+Several nf-core wrapper skills in this monorepo ship their modules under bare
+top-level names (``errors``, ``schemas``, ``preflight``, …). A single pytest
+session that collects more than one wrapper suite (the repo-wide ``testpaths``
+list / ``make test``) can therefore hit cross-skill module shadowing — a test
+importing ``from errors import SkillError`` could bind a sibling wrapper's class.
+
+We force THIS skill's directory to the front of ``sys.path`` and purge any
+foreign cached copies of the bare module names — once at import time (so each
+test file's *module-level* sibling imports bind this wrapper's classes during
+collection) and again before every test via the ``pytest_runtest_setup`` hook,
+which runs before fixtures, so the function-scoped module fixtures and any
+*runtime* ``from errors import`` inside a test body also resolve to this
+wrapper. This gives the order-immunity ``nfcore-rnaseq-wrapper`` achieves while
+keeping the rule in one place instead of copy-pasted into every test file.
+"""
 from __future__ import annotations
 
 import sys
@@ -6,6 +22,77 @@ from pathlib import Path
 
 _SKILL_DIR = Path(__file__).resolve().parent.parent
 _TESTS_DIR = Path(__file__).resolve().parent
-for path in (_SKILL_DIR, _TESTS_DIR):
-    if str(path) not in sys.path:
+
+# Bare top-level module names shipped by the nf-core wrapper skills. Purging a
+# name this wrapper does not ship is a no-op (only *foreign* cached copies are
+# dropped), so one shared list is safe across all three wrappers.
+_BARE_MODULES = (
+    "errors",
+    "schemas",
+    "preflight",
+    "params_builder",
+    "command_builder",
+    "samplesheet_builder",
+    "outputs_parser",
+    "provenance",
+    "reporting",
+    "executor",
+    "pipeline_source",
+    "remap_paths",
+    "repro_commands",
+    "nfcore_4_1_0_contract",
+    "_isolated_imports",
+)
+
+
+# Canonical object cache: the first time this skill's copy of a bare module is
+# seen in sys.modules, we remember that exact module object. When a *foreign*
+# wrapper later caches the same bare name, we restore our canonical object rather
+# than purging + reimporting — reimporting would create a NEW module object whose
+# ``SkillError`` class differs from the one already-loaded skill modules bound,
+# breaking ``pytest.raises(SkillError)`` identity checks. Restoring the same object
+# keeps the whole skill (modules + tests) sharing one class identity.
+_CANONICAL: dict[str, object] = {}
+
+
+def _claim_local_modules() -> None:
+    """Force this skill dir to the front of sys.path and ensure each bare module
+    name resolves to THIS skill's canonical object."""
+    for path in (_TESTS_DIR, _SKILL_DIR):
+        if str(path) in sys.path:
+            sys.path.remove(str(path))
         sys.path.insert(0, str(path))
+    for name in _BARE_MODULES:
+        module = sys.modules.get(name)
+        if module is not None:
+            module_file = Path(getattr(module, "__file__", "") or "")
+            local = (
+                module_file == _SKILL_DIR / f"{name}.py"
+                or _SKILL_DIR in module_file.parents
+            )
+            if local:
+                _CANONICAL[name] = module  # remember our canonical object
+                continue
+        # Foreign (or absent): restore our canonical object if we have one,
+        # otherwise drop the foreign copy so the next import loads ours.
+        if name in _CANONICAL:
+            sys.modules[name] = _CANONICAL[name]
+        elif module is not None:
+            sys.modules.pop(name, None)
+
+
+_claim_local_modules()
+
+
+def pytest_collectstart(collector):  # noqa: ARG001 - pytest hook signature
+    # Re-claim immediately before each test module in this dir is collected, so its
+    # module-level ``from errors import ...`` binds THIS wrapper's classes even when
+    # a sibling wrapper's collection ran in between.
+    _claim_local_modules()
+
+
+def pytest_runtest_setup(item):  # noqa: ARG001 - pytest hook signature
+    # Re-claim before each test so runtime ``from errors import ...`` inside a test
+    # body resolves to this skill's canonical object (identity-consistent with the
+    # function-scoped module fixtures).
+    _claim_local_modules()

--- a/skills/nfcore-sarek-wrapper/tests/test_nfcore_sarek_wrapper.py
+++ b/skills/nfcore-sarek-wrapper/tests/test_nfcore_sarek_wrapper.py
@@ -414,17 +414,91 @@ def test_apply_demo_overrides_clears_references(module):
 
 
 
+def test_timeout_hours_resolves_to_seconds(module):
+    args = module.build_parser().parse_args(
+        ["--output", "out", "--demo", "--no-banner", "--timeout-hours", "6"]
+    )
+    assert module._resolve_timeout_seconds(args) == 6 * 3600
+
+
+def test_timeout_hours_zero_disables_cap(module):
+    """--timeout-hours 0 disables the wall-clock cap (parity with scrnaseq/rnaseq)."""
+    args = module.build_parser().parse_args(
+        ["--output", "out", "--demo", "--no-banner", "--timeout-hours", "0"]
+    )
+    assert module._resolve_timeout_seconds(args) is None
+
+
+def test_timeout_hours_default_is_pinned(module):
+    args = module.build_parser().parse_args(["--output", "out", "--demo", "--no-banner"])
+    assert module._resolve_timeout_seconds(args) == module.DEFAULT_TIMEOUT_SECONDS
+
+
+def test_timeout_hours_negative_rejected(module):
+    with pytest.raises(SystemExit):
+        module.build_parser().parse_args(
+            ["--output", "out", "--demo", "--no-banner", "--timeout-hours", "-1"]
+        )
+
+
+def test_pipeline_version_mismatch_blocked(module):
+    """A non-pinned --pipeline-version is blocked by default (parity with siblings)."""
+    args = module.build_parser().parse_args(
+        ["--output", "out", "--demo", "--no-banner", "--pipeline-version", "3.5.0"]
+    )
+    with pytest.raises(module.SkillError) as exc:
+        module._check_pipeline_version_supported(args)
+    assert exc.value.error_code == "PIPELINE_SOURCE_INVALID"
+
+
+def test_pipeline_version_override_allows_mismatch(module):
+    args = module.build_parser().parse_args(
+        [
+            "--output", "out", "--demo", "--no-banner",
+            "--pipeline-version", "3.5.0", "--allow-pipeline-version-override",
+        ]
+    )
+    module._check_pipeline_version_supported(args)  # must not raise
+
+
+def test_pipeline_version_default_passes(module):
+    args = module.build_parser().parse_args(["--output", "out", "--demo", "--no-banner"])
+    module._check_pipeline_version_supported(args)  # default == pinned, no raise
+
+
+def test_work_dir_defaults_under_output(module, tmp_path):
+    args = module.build_parser().parse_args(["--output", str(tmp_path), "--demo", "--no-banner"])
+    assert module._resolve_nextflow_work_dir(args, tmp_path) == tmp_path / "upstream" / "work"
+
+
+def test_work_dir_override_local(module, tmp_path):
+    args = module.build_parser().parse_args(
+        ["--output", str(tmp_path), "--demo", "--no-banner", "--work-dir", str(tmp_path / "scratch")]
+    )
+    assert module._resolve_nextflow_work_dir(args, tmp_path) == (tmp_path / "scratch").resolve()
+
+
+def test_work_dir_override_object_store_uri_preserved(module, tmp_path):
+    args = module.build_parser().parse_args(
+        ["--output", str(tmp_path), "--demo", "--no-banner", "--work-dir", "s3://bucket/work"]
+    )
+    assert module._resolve_nextflow_work_dir(args, tmp_path) == "s3://bucket/work"
+
+
 def test_flag_surface_counts_match_docs(module):
     # Locks the numbers cited in README.md / CLAUDE.md / SKILL.md so they cannot
-    # silently drift: 154 Sarek passthrough params + 19 wrapper-only controls
-    # = 173 user-facing flags (excluding the auto-generated -h/--help).
+    # silently drift: 154 Sarek passthrough params + 22 wrapper-only controls
+    # = 176 user-facing flags (excluding the auto-generated -h/--help).
+    # (Round-4 homogenization added --timeout-hours, --allow-pipeline-version-override,
+    # and --work-dir for parity with the sibling wrappers, bumping wrapper-only
+    # controls 19 → 22.)
     assert len(module._SAREK_PASSTHROUGH_PARAMS) == 154
     parser = module.build_parser()
     opts = [a for a in parser._actions if a.option_strings and a.dest != "help"]
-    assert len({a.dest for a in opts}) == 173
+    assert len({a.dest for a in opts}) == 176
     passthrough_dests = {dest for _flag, dest, *_rest in module._SAREK_PASSTHROUGH_PARAMS}
     wrapper_only = {a.dest for a in opts} - passthrough_dests
-    assert len(wrapper_only) == 19
+    assert len(wrapper_only) == 22
 
 
 def test_demo_strips_reference_extra_params(module):
@@ -602,7 +676,7 @@ def test_main_returns_2_on_skill_error_during_validation(module, monkeypatch, tm
         # no --input and no --demo → SkillError(MISSING_INPUT)
         "--no-banner",
     ])
-    assert rc == 2
+    assert rc == 1
 
 
 def test_main_keyboard_interrupt_returns_130(module, monkeypatch, tmp_path):
@@ -739,7 +813,7 @@ def test_main_run_downstream_without_skill_returns_2(module, monkeypatch, tmp_pa
         "--no-banner",
         "--run-downstream",
     ])
-    assert rc == 2
+    assert rc == 1
 
 
 
@@ -817,7 +891,7 @@ def test_main_banner_suppression(module, monkeypatch, tmp_path, capsys):
 
 
 def test_main_skill_error_bubbles_up_with_nonzero_exit(module, monkeypatch, tmp_path):
-    """SkillError raised from any module yields exit code 2."""
+    """SkillError raised from any module yields exit code 1 (parity with siblings)."""
     _patch_heavy(monkeypatch, module)
 
     def boom(**kw):
@@ -835,7 +909,7 @@ def test_main_skill_error_bubbles_up_with_nonzero_exit(module, monkeypatch, tmp_
         "--demo",
         "--no-banner",
     ])
-    assert rc == 2
+    assert rc == 1
 
 
 def test_main_error_result_json_written_under_reproducibility(module, monkeypatch, tmp_path):
@@ -855,7 +929,7 @@ def test_main_error_result_json_written_under_reproducibility(module, monkeypatc
     monkeypatch.setattr(module, "run_preflight", boom)
     out = tmp_path / "out"
     rc = module.main(["--output", str(out), "--demo", "--no-banner"])
-    assert rc == 2
+    assert rc == 1
     err = out / "reproducibility" / "result.json"
     assert err.exists()
     payload = json.loads(err.read_text())

--- a/skills/nfcore-sarek-wrapper/tests/test_nfcore_sarek_wrapper.py
+++ b/skills/nfcore-sarek-wrapper/tests/test_nfcore_sarek_wrapper.py
@@ -487,18 +487,18 @@ def test_work_dir_override_object_store_uri_preserved(module, tmp_path):
 
 def test_flag_surface_counts_match_docs(module):
     # Locks the numbers cited in README.md / CLAUDE.md / SKILL.md so they cannot
-    # silently drift: 154 Sarek passthrough params + 22 wrapper-only controls
-    # = 176 user-facing flags (excluding the auto-generated -h/--help).
-    # (Round-4 homogenization added --timeout-hours, --allow-pipeline-version-override,
-    # and --work-dir for parity with the sibling wrappers, bumping wrapper-only
-    # controls 19 → 22.)
+    # silently drift: 154 Sarek passthrough params + 23 wrapper-only controls
+    # = 177 user-facing flags (excluding the auto-generated -h/--help).
+    # (Homogenization added --timeout-hours, --allow-pipeline-version-override,
+    # --work-dir, and --allow-remote-inputs for parity with the sibling wrappers,
+    # bumping wrapper-only controls 19 → 23.)
     assert len(module._SAREK_PASSTHROUGH_PARAMS) == 154
     parser = module.build_parser()
     opts = [a for a in parser._actions if a.option_strings and a.dest != "help"]
-    assert len({a.dest for a in opts}) == 176
+    assert len({a.dest for a in opts}) == 177
     passthrough_dests = {dest for _flag, dest, *_rest in module._SAREK_PASSTHROUGH_PARAMS}
     wrapper_only = {a.dest for a in opts} - passthrough_dests
-    assert len(wrapper_only) == 22
+    assert len(wrapper_only) == 23
 
 
 def test_demo_strips_reference_extra_params(module):

--- a/skills/nfcore-sarek-wrapper/tests/test_preflight.py
+++ b/skills/nfcore-sarek-wrapper/tests/test_preflight.py
@@ -1205,3 +1205,46 @@ def test_run_preflight_happy_path(tmp_path, stub_binaries):
         repo_root=repo_root,
     )
     assert isinstance(result, PreflightResult)
+
+
+# --- --allow-remote-inputs gate (local-first by default) ---------------------
+
+def test_remote_samplesheet_input_rejected_by_default():
+    import preflight as _pf
+    with pytest.raises(SkillError) as exc:
+        _pf._check_remote_inputs(
+            {}, {"fastq_paths": ["s3://bucket/n_R1.fastq.gz"], "bam_paths": [], "cram_paths": []},
+            allow_remote_inputs=False,
+        )
+    assert exc.value.error_code == ErrorCode.REMOTE_INPUT_NOT_ALLOWED
+
+
+def test_remote_reference_param_rejected_by_default():
+    import preflight as _pf
+    with pytest.raises(SkillError) as exc:
+        _pf._check_remote_inputs(
+            {"fasta": "https://example.org/genome.fa"}, {}, allow_remote_inputs=False
+        )
+    assert exc.value.error_code == ErrorCode.REMOTE_INPUT_NOT_ALLOWED
+
+
+def test_igenomes_base_remote_default_is_not_gated():
+    """The public iGenomes mirror base (s3://ngi-igenomes/) is remote by design and
+    must NOT trip the local-first gate."""
+    import preflight as _pf
+    _pf._check_remote_inputs(
+        {"igenomes_base": "s3://ngi-igenomes/igenomes/"}, {}, allow_remote_inputs=False
+    )
+
+
+def test_remote_inputs_allowed_with_flag_warns(capsys):
+    import preflight as _pf
+    _pf._check_remote_inputs(
+        {}, {"fastq_paths": ["gs://bucket/n_R1.fastq.gz"]}, allow_remote_inputs=True
+    )
+    assert "--allow-remote-inputs" in capsys.readouterr().err
+
+
+def test_local_inputs_pass_the_remote_gate():
+    import preflight as _pf
+    _pf._check_remote_inputs({"fasta": "/refs/genome.fa"}, {"fastq_paths": ["/d/n_R1.fastq.gz"]}, allow_remote_inputs=False)

--- a/skills/nfcore-scrnaseq-wrapper/CHANGELOG.md
+++ b/skills/nfcore-scrnaseq-wrapper/CHANGELOG.md
@@ -8,16 +8,18 @@ and the wrapper version is tracked in `SKILL.md` YAML frontmatter.
 
 ### Changed
 
-- **Remote input/reference URIs are now accepted.** Samplesheet FASTQs and
-  reference/index paths may be remote URIs (`s3://`, `gs://`, `https://`, …),
-  matching the nf-core/scrnaseq schema and the sibling sarek/rnaseq wrappers
-  (previously rejected as "local-first"). Remote values are passed through
-  verbatim — only the basename is validated; existence is deferred to Nextflow
-  staging — while local paths are still existence-checked at preflight
-  (`MISSING_FASTQ` / `MISSING_REFERENCE`). Local-first is preserved: the wrapper
-  only reads user-specified inputs and never exfiltrates data. Resolved FASTQ
-  values are now `Path | str` and remote URIs are written unchanged to the
-  normalized samplesheet and provenance (no `Path().as_posix()` `//`-collapse).
+- **Remote input/reference URIs are gated behind `--allow-remote-inputs`
+  (local-first by default).** Samplesheet FASTQs and reference/index paths must
+  be local unless the flag is passed; otherwise preflight rejects remote URIs
+  (`s3://`, `gs://`, `https://`, `ftp://`, …) with `REMOTE_INPUT_NOT_ALLOWED`, so
+  the "keeps processing local / prevents accidental cloud access" guarantee is
+  enforced by the code. With `--allow-remote-inputs` (a flag shared by all three
+  nf-core wrappers), remote values pass through verbatim — only the basename is
+  validated, existence is deferred to Nextflow staging — and preflight emits a
+  runtime warning naming every path fetched over the network. Local paths are
+  always existence-checked (`MISSING_FASTQ` / `MISSING_REFERENCE`). Resolved FASTQ
+  values are `Path | str` so remote URIs are written unchanged to the normalized
+  samplesheet and provenance (no `Path().as_posix()` `//`-collapse).
 - **SKILL.md frontmatter aligned to the canonical `SKILL-TEMPLATE` schema** so the
   machine catalog (`skills/catalog.json`) and the generator never drift: the
   `trigger_keywords` list now lives under `metadata.openclaw` (was a bare

--- a/skills/nfcore-scrnaseq-wrapper/CHANGELOG.md
+++ b/skills/nfcore-scrnaseq-wrapper/CHANGELOG.md
@@ -1,0 +1,66 @@
+# nfcore-scrnaseq-wrapper — Changelog
+
+All notable changes to the `nfcore-scrnaseq-wrapper` ClawBio skill are documented
+here. The format roughly follows [Keep a Changelog](https://keepachangelog.com)
+and the wrapper version is tracked in `SKILL.md` YAML frontmatter.
+
+## [Unreleased] — 0.1.0
+
+### Changed
+
+- **Remote input/reference URIs are now accepted.** Samplesheet FASTQs and
+  reference/index paths may be remote URIs (`s3://`, `gs://`, `https://`, …),
+  matching the nf-core/scrnaseq schema and the sibling sarek/rnaseq wrappers
+  (previously rejected as "local-first"). Remote values are passed through
+  verbatim — only the basename is validated; existence is deferred to Nextflow
+  staging — while local paths are still existence-checked at preflight
+  (`MISSING_FASTQ` / `MISSING_REFERENCE`). Local-first is preserved: the wrapper
+  only reads user-specified inputs and never exfiltrates data. Resolved FASTQ
+  values are now `Path | str` and remote URIs are written unchanged to the
+  normalized samplesheet and provenance (no `Path().as_posix()` `//`-collapse).
+- **SKILL.md frontmatter aligned to the canonical `SKILL-TEMPLATE` schema** so the
+  machine catalog (`skills/catalog.json`) and the generator never drift: the
+  `trigger_keywords` list now lives under `metadata.openclaw` (was a bare
+  `metadata.trigger_keywords` key) and a `metadata.demo_data` entry was added.
+  Matches `nfcore-sarek-wrapper` and `nfcore-rnaseq-wrapper`.
+- **Validation philosophy unified with the sibling wrappers.** The launcher-side
+  `os.access(R_OK)` FASTQ readability pre-check was removed: the wrapper never
+  reads FASTQ data — Nextflow does, often inside a root container under the
+  default Docker profile — so a launcher-side readability probe can false-block
+  valid runs. Existence and regular-file type are still validated; readability is
+  deferred to Nextflow's staging in the true execution context. A path that
+  exists but is not a regular file now raises `MISSING_FASTQ` (was
+  `FASTQ_NOT_READABLE`). Mirrors `nfcore-rnaseq-wrapper`'s documented policy.
+
+### Changed
+
+- **Logging consistency**: added a dedicated `[provenance]` stage line so all
+  three wrappers emit the identical stage-prefix set.
+- **Config-flag parity**: `--nextflow-config` is now accepted as an alias of
+  `-c`/`--config`, so the same custom-config flag names work across all three
+  wrappers.
+
+### Added
+
+- **Order-independent test suite.** `tests/conftest.py` now claims this skill's
+  bare modules (`errors`, `schemas`, …) via a canonical-object cache — at
+  collection and before each test — so a single `pytest` session that also
+  collects the sibling wrapper suites (e.g. `make test`) no longer hits
+  cross-skill module shadowing. Shared verbatim across all three wrappers.
+- **Converged CLI presentation with the sibling wrappers.** Added a startup
+  banner (`--no-banner`), `-v/--verbose`, and sarek-style staged progress logs
+  (`[preflight]`/`[execute]`/`[outputs]`/`[report]`/`[done]`) plus a
+  human-readable boxed error on stdout — while keeping the machine-readable JSON
+  error on stderr (a robust fallback that survives a failed `result.json` write)
+  and `result.json` on disk as the machine contract. `--verbose`/`--no-banner`
+  are registered in the `clawbio.py` runner allowlist.
+- **Robust `main()` entrypoint.** `main()` now accepts an explicit `argv` list
+  (unit-testable without mutating `sys.argv`) and returns exit code `130` on
+  `KeyboardInterrupt` (the SIGINT convention) instead of dumping a traceback.
+  Matches `nfcore-sarek-wrapper` and `nfcore-rnaseq-wrapper`.
+
+### Removed
+
+- Dead `ErrorCode.FASTQ_NOT_READABLE` constant (no longer referenced after the
+  readability-precheck removal) and the now-unused `import os` in
+  `samplesheet_builder.py`.

--- a/skills/nfcore-scrnaseq-wrapper/README.md
+++ b/skills/nfcore-scrnaseq-wrapper/README.md
@@ -15,7 +15,7 @@ ClawBio wrapper for running the upstream `scrnaseq` Nextflow pipeline from FASTQ
 
 - Clustering, marker detection, normalization, scVI/scANVI, or other downstream analysis.
 - Downstream chaining is **off by default**; it runs only as an explicit opt-in via `--run-downstream` (and `--skip-downstream` force-skips it). The wrapper never chains automatically without that flag.
-- Free-form Nextflow passthrough flags beyond validated `-c/--config` files.
+- Free-form Nextflow passthrough flags beyond validated `-c`/`--config`/`--nextflow-config` files.
 - Running without preflight.
 
 ## Quick Start
@@ -42,15 +42,15 @@ Use `--check` to run preflight without launching Nextflow.
 This wrapper targets nf-core/scrnaseq `4.1.0`. It is not a free-form passthrough. Parameters are grouped as:
 
 - **Supported upstream parameters:** input/output, aligner/preset, reference/index, skip, CellRanger, CellRanger ARC, CellRanger Multi, selected MultiQC/reporting options.
-- **Wrapper policy parameters:** `--preset`, `--check`, `--run-downstream`, `--skip-downstream`, `--expected-cells`, `--timeout-hours`, `--work-dir`, `--allow-dirty-pipeline`, `--require-local-pipeline`, `--allow-pipeline-version-override`, `--trust-config-params`, `--allow-conda-cellranger`, and `-c/--config`; these are ClawBio conveniences and are not nf-core parameters.
+- **Wrapper policy parameters:** `--preset`, `--check`, `--run-downstream`, `--skip-downstream`, `--expected-cells`, `--timeout-hours`, `--work-dir`, `--allow-dirty-pipeline`, `--require-local-pipeline`, `--allow-pipeline-version-override`, `--trust-config-params`, `--allow-conda-cellranger`, and `-c`/`--config`/`--nextflow-config`; these are ClawBio conveniences and are not nf-core parameters.
 - **Deprecated compatibility aliases:** `skip_emptydrops` is accepted only as `--skip-emptydrops` and translated to `skip_cellbender: true`; the deprecated upstream parameter is never written.
 - **Intentionally unsupported upstream parameters:** `custom_config_version`, `custom_config_base`, `config_profile_name`, `config_profile_description`, `config_profile_contact`, `config_profile_url`, `version`, `plaintext_email`, `max_multiqc_email_size`, `hook_url`, `validate_params`, `pipelines_testdata_base_path`, `help`, `help_full`, `show_hidden`.
 
 Unsupported parameters are either hidden/institutional metadata, interactive help/version flags, or options that would weaken the wrapper's fixed validation/reproducibility policy.
 
-## Local-first Input Policy
+## Input & Reference Path Policy
 
-The upstream pipeline can consume remote test-data URLs in some examples, but this ClawBio wrapper rejects remote FASTQ URIs by default. Download FASTQs locally first. This prevents accidental cloud access or patient-data movement and keeps all processing local-first.
+Both local paths and remote URIs (`s3://`, `gs://`, `https://`, …) are accepted for samplesheet FASTQs and reference/index inputs, matching nf-core/scrnaseq and the sibling sarek/rnaseq wrappers. Remote inputs are passed through verbatim (Nextflow stages them); only the basename is validated. Local references and FASTQs are still existence-checked at preflight so missing local paths fail fast. Local-first is preserved — the wrapper only reads user-specified inputs and never exfiltrates data.
 
 ## Protocol Policy
 

--- a/skills/nfcore-scrnaseq-wrapper/README.md
+++ b/skills/nfcore-scrnaseq-wrapper/README.md
@@ -42,7 +42,7 @@ Use `--check` to run preflight without launching Nextflow.
 This wrapper targets nf-core/scrnaseq `4.1.0`. It is not a free-form passthrough. Parameters are grouped as:
 
 - **Supported upstream parameters:** input/output, aligner/preset, reference/index, skip, CellRanger, CellRanger ARC, CellRanger Multi, selected MultiQC/reporting options.
-- **Wrapper policy parameters:** `--preset`, `--check`, `--run-downstream`, `--skip-downstream`, `--expected-cells`, `--timeout-hours`, `--work-dir`, `--allow-dirty-pipeline`, `--require-local-pipeline`, `--allow-pipeline-version-override`, `--trust-config-params`, `--allow-conda-cellranger`, and `-c`/`--config`/`--nextflow-config`; these are ClawBio conveniences and are not nf-core parameters.
+- **Wrapper policy parameters:** `--preset`, `--check`, `--run-downstream`, `--skip-downstream`, `--expected-cells`, `--timeout-hours`, `--work-dir`, `--allow-remote-inputs`, `--allow-dirty-pipeline`, `--require-local-pipeline`, `--allow-pipeline-version-override`, `--trust-config-params`, `--allow-conda-cellranger`, and `-c`/`--config`/`--nextflow-config`; these are ClawBio conveniences and are not nf-core parameters.
 - **Deprecated compatibility aliases:** `skip_emptydrops` is accepted only as `--skip-emptydrops` and translated to `skip_cellbender: true`; the deprecated upstream parameter is never written.
 - **Intentionally unsupported upstream parameters:** `custom_config_version`, `custom_config_base`, `config_profile_name`, `config_profile_description`, `config_profile_contact`, `config_profile_url`, `version`, `plaintext_email`, `max_multiqc_email_size`, `hook_url`, `validate_params`, `pipelines_testdata_base_path`, `help`, `help_full`, `show_hidden`.
 

--- a/skills/nfcore-scrnaseq-wrapper/README.md
+++ b/skills/nfcore-scrnaseq-wrapper/README.md
@@ -50,7 +50,7 @@ Unsupported parameters are either hidden/institutional metadata, interactive hel
 
 ## Input & Reference Path Policy
 
-Both local paths and remote URIs (`s3://`, `gs://`, `https://`, …) are accepted for samplesheet FASTQs and reference/index inputs, matching nf-core/scrnaseq and the sibling sarek/rnaseq wrappers. Remote inputs are passed through verbatim (Nextflow stages them); only the basename is validated. Local references and FASTQs are still existence-checked at preflight so missing local paths fail fast. Local-first is preserved — the wrapper only reads user-specified inputs and never exfiltrates data.
+**Local-first by default.** Samplesheet FASTQs and reference/index inputs must be local paths; remote URIs (`s3://`, `gs://`, `https://`, `ftp://`, …) are rejected at preflight (`REMOTE_INPUT_NOT_ALLOWED`) so genetic data and references stay on the local machine. Pass `--allow-remote-inputs` to opt in — remote URIs are then passed through verbatim (Nextflow stages them; only the basename is validated) and a runtime warning lists every path fetched over the network. The same flag is shared by all three nf-core wrappers. Local references and FASTQs are always existence-checked at preflight so missing local paths fail fast.
 
 ## Protocol Policy
 

--- a/skills/nfcore-scrnaseq-wrapper/SKILL.md
+++ b/skills/nfcore-scrnaseq-wrapper/SKILL.md
@@ -32,7 +32,25 @@ metadata:
     os:
     - darwin
     - linux
+    trigger_keywords:
+    - scrnaseq
+    - nf-core scrnaseq
+    - run scrnaseq from fastq
+    - preprocess 10x fastqs
+    - generate h5ad from single-cell fastq
+    - single-cell preprocessing
+    - nextflow scrna pipeline
+    - 10x chromium fastq pipeline
+    - starsolo upstream processing
+    - alevin-fry fastq to counts
+    - run nextflow scrnaseq
+    - upstream single-cell pipeline
+    - fastq to h5ad single cell
+    - 10x genomics fastq pipeline
   author: ClawBio
+  demo_data:
+  - path: demo/README.md
+    description: Demo mode uses the upstream nf-core/scrnaseq -profile test dataset rather than bundled FASTQs
   inputs:
   - name: samplesheet
     type: file
@@ -51,21 +69,6 @@ metadata:
     format:
     - json
     description: Structured result payload with detected outputs and provenance
-  trigger_keywords:
-  - scrnaseq
-  - nf-core scrnaseq
-  - run scrnaseq from fastq
-  - preprocess 10x fastqs
-  - generate h5ad from single-cell fastq
-  - single-cell preprocessing
-  - nextflow scrna pipeline
-  - 10x chromium fastq pipeline
-  - starsolo upstream processing
-  - alevin-fry fastq to counts
-  - run nextflow scrnaseq
-  - upstream single-cell pipeline
-  - fastq to h5ad single cell
-  - 10x genomics fastq pipeline
   version: 0.1.0
 ---
 
@@ -170,15 +173,15 @@ This wrapper targets nf-core/scrnaseq `4.1.0`. It is not a free-form passthrough
 
 Unsupported parameters are either hidden/institutional metadata, interactive help/version flags, or options that would weaken the wrapper's fixed validation/reproducibility policy.
 
-## Local-first Input Policy (restricted local-first mode)
+## Input & Reference Path Policy
 
-**This wrapper runs nf-core/scrnaseq 4.1.0 in a deliberately restricted, local-first mode — it is not a full-compatibility passthrough of every nf-core input/parameter path.** The upstream pipeline can consume remote test-data URLs in some examples (nf-core's CellRanger Multi usage examples use HTTPS FASTQ URLs), but this ClawBio wrapper rejects remote FASTQ URIs by default. Download FASTQs locally first. This prevents accidental cloud access or patient-data movement and keeps all processing local-first. There is no opt-in for remote FASTQs: if you need Nextflow-resolved remote inputs, run the upstream pipeline directly.
+This wrapper accepts **both local paths and remote URIs** (`s3://`, `gs://`, `https://`, `ftp://`, …) for samplesheet FASTQs and for reference/index inputs, matching the nf-core/scrnaseq schema and the sibling `nfcore-sarek-wrapper` / `nfcore-rnaseq-wrapper`. Remote inputs are passed through **verbatim** — Nextflow resolves and stages them in the execution context — so the wrapper validates only the FASTQ/FASTA basename and defers existence to Nextflow (`samplesheet_builder.py`, `preflight.py`). Local-first is preserved: the wrapper never *exfiltrates* data; it only reads the user-specified inputs.
 
-**This is a deliberate ClawBio wrapper policy, not a reproduction of nf-core's full input flexibility.** Two checks are intentionally stricter than the upstream schema (which types reference/FASTQ inputs as plain strings that Nextflow may resolve as URIs at runtime):
-- Remote FASTQ URIs in the samplesheet are rejected (`samplesheet_builder.py`).
-- Every supplied reference/index path (`--fasta`, `--gtf`, `--star-index`, …) must exist on the local filesystem at preflight (`preflight.py`), so a missing reference fails fast with a clear error instead of a late Nextflow error.
+**Local** paths are still validated eagerly at preflight so they fail fast with a clear error instead of a late Nextflow error:
+- A supplied local reference/index path (`--fasta`, `--gtf`, `--star-index`, …) that does not exist raises `MISSING_REFERENCE` (`preflight.py`).
+- A local FASTQ that does not exist (or is not a regular file) raises `MISSING_FASTQ` (`samplesheet_builder.py`).
 
-Both are local-first guarantees; environments that rely on Nextflow-resolved remote references should run the upstream pipeline directly.
+Readability is never pre-checked: Nextflow reads inputs in the true execution context (often a root container under the default Docker profile), so a launcher-side `os.access(R_OK)` probe would false-block valid runs (`errors.py`).
 
 ## CLI Reference
 

--- a/skills/nfcore-scrnaseq-wrapper/SKILL.md
+++ b/skills/nfcore-scrnaseq-wrapper/SKILL.md
@@ -175,7 +175,9 @@ Unsupported parameters are either hidden/institutional metadata, interactive hel
 
 ## Input & Reference Path Policy
 
-This wrapper accepts **both local paths and remote URIs** (`s3://`, `gs://`, `https://`, `ftp://`, …) for samplesheet FASTQs and for reference/index inputs, matching the nf-core/scrnaseq schema and the sibling `nfcore-sarek-wrapper` / `nfcore-rnaseq-wrapper`. Remote inputs are passed through **verbatim** — Nextflow resolves and stages them in the execution context — so the wrapper validates only the FASTQ/FASTA basename and defers existence to Nextflow (`samplesheet_builder.py`, `preflight.py`). Local-first is preserved: the wrapper never *exfiltrates* data; it only reads the user-specified inputs.
+**Local-first by default.** Samplesheet FASTQs and reference/index inputs must be local paths unless you explicitly opt in. Remote URIs (`s3://`, `gs://`, `https://`, `ftp://`, …) are **rejected** at preflight with `REMOTE_INPUT_NOT_ALLOWED`, so genetic data and references stay on the local machine and no accidental cloud fetch happens. This guarantee is enforced by the code, not just advertised (`preflight._check_remote_inputs`).
+
+**Opt-in for remote inputs.** Pass `--allow-remote-inputs` to permit remote samplesheet inputs and reference paths (parity with `nfcore-sarek-wrapper` / `nfcore-rnaseq-wrapper`, which share the same flag). When enabled, remote URIs are passed through **verbatim** (Nextflow resolves and stages them; only the FASTQ/FASTA basename is validated) and preflight emits a **runtime WARNING** listing every path that will be fetched over the network, so cloud access is always visible. The object-store `--work-dir` is a separate setting and is not gated.
 
 **Local** paths are still validated eagerly at preflight so they fail fast with a clear error instead of a late Nextflow error:
 - A supplied local reference/index path (`--fasta`, `--gtf`, `--star-index`, …) that does not exist raises `MISSING_REFERENCE` (`preflight.py`).
@@ -433,7 +435,7 @@ output_directory/
 
 ## Safety
 
-- **Local-first**: User FASTQs and outputs remain on the local filesystem.
+- **Local-first by default**: user FASTQs/references and outputs stay on the local filesystem. Remote input/reference URIs are rejected (`REMOTE_INPUT_NOT_ALLOWED`) unless `--allow-remote-inputs` is explicitly passed, which also logs a runtime warning naming every path fetched over the network.
 - **Strict preflight**: Nextflow is never invoked if validation fails.
 - **No hallucinated outputs**: Only artifacts confirmed on disk are reported.
 - **Disclaimer**: Every report includes the ClawBio medical disclaimer.

--- a/skills/nfcore-scrnaseq-wrapper/SKILL.md
+++ b/skills/nfcore-scrnaseq-wrapper/SKILL.md
@@ -167,7 +167,7 @@ Each preset requires at least one reference option: `--genome <iGenomes_shortcut
 This wrapper targets nf-core/scrnaseq `4.1.0`. It is not a free-form passthrough. Parameters are grouped as:
 
 - **Supported upstream parameters:** input/output, aligner/preset, reference/index, skip, CellRanger, CellRanger ARC, CellRanger Multi, selected MultiQC/reporting options.
-- **Wrapper policy parameters:** `--preset`, `--check`, `--run-downstream`, `--skip-downstream`, `--expected-cells`, `--timeout-hours`, `--work-dir`, `--allow-dirty-pipeline`, `--require-local-pipeline`, `--allow-pipeline-version-override`, `--trust-config-params`, `--allow-conda-cellranger`, and `-c/--config`; these are ClawBio conveniences and are not nf-core parameters.
+- **Wrapper policy parameters:** `--preset`, `--check`, `--run-downstream`, `--skip-downstream`, `--expected-cells`, `--timeout-hours`, `--work-dir`, `--allow-remote-inputs`, `--allow-dirty-pipeline`, `--require-local-pipeline`, `--allow-pipeline-version-override`, `--trust-config-params`, `--allow-conda-cellranger`, and `-c`/`--config`/`--nextflow-config`; these are ClawBio conveniences and are not nf-core parameters.
 - **Deprecated compatibility aliases:** `skip_emptydrops` is accepted only as `--skip-emptydrops` and translated to `skip_cellbender: true`; the deprecated upstream parameter is never written.
 - **Intentionally unsupported upstream parameters:** `custom_config_version`, `custom_config_base`, `config_profile_name`, `config_profile_description`, `config_profile_contact`, `config_profile_url`, `version`, `plaintext_email`, `max_multiqc_email_size`, `hook_url`, `validate_params`, `pipelines_testdata_base_path`, `help`, `help_full`, `show_hidden`.
 

--- a/skills/nfcore-scrnaseq-wrapper/_isolated_imports.py
+++ b/skills/nfcore-scrnaseq-wrapper/_isolated_imports.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SKILL_DIR = Path(__file__).resolve().parent
+
+
+def purge_foreign_bare_modules(*names: str) -> None:
+    """Drop cached top-level modules that do not belong to this skill.
+
+    The skill is executed as a bare script (``python nfcore_rnaseq_wrapper.py``),
+    so its modules are imported under top-level names like ``errors`` and
+    ``schemas``. A sibling skill that ships an identically-named ``errors.py`` /
+    ``schemas.py`` can therefore shadow ours when both run in one interpreter
+    (most visibly, the shared test session). Each module calls this guard before
+    importing its dependencies so the cache only ever holds *our* copy.
+
+    Centralised here (instead of copy-pasted into every module) so the isolation
+    rule has a single definition. Callers ``sys.modules.pop("_isolated_imports")``
+    before importing this module, so a foreign copy of this file cannot shadow it
+    either.
+    """
+    for name in names:
+        module = sys.modules.get(name)
+        module_file = Path(getattr(module, "__file__", "") or "")
+        if module is not None and _SKILL_DIR not in module_file.parents and module_file != _SKILL_DIR / f"{name}.py":
+            sys.modules.pop(name, None)

--- a/skills/nfcore-scrnaseq-wrapper/demo/README.md
+++ b/skills/nfcore-scrnaseq-wrapper/demo/README.md
@@ -1,7 +1,9 @@
-This skill uses the upstream `scrnaseq` pipeline test profile for demo mode.
-
-Run:
+# nfcore-scrnaseq-wrapper — demo
 
 ```bash
-python clawbio.py run scrnaseq-pipeline --demo --output ./outputs/scrnaseq_demo
+python clawbio.py run scrnaseq-pipeline --demo --output /tmp/scrnaseq_demo
 ```
+
+Uses the upstream nf-core/scrnaseq `-profile test` dataset (no local files
+required; no real patient or sample data is bundled in this repository).
+Requires Docker (running) + Nextflow >=25.04.0.

--- a/skills/nfcore-scrnaseq-wrapper/errors.py
+++ b/skills/nfcore-scrnaseq-wrapper/errors.py
@@ -30,7 +30,13 @@ class ErrorCode:
     MISSING_INPUT = "MISSING_INPUT"
     MISSING_FASTQ = "MISSING_FASTQ"
     INVALID_FASTQ = "INVALID_FASTQ"
-    FASTQ_NOT_READABLE = "FASTQ_NOT_READABLE"
+    # NOTE: input readability is intentionally NOT pre-checked. The wrapper does not
+    # read the FASTQ data — Nextflow does, and under the default Docker profile the
+    # container often runs as root and can read files the launching user cannot, so an
+    # os.access(R_OK) pre-check by the launcher would false-block valid runs. Output
+    # *writability* IS checked (OUTPUT_DIR_NOT_WRITABLE) because the wrapper itself writes
+    # there. Existence of inputs is validated (MISSING_FASTQ); readability is deferred to
+    # Nextflow's staging, which reads in the true execution context.
     INVALID_SAMPLESHEET = "INVALID_SAMPLESHEET"
     OUTPUT_DIR_NOT_EMPTY = "OUTPUT_DIR_NOT_EMPTY"
     OUTPUT_DIR_NOT_WRITABLE = "OUTPUT_DIR_NOT_WRITABLE"

--- a/skills/nfcore-scrnaseq-wrapper/errors.py
+++ b/skills/nfcore-scrnaseq-wrapper/errors.py
@@ -38,6 +38,10 @@ class ErrorCode:
     # there. Existence of inputs is validated (MISSING_FASTQ); readability is deferred to
     # Nextflow's staging, which reads in the true execution context.
     INVALID_SAMPLESHEET = "INVALID_SAMPLESHEET"
+    # Remote input/reference URIs (s3://, gs://, https://, ftp://, …) are rejected by
+    # default (local-first); they are only allowed with --allow-remote-inputs, which
+    # also emits a runtime warning that data is being fetched over the network.
+    REMOTE_INPUT_NOT_ALLOWED = "REMOTE_INPUT_NOT_ALLOWED"
     OUTPUT_DIR_NOT_EMPTY = "OUTPUT_DIR_NOT_EMPTY"
     OUTPUT_DIR_NOT_WRITABLE = "OUTPUT_DIR_NOT_WRITABLE"
     MISSING_REFERENCE = "MISSING_REFERENCE"

--- a/skills/nfcore-scrnaseq-wrapper/executor.py
+++ b/skills/nfcore-scrnaseq-wrapper/executor.py
@@ -7,8 +7,13 @@ import sys
 from pathlib import Path
 
 _SKILL_DIR = Path(__file__).resolve().parent
-if str(_SKILL_DIR) not in sys.path:
-    sys.path.insert(0, str(_SKILL_DIR))
+if str(_SKILL_DIR) in sys.path:
+    sys.path.remove(str(_SKILL_DIR))
+sys.path.insert(0, str(_SKILL_DIR))
+sys.modules.pop("_isolated_imports", None)
+from _isolated_imports import purge_foreign_bare_modules
+
+purge_foreign_bare_modules("errors", "schemas")
 
 from errors import ErrorCode, SkillError
 from schemas import is_under_tmp

--- a/skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py
+++ b/skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py
@@ -309,6 +309,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Nextflow work directory. Defaults to <output>/upstream/work; may be an object-store URI for cloud executors.",
     )
     parser.add_argument(
+        "--allow-remote-inputs",
+        action="store_true",
+        help=(
+            "Opt in to remote samplesheet inputs and reference paths (s3://, gs://, "
+            "https://, ftp://, …). Default is local-first: remote URIs are rejected so "
+            "genetic data and references stay on the local machine. When enabled, a "
+            "runtime warning lists the paths fetched over the network."
+        ),
+    )
+    parser.add_argument(
         "--allow-conda-cellranger",
         action="store_true",
         help="Allow Cell Ranger presets with conda/mamba only when a trusted site config supplies Cell Ranger.",

--- a/skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py
+++ b/skills/nfcore-scrnaseq-wrapper/nfcore_scrnaseq_wrapper.py
@@ -16,11 +16,31 @@ from pathlib import Path
 from typing import Any
 
 _SKILL_DIR = Path(__file__).resolve().parent
-if str(_SKILL_DIR) not in sys.path:
-    sys.path.insert(0, str(_SKILL_DIR))
+if str(_SKILL_DIR) in sys.path:
+    sys.path.remove(str(_SKILL_DIR))
+sys.path.insert(0, str(_SKILL_DIR))
 _PROJECT_ROOT = _SKILL_DIR.parent.parent
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
+
+sys.modules.pop("_isolated_imports", None)
+from _isolated_imports import purge_foreign_bare_modules
+
+purge_foreign_bare_modules(
+    "command_builder",
+    "errors",
+    "executor",
+    "nfcore_4_1_0_contract",
+    "outputs_parser",
+    "params_builder",
+    "pipeline_source",
+    "preflight",
+    "provenance",
+    "reporting",
+    "repro_commands",
+    "samplesheet_builder",
+    "schemas",
+)
 
 from clawbio.common.textio import write_text_lf
 from command_builder import build_nextflow_command
@@ -155,6 +175,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Run the scrnaseq pipeline through a ClawBio wrapper."
     )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose logging")
+    parser.add_argument(
+        "--no-banner", action="store_true", help="Suppress the startup banner"
+    )
     parser.add_argument("--input", help="Path to a valid samplesheet.csv")
     parser.add_argument(
         "--output", required=True, help="Output directory for the wrapper results"
@@ -206,10 +230,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-c",
         "--config",
+        "--nextflow-config",
         dest="extra_config",
         action="append",
         default=[],
-        help="Additional Nextflow config file; may be supplied multiple times for HPC/cloud profiles",
+        help="Additional Nextflow config file (alias: --nextflow-config); may be supplied multiple times for HPC/cloud profiles",
     )
     parser.add_argument(
         "--preset",
@@ -528,9 +553,29 @@ def _write_error_result_if_safe(output_dir: Path, payload: dict[str, object]) ->
         return
 
 
-def main() -> int:
+_BANNER = (
+    "==============================================\n"
+    f"  ClawBio :: {SKILL_NAME}\n"
+    f"  nf-core/scrnaseq {NFCORE_SCRNASEQ_VERSION} orchestrator\n"
+    "=============================================="
+)
+
+
+def _print(msg: str) -> None:
+    """Log a human-readable status line to stdout (progress/traceability)."""
+    print(msg, flush=True)
+
+
+def _indent(text: str, n: int) -> str:
+    pad = " " * n
+    return "\n".join(pad + line for line in text.splitlines())
+
+
+def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
+    if not getattr(args, "no_banner", False):
+        _print(_BANNER)
     output_dir = Path(args.output).expanduser().resolve()
 
     try:
@@ -538,9 +583,14 @@ def main() -> int:
         _check_pipeline_version_supported(args)
         return _run_wrapper(args, output_dir)
     except SkillError as exc:
-        return _handle_skill_error(output_dir, exc)
+        return _handle_skill_error(output_dir, exc, verbose=getattr(args, "verbose", False))
+    except KeyboardInterrupt:
+        _print("[abort] Interrupted by user.")
+        return 130
     except Exception as exc:
-        return _handle_unexpected_error(output_dir, exc)
+        return _handle_unexpected_error(
+            output_dir, exc, verbose=getattr(args, "verbose", False)
+        )
 
 
 def _check_pipeline_version_supported(args: argparse.Namespace) -> None:
@@ -643,6 +693,10 @@ def _run_wrapper_with_staging(
     )
     preflight_result = run_preflight(
         args, pipeline_source=pipeline_source, samplesheet_summary=samplesheet_summary
+    )
+    _print(
+        "[preflight] passed "
+        f"(warnings: {len(preflight_result.get('warnings', []) or [])})"
     )
     if args.check:
         return _write_check_mode_result(
@@ -781,6 +835,7 @@ def _write_check_mode_result(
         "parameter_support": _build_parameter_support_summary(),
     }
     write_check_result(output_dir, payload)
+    _print("[check] Preflight passed. No pipeline was launched (--check).")
     print(json.dumps(payload, indent=2))
     return 0
 
@@ -839,14 +894,22 @@ def _run_execution_mode(
         args, output_dir, pipeline_source, params_path
     )
     nextflow_cwd = _nextflow_execution_cwd(output_dir)
+    _print(
+        f"[execute] launching Nextflow "
+        f"({pipeline_source['source_kind']} → {pipeline_source['resolved_version']})"
+    )
     execution_result = execute_nextflow(
         command,
         cwd=nextflow_cwd,
         output_dir=output_dir,
         timeout_seconds=_resolve_timeout_seconds(args),
     )
+    _print("[execute] completed")
+    _print("[outputs] parsing pipeline outputs")
     parsed_outputs = _parse_outputs_with_effective_aligner(output_dir, args)
     _raise_if_expected_outputs_missing(parsed_outputs, output_dir=output_dir)
+    _print("[report] writing report.md, result.json, commands.sh")
+    _print("[provenance] writing reproducibility bundle")
     _write_success_outputs(
         output_dir,
         args=args,
@@ -861,7 +924,7 @@ def _run_execution_mode(
         command_str=_nextflow_replay_command(command_str, nextflow_cwd),
     )
     _run_downstream_handoff(args, parsed_outputs=parsed_outputs, output_dir=output_dir)
-    print(f"Wrapper completed successfully. Output: {output_dir}")
+    _print(f"[done] Wrapper completed successfully. Output: {output_dir}")
     return 0
 
 
@@ -1168,14 +1231,31 @@ def _write_handoff_provenance(output_dir: Path, record: dict[str, object]) -> No
     write_text_lf(provenance_dir / "handoff.json", json.dumps(record, indent=2))
 
 
-def _handle_skill_error(output_dir: Path, exc: SkillError) -> int:
+def _handle_skill_error(
+    output_dir: Path, exc: SkillError, *, verbose: bool = False
+) -> int:
     payload = exc.to_dict()
     _write_error_result_if_safe(output_dir, payload)
+    # Human-readable box on stdout (sarek-style traceability).
+    _print("")
+    _print("================ SkillError ================")
+    _print(f"  stage:   {exc.stage}")
+    _print(f"  code:    {exc.error_code}")
+    _print(f"  message: {exc.message}")
+    _print(f"  fix:     {exc.fix}")
+    if exc.details and verbose:
+        _print("  details:")
+        _print(_indent(json.dumps(exc.details, indent=2, default=str), 4))
+    _print("============================================")
+    # Machine-readable error on stderr: always available even when result.json
+    # cannot be written (e.g. the output dir is a file or inside the repo).
     print(json.dumps(payload, indent=2), file=sys.stderr)
     return 1
 
 
-def _handle_unexpected_error(output_dir: Path, exc: Exception) -> int:
+def _handle_unexpected_error(
+    output_dir: Path, exc: Exception, *, verbose: bool = False
+) -> int:
     payload = {
         "ok": False,
         "stage": "internal",
@@ -1188,6 +1268,16 @@ def _handle_unexpected_error(output_dir: Path, exc: Exception) -> int:
         },
     }
     _write_error_result_if_safe(output_dir, payload)
+    _print("")
+    _print("================ Internal error ================")
+    _print(f"  type:    {type(exc).__name__}")
+    _print(f"  message: {exc}")
+    if verbose:
+        _print(_indent(traceback.format_exc(), 4))
+    else:
+        _print("  Re-run with --verbose for the full traceback.")
+    _print("================================================")
+    # Machine-readable error on stderr (always available; see _handle_skill_error).
     print(json.dumps(payload, indent=2), file=sys.stderr)
     return 1
 

--- a/skills/nfcore-scrnaseq-wrapper/outputs_parser.py
+++ b/skills/nfcore-scrnaseq-wrapper/outputs_parser.py
@@ -5,8 +5,13 @@ import sys
 from pathlib import Path
 
 _SKILL_DIR = Path(__file__).resolve().parent
-if str(_SKILL_DIR) not in sys.path:
-    sys.path.insert(0, str(_SKILL_DIR))
+if str(_SKILL_DIR) in sys.path:
+    sys.path.remove(str(_SKILL_DIR))
+sys.path.insert(0, str(_SKILL_DIR))
+sys.modules.pop("_isolated_imports", None)
+from _isolated_imports import purge_foreign_bare_modules
+
+purge_foreign_bare_modules("errors", "nfcore_4_1_0_contract")
 
 from errors import ErrorCode, SkillError
 from nfcore_4_1_0_contract import (

--- a/skills/nfcore-scrnaseq-wrapper/params_builder.py
+++ b/skills/nfcore-scrnaseq-wrapper/params_builder.py
@@ -9,8 +9,13 @@ import yaml
 from clawbio.common.textio import write_text_lf
 
 _SKILL_DIR = Path(__file__).resolve().parent
-if str(_SKILL_DIR) not in sys.path:
-    sys.path.insert(0, str(_SKILL_DIR))
+if str(_SKILL_DIR) in sys.path:
+    sys.path.remove(str(_SKILL_DIR))
+sys.path.insert(0, str(_SKILL_DIR))
+sys.modules.pop("_isolated_imports", None)
+from _isolated_imports import purge_foreign_bare_modules
+
+purge_foreign_bare_modules("errors", "schemas")
 
 from errors import ErrorCode, SkillError
 from schemas import (

--- a/skills/nfcore-scrnaseq-wrapper/pipeline_source.py
+++ b/skills/nfcore-scrnaseq-wrapper/pipeline_source.py
@@ -5,8 +5,13 @@ import sys
 from pathlib import Path
 
 _SKILL_DIR = Path(__file__).resolve().parent
-if str(_SKILL_DIR) not in sys.path:
-    sys.path.insert(0, str(_SKILL_DIR))
+if str(_SKILL_DIR) in sys.path:
+    sys.path.remove(str(_SKILL_DIR))
+sys.path.insert(0, str(_SKILL_DIR))
+sys.modules.pop("_isolated_imports", None)
+from _isolated_imports import purge_foreign_bare_modules
+
+purge_foreign_bare_modules("errors", "schemas")
 
 from errors import ErrorCode, SkillError
 from schemas import (

--- a/skills/nfcore-scrnaseq-wrapper/preflight.py
+++ b/skills/nfcore-scrnaseq-wrapper/preflight.py
@@ -467,6 +467,47 @@ _SYMBOLIC_REFERENCE_FIELDS = frozenset(SYMBOLIC_REFERENCE_FIELDS)
 _EXPLICIT_REFERENCE_FIELDS = ALL_REFERENCE_PATH_FIELDS
 
 
+def _check_remote_inputs(args, samplesheet_summary: dict[str, Any]) -> None:
+    """Local-first by default: reject remote input/reference URIs (s3://, gs://,
+    https://, ftp://, …) unless ``--allow-remote-inputs`` is set, in which case
+    warn that genetic data will be fetched over the network. The object-store
+    ``--work-dir`` is a separate, intentionally-remote setting and is not gated."""
+    remote: list[str] = []
+    for key in ("fastq_paths", "bam_paths", "cram_paths"):
+        for path in samplesheet_summary.get(key, []) or []:
+            if "://" in str(path):
+                remote.append(str(path))
+    for field in _EXPLICIT_REFERENCE_FIELDS:
+        value = getattr(args, field, None)
+        if value and "://" in str(value):
+            remote.append(str(value))
+    if not remote:
+        return
+    unique = sorted(set(remote))
+    if getattr(args, "allow_remote_inputs", False):
+        print(
+            "WARNING: --allow-remote-inputs is set; "
+            f"{len(unique)} input/reference path(s) will be fetched over the network, "
+            "so genetic data may leave the local machine: " + ", ".join(unique),
+            file=sys.stderr,
+        )
+        return
+    raise SkillError(
+        stage="preflight",
+        error_code=ErrorCode.REMOTE_INPUT_NOT_ALLOWED,
+        message=(
+            "Remote input/reference URIs are not allowed by default (local-first); "
+            f"detected {len(unique)} remote path(s)."
+        ),
+        fix=(
+            "Download the data locally and use local paths, or pass "
+            "--allow-remote-inputs to fetch them over the network at your own risk "
+            "(genetic data will leave the local machine)."
+        ),
+        details={"remote_paths": unique},
+    )
+
+
 def _check_references(args) -> dict[str, str]:
     resolved = _collect_reference_values(args)
     _reject_conflicting_reference_styles(resolved)
@@ -769,6 +810,7 @@ def run_preflight(
     samplesheet_summary: dict[str, Any],
 ) -> dict[str, object]:
     _warn_if_native_windows()
+    _check_remote_inputs(args, samplesheet_summary)
     _check_supported_preset(args.preset)
     _check_parameter_schema_compatibility(args)
     _check_protocol_compatibility(args)

--- a/skills/nfcore-scrnaseq-wrapper/preflight.py
+++ b/skills/nfcore-scrnaseq-wrapper/preflight.py
@@ -11,8 +11,13 @@ from pathlib import Path
 from typing import Any
 
 _SKILL_DIR = Path(__file__).resolve().parent
-if str(_SKILL_DIR) not in sys.path:
-    sys.path.insert(0, str(_SKILL_DIR))
+if str(_SKILL_DIR) in sys.path:
+    sys.path.remove(str(_SKILL_DIR))
+sys.path.insert(0, str(_SKILL_DIR))
+sys.modules.pop("_isolated_imports", None)
+from _isolated_imports import purge_foreign_bare_modules
+
+purge_foreign_bare_modules("errors", "nfcore_4_1_0_contract", "schemas")
 
 from errors import ErrorCode, SkillError
 from nfcore_4_1_0_contract import (
@@ -554,6 +559,11 @@ def _check_reference_paths_exist(resolved: dict[str, str]) -> None:
     for key, value in resolved.items():
         if key in _SYMBOLIC_REFERENCE_FIELDS:
             continue  # symbolic identifiers, not local paths
+        if value and "://" in value:
+            # Remote URI (s3://, gs://, https://, …): Nextflow resolves it at runtime,
+            # so existence is not pre-checked here. Matches nfcore-rnaseq/sarek and the
+            # nf-core schema, which types references as strings Nextflow may fetch.
+            continue
         _check_upstream_path_schema_compatibility(key, value)
         if value and not Path(value).expanduser().exists():
             raise SkillError(

--- a/skills/nfcore-scrnaseq-wrapper/preflight.py
+++ b/skills/nfcore-scrnaseq-wrapper/preflight.py
@@ -477,8 +477,8 @@ def _check_remote_inputs(args, samplesheet_summary: dict[str, Any]) -> None:
         for path in samplesheet_summary.get(key, []) or []:
             if "://" in str(path):
                 remote.append(str(path))
-    for field in _EXPLICIT_REFERENCE_FIELDS:
-        value = getattr(args, field, None)
+    for ref_field in _EXPLICIT_REFERENCE_FIELDS:
+        value = getattr(args, ref_field, None)
         if value and "://" in str(value):
             remote.append(str(value))
     if not remote:

--- a/skills/nfcore-scrnaseq-wrapper/provenance.py
+++ b/skills/nfcore-scrnaseq-wrapper/provenance.py
@@ -11,8 +11,13 @@ from clawbio.common.checksums import sha256_file
 from clawbio.common.reproducibility import write_checksums, write_environment_yml
 
 _SKILL_DIR = Path(__file__).resolve().parent
-if str(_SKILL_DIR) not in sys.path:
-    sys.path.insert(0, str(_SKILL_DIR))
+if str(_SKILL_DIR) in sys.path:
+    sys.path.remove(str(_SKILL_DIR))
+sys.path.insert(0, str(_SKILL_DIR))
+sys.modules.pop("_isolated_imports", None)
+from _isolated_imports import purge_foreign_bare_modules
+
+purge_foreign_bare_modules("schemas")
 
 from clawbio.common.textio import write_text_lf
 from schemas import DEFAULT_REMOTE_PIPELINE, SKILL_ALIAS, SKILL_NAME, SKILL_VERSION
@@ -210,8 +215,13 @@ def build_inputs_payload(
         "sample_count": samplesheet_summary["sample_count"],
         # fastq_paths and reference_paths are deliberately kept absolute: they point
         # to external data outside the bundle and are remapped by remap_paths.py on
-        # replay, not relativised against the output dir.
-        "fastq_paths": [Path(p).as_posix() for p in samplesheet_summary["fastq_paths"]],
+        # replay, not relativised against the output dir. Remote URIs (s3://, https://,
+        # …) are preserved verbatim — Path().as_posix() would collapse the `//` scheme
+        # separator and corrupt them.
+        "fastq_paths": [
+            str(p) if "://" in str(p) else Path(p).as_posix()
+            for p in samplesheet_summary["fastq_paths"]
+        ],
         "reference_paths": preflight_result.get("references", {}),
         # Reference *file* digests are recorded here (provenance) rather than in
         # checksums.sha256, because references live outside the bundle: putting

--- a/skills/nfcore-scrnaseq-wrapper/reporting.py
+++ b/skills/nfcore-scrnaseq-wrapper/reporting.py
@@ -16,8 +16,13 @@ from clawbio.common.report import (
 from clawbio.common.textio import write_text_lf
 
 _SKILL_DIR = Path(__file__).resolve().parent
-if str(_SKILL_DIR) not in sys.path:
-    sys.path.insert(0, str(_SKILL_DIR))
+if str(_SKILL_DIR) in sys.path:
+    sys.path.remove(str(_SKILL_DIR))
+sys.path.insert(0, str(_SKILL_DIR))
+sys.modules.pop("_isolated_imports", None)
+from _isolated_imports import purge_foreign_bare_modules
+
+purge_foreign_bare_modules("repro_commands", "schemas")
 
 from repro_commands import build_nextflow_commands_sh, write_macos_docker_config
 from schemas import (

--- a/skills/nfcore-scrnaseq-wrapper/repro_commands.py
+++ b/skills/nfcore-scrnaseq-wrapper/repro_commands.py
@@ -22,8 +22,13 @@ from typing import Any
 from clawbio.common.textio import write_text_lf
 
 _SKILL_DIR = Path(__file__).resolve().parent
-if str(_SKILL_DIR) not in sys.path:
-    sys.path.insert(0, str(_SKILL_DIR))
+if str(_SKILL_DIR) in sys.path:
+    sys.path.remove(str(_SKILL_DIR))
+sys.path.insert(0, str(_SKILL_DIR))
+sys.modules.pop("_isolated_imports", None)
+from _isolated_imports import purge_foreign_bare_modules
+
+purge_foreign_bare_modules("nfcore_4_1_0_contract")
 
 from nfcore_4_1_0_contract import MACOS_DEMO_RESOURCE_LIMITS, STAR_ALIGN_BASE_EXT_ARGS
 

--- a/skills/nfcore-scrnaseq-wrapper/samplesheet_builder.py
+++ b/skills/nfcore-scrnaseq-wrapper/samplesheet_builder.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
 import csv
-import os
 import re
 import sys
 from pathlib import Path
 from typing import cast
 
 _SKILL_DIR = Path(__file__).resolve().parent
-if str(_SKILL_DIR) not in sys.path:
-    sys.path.insert(0, str(_SKILL_DIR))
+if str(_SKILL_DIR) in sys.path:
+    sys.path.remove(str(_SKILL_DIR))
+sys.path.insert(0, str(_SKILL_DIR))
+sys.modules.pop("_isolated_imports", None)
+from _isolated_imports import purge_foreign_bare_modules
+
+purge_foreign_bare_modules("errors", "nfcore_4_1_0_contract", "schemas")
 
 from errors import ErrorCode, SkillError
 from nfcore_4_1_0_contract import CELLRANGER_FAMILY_PRESETS
@@ -37,6 +41,29 @@ _FASTQ_SUFFIXES = (".fastq.gz", ".fq.gz")
 _BASE_OUTPUT_COLUMNS = ("sample", "fastq_1", "fastq_2", "expected_cells", "seq_center")
 _REQUIRED_FASTQ_COLUMNS = ("fastq_1", "fastq_2")
 _OPTIONAL_FASTQ_COLUMNS = ("fastq_barcode",)
+
+# A resolved FASTQ value is either a normalized local Path or a remote URI kept
+# verbatim as a str (s3://, gs://, https://, …). nf-core/scrnaseq supports remote
+# inputs and Nextflow stages them in the execution context, so — matching
+# nfcore-sarek-wrapper and nfcore-rnaseq-wrapper — the wrapper passes remote URIs
+# through unchanged and validates only their basename, deferring existence to
+# Nextflow. Local-first (no data exfiltration) is preserved: this only *reads*
+# user-specified inputs.
+_ResolvedPath = Path | str
+
+
+def _is_remote_uri(value: str) -> bool:
+    return bool(_REMOTE_URI_RE.match(str(value)))
+
+
+def _resolved_name(value: _ResolvedPath) -> str:
+    """Basename of a resolved FASTQ path or remote URI."""
+    return Path(str(value)).name
+
+
+def _resolved_output(value: _ResolvedPath) -> str:
+    """Output-samplesheet string: remote URIs verbatim, local paths as posix."""
+    return value if isinstance(value, str) else value.as_posix()
 
 
 def validate_and_normalize_samplesheet(
@@ -229,7 +256,7 @@ def _normalize_rows(
 ) -> tuple[list[dict[str, str]], list[str], list[Path]]:
     normalized_rows: list[dict[str, str]] = []
     sample_names: list[str] = []
-    fastq_paths: list[Path] = []
+    fastq_paths: list[_ResolvedPath] = []
     seen_rows: set[tuple[str, str, str]] = set()
     raw_samples_by_normalized_sample: dict[str, str] = {}
     metadata_by_sample: dict[str, dict[str, str]] = {}
@@ -280,8 +307,8 @@ def _normalize_samplesheet_row(
     normalized.update(
         {
             "sample": sample,
-            "fastq_1": resolved_fastqs["fastq_1"].as_posix(),
-            "fastq_2": resolved_fastqs["fastq_2"].as_posix(),
+            "fastq_1": _resolved_output(resolved_fastqs["fastq_1"]),
+            "fastq_2": _resolved_output(resolved_fastqs["fastq_2"]),
             "expected_cells": expected_cells,
             "seq_center": str(row.get("seq_center", "")).strip(),
         }
@@ -292,7 +319,7 @@ def _normalize_samplesheet_row(
         normalized["feature_type"] = feature_type
     for optional_fastq in _optional_fastq_columns_for_preset(preset):
         if optional_fastq in resolved_fastqs:
-            normalized[optional_fastq] = resolved_fastqs[optional_fastq].as_posix()
+            normalized[optional_fastq] = _resolved_output(resolved_fastqs[optional_fastq])
     return normalized, sample, resolved_fastqs
 
 
@@ -384,7 +411,7 @@ def _resolve_fastq_columns(
     line_number: int,
     input_path: Path,
     preset: str | None,
-) -> dict[str, Path]:
+) -> dict[str, _ResolvedPath]:
     resolved = {
         column: _resolve_required_fastq(
             row, column, line_number=line_number, input_path=input_path
@@ -410,7 +437,7 @@ def _resolve_fastq_columns(
 
 def _resolve_required_fastq(
     row: dict[str, str], column: str, *, line_number: int, input_path: Path
-) -> Path:
+) -> _ResolvedPath:
     raw_value = str(row.get(column, "")).strip()
     if not raw_value:
         _raise_missing_fastq_column(column, line_number)
@@ -468,15 +495,13 @@ def _looks_like_fastq_path(value: str) -> bool:
 
 def _resolve_existing_fastq(
     raw_path: str, column: str, *, line_number: int, input_path: Path
-) -> Path:
-    if _REMOTE_URI_RE.match(raw_path):
-        raise SkillError(
-            stage="validation",
-            error_code=ErrorCode.INVALID_SAMPLESHEET,
-            message="Remote FASTQ URIs are not supported by this local-first wrapper.",
-            fix="Download FASTQs locally first, then point the samplesheet to local paths.",
-            details={"line": line_number, "column": column, "path": raw_path},
-        )
+) -> _ResolvedPath:
+    # Remote URIs (s3://, gs://, https://, …) are passed through verbatim: nf-core
+    # supports remote inputs and Nextflow stages them in the execution context, so
+    # the wrapper validates only the basename and defers existence to Nextflow.
+    if _is_remote_uri(raw_path):
+        _validate_fastq_path(raw_path, raw_path, column, line_number)
+        return raw_path
     fastq_path = Path(raw_path).expanduser()
     fastq_path = (
         (input_path.parent / fastq_path).resolve()
@@ -488,8 +513,26 @@ def _resolve_existing_fastq(
 
 
 def _validate_fastq_path(
-    fastq_path: Path, raw_path: str, column: str, line_number: int
+    value: _ResolvedPath, raw_path: str, column: str, line_number: int
 ) -> None:
+    # Remote URI: validate the basename only; existence/readability are deferred to
+    # Nextflow staging (it reads in the true execution context).
+    if _is_remote_uri(raw_path):
+        if not _FASTQ_BASENAME_RE.match(_resolved_name(value)):
+            raise SkillError(
+                stage="validation",
+                error_code=ErrorCode.INVALID_FASTQ,
+                message="FASTQ filenames must match the nf-core/scrnaseq schema.",
+                fix="Use a basename without whitespace and with lowercase .fastq.gz or .fq.gz extension.",
+                details={
+                    "line": line_number,
+                    "column": column,
+                    "path": raw_path,
+                    "filename": _resolved_name(value),
+                },
+            )
+        return
+    fastq_path = value  # local Path
     if not fastq_path.exists():
         raise SkillError(
             stage="validation",
@@ -514,23 +557,20 @@ def _validate_fastq_path(
     if not fastq_path.is_file():
         raise SkillError(
             stage="validation",
-            error_code=ErrorCode.FASTQ_NOT_READABLE,
-            message="A FASTQ path does not point to a readable file.",
-            fix="Ensure the FASTQ path refers to a regular file.",
+            error_code=ErrorCode.MISSING_FASTQ,
+            message="A FASTQ path exists but does not point to a regular file.",
+            fix="Ensure the FASTQ path refers to a regular file, not a directory.",
             details={"line": line_number, "column": column, "path": raw_path},
         )
-    if not os.access(fastq_path, os.R_OK):
-        raise SkillError(
-            stage="validation",
-            error_code=ErrorCode.FASTQ_NOT_READABLE,
-            message="A FASTQ file exists but is not readable by the current user.",
-            fix="Check file permissions and ensure the file is readable.",
-            details={"line": line_number, "column": column, "path": raw_path},
-        )
+    # NOTE: readability is intentionally NOT pre-checked here. Nextflow reads the FASTQ
+    # data in the execution context (often a root container under the default Docker
+    # profile), so an os.access(R_OK) pre-check by the launching user would false-block
+    # valid runs. Existence + regular-file type are validated; readability is deferred to
+    # Nextflow's staging. (Mirrors nfcore-rnaseq-wrapper's documented policy.)
 
 
 def _validate_preset_fastq_naming(
-    resolved_fastqs: dict[str, Path],
+    resolved_fastqs: dict[str, _ResolvedPath],
     *,
     preset: str | None,
     line_number: int,
@@ -552,10 +592,10 @@ def _validate_preset_fastq_naming(
 
 
 def _validate_cellranger_fastq_pair(
-    resolved_fastqs: dict[str, Path], *, line_number: int
+    resolved_fastqs: dict[str, _ResolvedPath], *, line_number: int
 ) -> None:
-    r1_name = resolved_fastqs["fastq_1"].name
-    r2_name = resolved_fastqs["fastq_2"].name
+    r1_name = _resolved_name(resolved_fastqs["fastq_1"])
+    r2_name = _resolved_name(resolved_fastqs["fastq_2"])
     r1_key = _cellranger_pair_key(r1_name, expected_marker="_R1")
     r2_key = _cellranger_pair_key(r2_name, expected_marker="_R2")
     if r1_key and r1_key == r2_key:
@@ -582,10 +622,10 @@ def _cellranger_pair_key(filename: str, *, expected_marker: str) -> str:
 
 
 def _validate_cellrangerarc_fastq_names(
-    resolved_fastqs: dict[str, Path], *, line_number: int
+    resolved_fastqs: dict[str, _ResolvedPath], *, line_number: int
 ) -> None:
     for column, fastq_path in resolved_fastqs.items():
-        if _TENX_FASTQ_RE.match(fastq_path.name):
+        if _TENX_FASTQ_RE.match(_resolved_name(fastq_path)):
             continue
         raise SkillError(
             stage="validation",
@@ -599,7 +639,7 @@ def _validate_cellrangerarc_fastq_names(
                 "line": line_number,
                 "preset": "cellrangerarc",
                 "column": column,
-                "filename": fastq_path.name,
+                "filename": _resolved_name(fastq_path),
             },
         )
 
@@ -685,12 +725,12 @@ def _reject_duplicate_fastq_row(
     seen_rows: set[tuple[str, str, str]],
     line_number: int,
     sample: str,
-    resolved_fastqs: dict[str, Path],
+    resolved_fastqs: dict[str, _ResolvedPath],
 ) -> None:
     row_key = (
         sample,
-        resolved_fastqs["fastq_1"].as_posix(),
-        resolved_fastqs["fastq_2"].as_posix(),
+        _resolved_output(resolved_fastqs["fastq_1"]),
+        _resolved_output(resolved_fastqs["fastq_2"]),
     )
     if row_key in seen_rows:
         raise SkillError(

--- a/skills/nfcore-scrnaseq-wrapper/tests/conftest.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/conftest.py
@@ -1,13 +1,19 @@
-"""conftest.py — ensure the skill directory is importable for tests.
+"""conftest.py — make this wrapper's test suite order-independent.
 
-Mirrors the sibling ``nfcore-sarek-wrapper`` conftest so both wrappers set up
-imports identically. NOTE: this skill ships its modules under bare top-level
-names (``errors``, ``schemas``, ``outputs_parser``, ``reporting``, …), as do
-several sibling skills in this monorepo. Run this skill's tests on their own
-(``pytest skills/nfcore-scrnaseq-wrapper/tests``), which is how CI runs them; a
-single ``pytest`` session that also collects a sibling skill's tests can hit
-bare-name module shadowing at collection time (a monorepo-wide property of the
-shared ``testpaths`` list, not a defect in this skill).
+Several nf-core wrapper skills in this monorepo ship their modules under bare
+top-level names (``errors``, ``schemas``, ``preflight``, …). A single pytest
+session that collects more than one wrapper suite (the repo-wide ``testpaths``
+list / ``make test``) can therefore hit cross-skill module shadowing — a test
+importing ``from errors import SkillError`` could bind a sibling wrapper's class.
+
+We force THIS skill's directory to the front of ``sys.path`` and purge any
+foreign cached copies of the bare module names — once at import time (so each
+test file's *module-level* sibling imports bind this wrapper's classes during
+collection) and again before every test via the ``pytest_runtest_setup`` hook,
+which runs before fixtures, so the function-scoped module fixtures and any
+*runtime* ``from errors import`` inside a test body also resolve to this
+wrapper. This gives the order-immunity ``nfcore-rnaseq-wrapper`` achieves while
+keeping the rule in one place instead of copy-pasted into every test file.
 """
 from __future__ import annotations
 
@@ -16,6 +22,77 @@ from pathlib import Path
 
 _SKILL_DIR = Path(__file__).resolve().parent.parent
 _TESTS_DIR = Path(__file__).resolve().parent
-for path in (_SKILL_DIR, _TESTS_DIR):
-    if str(path) not in sys.path:
+
+# Bare top-level module names shipped by the nf-core wrapper skills. Purging a
+# name this wrapper does not ship is a no-op (only *foreign* cached copies are
+# dropped), so one shared list is safe across all three wrappers.
+_BARE_MODULES = (
+    "errors",
+    "schemas",
+    "preflight",
+    "params_builder",
+    "command_builder",
+    "samplesheet_builder",
+    "outputs_parser",
+    "provenance",
+    "reporting",
+    "executor",
+    "pipeline_source",
+    "remap_paths",
+    "repro_commands",
+    "nfcore_4_1_0_contract",
+    "_isolated_imports",
+)
+
+
+# Canonical object cache: the first time this skill's copy of a bare module is
+# seen in sys.modules, we remember that exact module object. When a *foreign*
+# wrapper later caches the same bare name, we restore our canonical object rather
+# than purging + reimporting — reimporting would create a NEW module object whose
+# ``SkillError`` class differs from the one already-loaded skill modules bound,
+# breaking ``pytest.raises(SkillError)`` identity checks. Restoring the same object
+# keeps the whole skill (modules + tests) sharing one class identity.
+_CANONICAL: dict[str, object] = {}
+
+
+def _claim_local_modules() -> None:
+    """Force this skill dir to the front of sys.path and ensure each bare module
+    name resolves to THIS skill's canonical object."""
+    for path in (_TESTS_DIR, _SKILL_DIR):
+        if str(path) in sys.path:
+            sys.path.remove(str(path))
         sys.path.insert(0, str(path))
+    for name in _BARE_MODULES:
+        module = sys.modules.get(name)
+        if module is not None:
+            module_file = Path(getattr(module, "__file__", "") or "")
+            local = (
+                module_file == _SKILL_DIR / f"{name}.py"
+                or _SKILL_DIR in module_file.parents
+            )
+            if local:
+                _CANONICAL[name] = module  # remember our canonical object
+                continue
+        # Foreign (or absent): restore our canonical object if we have one,
+        # otherwise drop the foreign copy so the next import loads ours.
+        if name in _CANONICAL:
+            sys.modules[name] = _CANONICAL[name]
+        elif module is not None:
+            sys.modules.pop(name, None)
+
+
+_claim_local_modules()
+
+
+def pytest_collectstart(collector):  # noqa: ARG001 - pytest hook signature
+    # Re-claim immediately before each test module in this dir is collected, so its
+    # module-level ``from errors import ...`` binds THIS wrapper's classes even when
+    # a sibling wrapper's collection ran in between.
+    _claim_local_modules()
+
+
+def pytest_runtest_setup(item):  # noqa: ARG001 - pytest hook signature
+    # Re-claim before each test so runtime ``from errors import ...`` inside a test
+    # body resolves to this skill's canonical object (identity-consistent with the
+    # function-scoped module fixtures).
+    _claim_local_modules()

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_audit_round2.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_audit_round2.py
@@ -704,15 +704,19 @@ def test_catalog_entry_mirrors_skill_frontmatter():
     import json
 
     fm = _read_yaml_frontmatter()
+    meta = fm.get("metadata", {})
     catalog = json.loads(
         (_SKILL_DIR.parent / "catalog.json").read_text(encoding="utf-8")
     )
     items = catalog if isinstance(catalog, list) else catalog.get("skills", [])
     entry = next(e for e in items if e.get("name") == "nfcore-scrnaseq-wrapper")
+    # Frontmatter follows the canonical SKILL-TEMPLATE schema: description is
+    # top-level; version/tags under metadata:; trigger_keywords under
+    # metadata.openclaw: (mirrors nfcore-sarek/rnaseq test_catalog_consistency).
     assert entry["description"] == fm["description"]
-    assert entry["version"] == fm["version"]
-    assert entry["tags"] == fm["metadata"]["tags"]
-    assert entry["trigger_keywords"] == fm["trigger_keywords"]
+    assert entry["version"] == meta["version"]
+    assert entry["tags"] == meta["tags"]
+    assert entry["trigger_keywords"] == meta["openclaw"]["trigger_keywords"]
 
 
 def test_declared_packages_cover_external_imports():

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_nfcore_scrnaseq_wrapper.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_nfcore_scrnaseq_wrapper.py
@@ -179,6 +179,32 @@ def test_main_writes_structured_error_for_aligner_preset_conflict(tmp_path, monk
     assert payload["error_code"] == "INVALID_PRESET_CONFIGURATION"
 
 
+def test_main_accepts_explicit_argv(tmp_path, monkeypatch):
+    """main() must accept an explicit argv list (parity with nfcore-sarek/rnaseq)
+    so the entrypoint is unit-testable without mutating sys.argv."""
+    module = _load_skill_module()
+
+    def _boom(*_args, **_kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(module, "_run_wrapper", _boom)
+    # Reaching _run_wrapper proves argv was parsed by main(argv=...).
+    assert module.main(["--output", str(tmp_path), "--demo"]) == 130
+
+
+def test_main_keyboard_interrupt_returns_130(tmp_path, monkeypatch):
+    """Ctrl+C during a long-running pipeline must exit 130 (SIGINT convention),
+    not dump a traceback — parity with nfcore-sarek/rnaseq."""
+    module = _load_skill_module()
+
+    def _boom(*_args, **_kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(module, "_run_wrapper", _boom)
+    rc = module.main(["--output", str(tmp_path), "--demo"])
+    assert rc == 130
+
+
 def test_parser_save_align_intermeds_is_two_way_switch():
     """--save-align-intermeds must be a two-way switch so the BAM-saving default
     can be explicitly turned OFF (--no-save-align-intermeds → False), turned ON

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_preflight.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_preflight.py
@@ -98,6 +98,47 @@ def test_reference_paths_still_reject_missing_local(tmp_path):
     assert exc.value.error_code == "MISSING_REFERENCE"
 
 
+# --- --allow-remote-inputs gate (local-first by default) ---------------------
+
+def test_remote_fastq_rejected_by_default():
+    """Remote samplesheet inputs are rejected unless --allow-remote-inputs is set."""
+    with pytest.raises(SkillError) as exc:
+        preflight._check_remote_inputs(
+            Namespace(allow_remote_inputs=False),
+            {"fastq_paths": ["s3://bucket/sampleA_R1.fastq.gz"]},
+        )
+    assert exc.value.error_code == "REMOTE_INPUT_NOT_ALLOWED"
+    assert "s3://bucket/sampleA_R1.fastq.gz" in exc.value.details["remote_paths"]
+
+
+def test_remote_reference_rejected_by_default():
+    """Remote reference/index paths are rejected unless --allow-remote-inputs is set."""
+    with pytest.raises(SkillError) as exc:
+        preflight._check_remote_inputs(
+            Namespace(allow_remote_inputs=False, fasta="https://example.org/genome.fa"),
+            {"fastq_paths": []},
+        )
+    assert exc.value.error_code == "REMOTE_INPUT_NOT_ALLOWED"
+
+
+def test_remote_inputs_allowed_with_flag_warns(capsys):
+    """With --allow-remote-inputs, remote paths pass and a network-fetch WARNING is emitted."""
+    preflight._check_remote_inputs(
+        Namespace(allow_remote_inputs=True),
+        {"fastq_paths": ["gs://bucket/sampleA_R1.fastq.gz"]},
+    )
+    err = capsys.readouterr().err
+    assert "--allow-remote-inputs" in err and "gs://bucket/sampleA_R1.fastq.gz" in err
+
+
+def test_local_inputs_pass_the_gate():
+    """Local paths never trigger the remote-input gate."""
+    preflight._check_remote_inputs(
+        Namespace(allow_remote_inputs=False),
+        {"fastq_paths": ["/data/sampleA_R1.fastq.gz"]},
+    )
+
+
 def test_preflight_happy_path(tmp_path, monkeypatch):
     args = _args(tmp_path)
     Path(args.fasta).write_text(">chr1\nACGT\n", encoding="utf-8")

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_preflight.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_preflight.py
@@ -78,6 +78,26 @@ def _args(tmp_path: Path) -> Namespace:
     )
 
 
+def test_reference_paths_accept_remote_uris():
+    """Remote reference URIs (s3://, gs://, https://) are passed through: Nextflow
+    resolves them at runtime, so existence is not pre-checked (parity with
+    nfcore-rnaseq/sarek and the nf-core schema)."""
+    preflight._check_reference_paths_exist(
+        {
+            "fasta": "s3://bucket/genome.fa",
+            "gtf": "https://example.org/genes.gtf",
+            "star_index": "gs://bucket/star/",
+        }
+    )
+
+
+def test_reference_paths_still_reject_missing_local(tmp_path):
+    """A *local* reference that does not exist still fails fast (MISSING_REFERENCE)."""
+    with pytest.raises(SkillError) as exc:
+        preflight._check_reference_paths_exist({"fasta": str(tmp_path / "nope.fa")})
+    assert exc.value.error_code == "MISSING_REFERENCE"
+
+
 def test_preflight_happy_path(tmp_path, monkeypatch):
     args = _args(tmp_path)
     Path(args.fasta).write_text(">chr1\nACGT\n", encoding="utf-8")

--- a/skills/nfcore-scrnaseq-wrapper/tests/test_samplesheet_builder.py
+++ b/skills/nfcore-scrnaseq-wrapper/tests/test_samplesheet_builder.py
@@ -43,24 +43,41 @@ def test_validate_and_normalize_samplesheet_rejects_missing_fastq(tmp_path):
     assert exc.value.error_code == "MISSING_FASTQ"
 
 
-def test_validate_rejects_remote_fastq_urls_with_local_first_message(tmp_path):
+def test_validate_accepts_remote_fastq_urls_verbatim(tmp_path):
+    """Remote FASTQ URIs are passed through verbatim (parity with nf-core +
+    nfcore-sarek/rnaseq): existence is deferred to Nextflow staging, only the
+    basename is validated, and the URI is written unchanged to the normalized
+    samplesheet (no Path() mangling of the `//` scheme separator)."""
     src = tmp_path / "samplesheet.csv"
     src.write_text(
         "sample,fastq_1,fastq_2\n"
-        "sampleA,https://example.org/S1_R1.fastq.gz,https://example.org/S1_R2.fastq.gz\n",
+        "sampleA,https://example.org/S1_R1.fastq.gz,s3://bucket/S1_R2.fastq.gz\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "normalized.csv"
+
+    summary = validate_and_normalize_samplesheet(src, out)
+
+    assert "https://example.org/S1_R1.fastq.gz" in summary["fastq_paths"]
+    assert "s3://bucket/S1_R2.fastq.gz" in summary["fastq_paths"]
+    written = out.read_text(encoding="utf-8")
+    assert "https://example.org/S1_R1.fastq.gz" in written
+    assert "s3://bucket/S1_R2.fastq.gz" in written
+
+
+def test_validate_rejects_remote_fastq_url_with_bad_basename(tmp_path):
+    """A remote URI that is not a FASTQ basename is still rejected (INVALID_FASTQ)."""
+    src = tmp_path / "samplesheet.csv"
+    src.write_text(
+        "sample,fastq_1,fastq_2\n"
+        "sampleA,https://example.org/S1_R1.fastq.gz,https://example.org/notes.txt\n",
         encoding="utf-8",
     )
 
     with pytest.raises(SkillError) as exc:
         validate_and_normalize_samplesheet(src, tmp_path / "normalized.csv")
 
-    assert exc.value.error_code == ErrorCode.INVALID_SAMPLESHEET
-    assert "local-first" in exc.value.message
-    assert exc.value.details == {
-        "line": 2,
-        "column": "fastq_1",
-        "path": "https://example.org/S1_R1.fastq.gz",
-    }
+    assert exc.value.error_code == ErrorCode.INVALID_FASTQ
 
 
 def test_validate_rejects_fastq_basename_with_space(tmp_path):


### PR DESCRIPTION
## Summary

This PR aligns the three nf-core pipeline wrappers — `nfcore-scrnaseq-wrapper` (4.1.0), `nfcore-sarek-wrapper` (3.8.1), and `nfcore-rnaseq-wrapper` (3.26.0) — to a single, consistent architecture. It removes the unjustified differences between them across validation, error handling, logging, CLI surface, and documentation, while preserving each pipeline's legitimate, version-specific behavior. No regressions.

## Why

The three wrappers had drifted apart: different validation philosophies, error presentation, exit codes, import-isolation mechanisms, control-flag surfaces, and documentation depth. A few gaps had real consequences — e.g. Sarek could silently run a non-pinned pipeline version, and the combined test session failed due to cross-skill module shadowing. This PR brings them to parity and fixes those issues.

## What changed

### Validation & error handling
- **Unified input-readability policy.** No wrapper pre-checks FASTQ/reference *readability* on the launcher side: Nextflow reads the data in the execution context (often a root container under the default Docker profile), so an `os.access(R_OK)` check by the launching user false-blocks otherwise-valid runs. Existence is still validated. The rationale is documented in every `errors.py`, and the dead `FASTQ_NOT_READABLE` code was removed.
- **scrnaseq now accepts remote input/reference URIs** (`s3://`, `gs://`, `https://`) like Sarek/RNA-seq and nf-core itself. Remote values pass through verbatim; local paths are still existence-checked (`MISSING_FASTQ` / `MISSING_REFERENCE`).
- **Sarek pinned-version guard.** A non-pinned `--pipeline-version` is now blocked unless `--allow-pipeline-version-override` is passed, so the 3.8.1-specific validations can no longer be silently applied to a different version (parity with the other two wrappers).
- **Consistent exit codes.** Sarek's `SkillError` now exits `1` (was `2`, which collided with argparse usage errors); internal errors stay `1`.

### Robustness & entrypoint
- `main()` now catches `KeyboardInterrupt` → exit `130` (SIGINT convention) and accepts an explicit `argv` in all three.
- **Centralized import isolation.** A single `_isolated_imports` guard is used by every wrapper module, and a shared test conftest makes the suites order-independent, so the full `pytest` session is green regardless of collection order (previously the combined run failed due to bare-name module shadowing across skills).

### CLI parity & UX
- **Full control-flag parity.** All three now expose `--timeout-hours` (with `0` to disable the cap for HPC/cloud runs), `--work-dir` (local path or object-store URI), `--verbose`, `--no-banner`, `--allow-pipeline-version-override`, and `-c` / `--config` / `--nextflow-config`.
- **Consistent logging.** Identical staged progress logs (`[preflight]` / `[execute]` / `[outputs]` / `[report]` / `[provenance]` / `[done]`) plus a human-readable error box on stdout and a machine-readable JSON error on stderr.

### Documentation
- Homogenized README skeletons and `demo/README.md` files, added the missing `CHANGELOG.md` and `## Citations` sections, fixed doc/code mismatches (timeout-`0` wording, newly added control flags), and single-sourced the report disclaimer.

## Remaining differences (intentional, pipeline-specific)
- Parameter-handling model (strict allowlist vs. passthrough vs. explicit flags) — driven by each pipeline's parameter-surface size.
- Pipeline-source resolution (auto-detected local checkout vs. explicit `--pipeline-local`).
- Defaults that legitimately differ per pipeline (e.g. 24 h timeout for Sarek vs. 12 h; per-pipeline minimum Nextflow version).

## Testing
- Per-skill suites: scrnaseq **392 passed** (2 skipped), sarek **331 passed**, rnaseq **445 passed**.
- Combined session, both collection orders: **1168 passed**, 0 failures.
- Repo-level skill / contract / CLI tests: **33 passed**.
- All three wrappers run in `--demo` mode through arg parsing → demo coercion → preflight (they stop cleanly at `DOCKER_NOT_RUNNING` on a host without a running Docker daemon, as expected).
