### PR TITLE
feat: improve skill listing with section headings and total count

### DIFF
--- a/clawbio/cli.py
+++ b/clawbio/cli.py
@@ -1234,32 +1234,46 @@ def _skill_md_only_directories() -> list[Path]:
     ]
 
 
+
+
 def list_skills() -> dict:
     """Print available skills and return the registry dict."""
     print(f"{BOLD}ClawBio Skills{RESET}")
-    print(f"{'═' * 55}")
+    print(f"{'═' * 60}")
+    
+    # Registered skills
+    print(f"{BOLD}Registered Skills{RESET} ({len(SKILLS)}):")
     for name, info in SKILLS.items():
         script_exists = info["script"].exists()
         status = f"{GREEN}OK{RESET}" if script_exists else f"{RED}MISSING{RESET}"
-        print(f"  {BOLD}{name:<15}{RESET} {info['description']}")
-        print(f"  {'':15} {DIM}script: {info['script'].name}{RESET} [{status}]")
+        print(f"  {BOLD}{name:<20}{RESET} {info['description']}")
+        print(f"  {'':20} {DIM}script: {info['script'].name}{RESET} [{status}]")
         print()
-    for skill_dir in _skill_md_only_directories():
-        print(f"  {BOLD}{skill_dir.name:<15}{RESET} Agent-readable skill")
-        print(f"  {'':15} {DIM}SKILL.md only (not available via clawbio run){RESET}")
-        print()
+    
+    # Agent-readable skills (SKILL.md only)
+    md_only = _skill_md_only_directories()
+    if md_only:
+        print(f"{BOLD}Agent-Readable Skills{RESET} ({len(md_only)}):")
+        for skill_dir in md_only:
+            has_script = any(
+                f.suffix == ".py" and f.name != "__init__.py"
+                for f in sorted(skill_dir.rglob("*.py"))
+                if "tests" not in str(f.relative_to(skill_dir)).split("/")[0:1]
+                and "__pycache__" not in str(f)
+            )
+            indicator = f"{GREEN}has script{RESET}" if has_script else f"{YELLOW}spec only{RESET}"
+            print(f"  {DIM}{skill_dir.name:<20}{RESET} Agent-readable skill")
+            print(f"  {'':20} {DIM}[{indicator}] — SKILL.md only (not via clawbio run){RESET}")
+            print()
+    
+    total = len(SKILLS) + len(md_only)
+    print(f"{DIM}Total: {total} skills ({len(SKILLS)} registered, {len(md_only)} agent-readable){RESET}")
+    print()
     print(f"{DIM}Run a skill:  clawbio run <skill> --demo{RESET}")
     print(f"{DIM}With input:   clawbio run <skill> --input <file>{RESET}")
     print(f"{DIM}Upload once:  clawbio upload --input <file> --patient-id PT001{RESET}")
     print(f"{DIM}Full profile: clawbio run full-profile --profile profiles/PT001.json{RESET}")
     return SKILLS
-
-
-# --------------------------------------------------------------------------- #
-# upload_profile
-# --------------------------------------------------------------------------- #
-
-
 def upload_profile(
     input_path: str,
     patient_id: str = "",

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -41,6 +41,39 @@ def test_list_includes_skill_md_only_directories(monkeypatch, tmp_path, capsys):
     assert "SKILL.md only" in output
 
 
+
+def test_list_skills_shows_section_headings(monkeypatch, tmp_path, capsys):
+    """list_skills() shows Registered and Agent-Readable section headings."""
+    # Create a registered skill
+    registered_dir = tmp_path / "registered-skill"
+    registered_dir.mkdir()
+    (registered_dir / "SKILL.md").write_text("# Registered\n", encoding="utf-8")
+    (registered_dir / "run.py").write_text("print('hello')\n", encoding="utf-8")
+    
+    # Create an agent-only skill
+    agent_dir = tmp_path / "agent-only-skill"
+    agent_dir.mkdir()
+    (agent_dir / "SKILL.md").write_text("# Agent only\n", encoding="utf-8")
+    
+    from clawbio import cli
+    monkeypatch.setattr(cli, "SKILLS_DIR", tmp_path)
+    monkeypatch.setattr(cli, "SKILLS", {
+        "test-skill": {
+            "script": registered_dir / "run.py",
+            "description": "Test skill for unit testing",
+        }
+    })
+    
+    listed = cli.list_skills()
+    output = capsys.readouterr().out
+    
+    assert listed == {"test-skill": cli.SKILLS["test-skill"]}
+    assert "Registered Skills (1)" in output
+    assert "Agent-Readable Skills (1)" in output
+    assert "Total: 2 skills" in output
+    assert "test-skill" in output
+    assert "agent-only-skill" in output
+
 def test_run_help_exits_zero():
     result = _run("run", "--help")
     assert result.returncode == 0, result.stderr


### PR DESCRIPTION
This PR improves the skill listing output from #318 with better organization and visual indicators.

## What changed

- Added section headings: 'Registered Skills (N)' and 'Agent-Readable Skills (N)'
- Added total count at bottom: 'Total: N skills (X registered, Y agent-readable)'
- Added visual indicators for agent-readable skills: [has script] or [spec only]
- Added test for the improved output format

## Example output



## Testing

Added  to verify:
- Section headings are displayed
- Total count is accurate
- Both registered and agent-readable skills appear

Builds on top of merged #318.

Closes #298