### PR TITLE
Fix crash when VEP returns clin_sig_allele as a string

### DIFF
--- a/skills/clinical-variant-reporter/clinical_variant_reporter.py
+++ b/skills/clinical-variant-reporter/clinical_variant_reporter.py
@@ -210,7 +210,11 @@ def _extract_evidence_from_vep(vep_result: dict, record: VcfRecord) -> VariantEv
             sigs = cv.get("clin_sig", "")
             if sigs and not clinvar_sig:
                 clinvar_sig = sigs
-                clinvar_stars = cv.get("clin_sig_allele", {}).get("review_status_stars", 0)
+                # VEP returns clin_sig_allele as a dict for some variants and a
+                # string (e.g. "T:pathogenic") for others; only read stars from a dict.
+                clin_sig_allele = cv.get("clin_sig_allele", {})
+                if isinstance(clin_sig_allele, dict):
+                    clinvar_stars = clin_sig_allele.get("review_status_stars", 0)
 
         freq_data = cv.get("frequencies", {})
         if freq_data:

--- a/skills/clinical-variant-reporter/tests/test_clinical_variant_reporter.py
+++ b/skills/clinical-variant-reporter/tests/test_clinical_variant_reporter.py
@@ -409,3 +409,42 @@ class TestVepLivePath:
         assert params.get("transcript_version") == 1, (
             f"Expected transcript_version=1 in VEP params, got: {params}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression — VEP clin_sig_allele may be a string, not a dict
+# ---------------------------------------------------------------------------
+class TestClinSigAlleleTypeGuard:
+    """VEP returns colocated_variants[].clin_sig_allele as a dict for some
+    variants and a string (e.g. "T:pathogenic") for others. Extraction must not
+    crash on the string form (previously AttributeError: 'str' has no 'get')."""
+
+    def _record(self):
+        from clinical_variant_reporter import VcfRecord
+        return VcfRecord(chrom="13", pos=32339267, id="rs886040553",
+                         ref="A", alt="T", qual=".", filt="PASS", info={})
+
+    def _vep(self, clin_sig_allele):
+        return {
+            "most_severe_consequence": "stop_gained",
+            "transcript_consequences": [
+                {"gene_symbol": "BRCA2", "impact": "HIGH",
+                 "consequence_terms": ["stop_gained"],
+                 "transcript_id": "ENST00000544455.6"}
+            ],
+            "colocated_variants": [
+                {"clin_sig": ["pathogenic"], "clin_sig_allele": clin_sig_allele}
+            ],
+        }
+
+    def test_string_clin_sig_allele_does_not_crash(self):
+        from clinical_variant_reporter import _extract_evidence_from_vep
+        ev = _extract_evidence_from_vep(self._vep("T:pathogenic"), self._record())
+        assert ev.gene == "BRCA2"
+        assert ev.clinvar_review_stars == 0  # defaults gracefully when not a dict
+
+    def test_dict_clin_sig_allele_still_reads_stars(self):
+        from clinical_variant_reporter import _extract_evidence_from_vep
+        ev = _extract_evidence_from_vep(
+            self._vep({"review_status_stars": 3}), self._record())
+        assert ev.clinvar_review_stars == 3


### PR DESCRIPTION
## The bug

`clinical_variant_reporter._extract_evidence_from_vep` assumed VEP's
`colocated_variants[].clin_sig_allele` is always a dict and called
`.get("review_status_stars")` on it:

```python
clinvar_stars = cv.get("clin_sig_allele", {}).get("review_status_stars", 0)
```

VEP returns this field as a **string** (e.g. `"T:pathogenic"`) for many variants.
Calling `.get()` on a string raises `AttributeError: 'str' object has no attribute
'get'`, which crashes the whole live VEP annotation path. The skill passed on its
cached demo (`demo_evidence_cache.json`) but died on real VEP responses — surfaced
while running the ACMG engine live on real family genomes.

## The fix

Type-guard the field: only read review stars when `clin_sig_allele` is a dict,
otherwise default to 0 (unchanged behaviour on the dict form).

## Tests

Adds `TestClinSigAlleleTypeGuard` with two regression cases:
- string `clin_sig_allele` no longer crashes (defaults stars to 0)
- dict `clin_sig_allele` still reads `review_status_stars`

Full skill suite: 40 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in VEP evidence parsing with regression tests; demo/cache path unchanged.
> 
> **Overview**
> Fixes a crash in the **live VEP annotation path** when Ensembl returns `colocated_variants[].clin_sig_allele` as a string (e.g. `"T:pathogenic"`) instead of a dict. `_extract_evidence_from_vep` no longer calls `.get("review_status_stars")` on that value unless it is a dict; otherwise **ClinVar review stars default to 0**, matching prior behavior for the dict case.
> 
> Adds **`TestClinSigAlleleTypeGuard`** regression tests for string (no crash) and dict (stars still read) forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2c0f8002c19c06934a7198b1db1aff36dc4fa7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->