### PR TITLE
fix(cli): list agent-readable skills

### DIFF
--- a/clawbio/cli.py
+++ b/clawbio/cli.py
@@ -1222,6 +1222,18 @@ FULL_PROFILE_PIPELINE = ["pharmgx", "nutrigx", "prs", "compare"]
 # --------------------------------------------------------------------------- #
 
 
+def _skill_md_only_directories() -> list[Path]:
+    """Return agent-readable skills that are not registered with the CLI."""
+    registered_directories = {info["script"].parent.resolve() for info in SKILLS.values()}
+    return [
+        path
+        for path in sorted(SKILLS_DIR.iterdir())
+        if path.is_dir()
+        and (path / "SKILL.md").is_file()
+        and path.resolve() not in registered_directories
+    ]
+
+
 def list_skills() -> dict:
     """Print available skills and return the registry dict."""
     print(f"{BOLD}ClawBio Skills{RESET}")
@@ -1231,6 +1243,10 @@ def list_skills() -> dict:
         status = f"{GREEN}OK{RESET}" if script_exists else f"{RED}MISSING{RESET}"
         print(f"  {BOLD}{name:<15}{RESET} {info['description']}")
         print(f"  {'':15} {DIM}script: {info['script'].name}{RESET} [{status}]")
+        print()
+    for skill_dir in _skill_md_only_directories():
+        print(f"  {BOLD}{skill_dir.name:<15}{RESET} Agent-readable skill")
+        print(f"  {'':15} {DIM}SKILL.md only (not available via clawbio run){RESET}")
         print()
     print(f"{DIM}Run a skill:  clawbio run <skill> --demo{RESET}")
     print(f"{DIM}With input:   clawbio run <skill> --input <file>{RESET}")

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+from clawbio import cli
+
 CLAWBIO = Path(__file__).resolve().parents[1] / "clawbio.py"
 
 
@@ -21,6 +23,22 @@ def test_parser_constructs_without_error():
     """Parser must build cleanly — no duplicate-flag argparse.ArgumentError."""
     result = _run("list")
     assert result.returncode == 0, result.stderr
+
+
+def test_list_includes_skill_md_only_directories(monkeypatch, tmp_path, capsys):
+    """Listing exposes skills that are usable by agents but not CLI-runnable."""
+    skill_dir = tmp_path / "agent-only-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text("# Agent-only skill\n", encoding="utf-8")
+    monkeypatch.setattr(cli, "SKILLS_DIR", tmp_path)
+    monkeypatch.setattr(cli, "SKILLS", {})
+
+    listed = cli.list_skills()
+
+    assert listed == {}
+    output = capsys.readouterr().out
+    assert "agent-only-skill" in output
+    assert "SKILL.md only" in output
 
 
 def test_run_help_exits_zero():


### PR DESCRIPTION
## Summary

- Show every directory with a `SKILL.md` in `clawbio list`, while keeping the static registry authoritative for `clawbio run`.
- Mark non-registered entries as agent-readable, `SKILL.md`-only skills.

Closes #298

## Skill affected

CLI skill listing (no individual skill implementation changed).

## Checklist

- [x] SKILL.md is present and complete (existing skill definitions)
- [x] Tests included and passing (`pytest -v`)
- [ ] Demo data included for reviewers to test (N/A: CLI-only fix)
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

Focused CLI tests: 6 passed. The three unrelated nf-core help tests stalled while importing their optional dependency stack in the isolated CPU environment.
