### PR TITLE
fix(cvr): report live Ensembl release in Data Sources table

### DIFF
--- a/skills/clinical-variant-reporter/SKILL.md
+++ b/skills/clinical-variant-reporter/SKILL.md
@@ -206,7 +206,7 @@ output_directory/
 
 ## Safety
 
-- **Local-first**: All classification logic runs locally. Only variant coordinates and alleles are sent to public Ensembl VEP REST — no patient identifiers or phenotype data ever leave the machine
+- **Local-first**: All classification logic runs locally. Only variant coordinates and alleles are sent to public Ensembl VEP REST. In live mode, the Data Sources report section also queries Ensembl's `info/variation/homo_sapiens` endpoint (no variant data in that request) to report the actual ClinVar/dbSNP/OMIM versions bundled with the release — no patient identifiers or phenotype data ever leave the machine
 - **Disclaimer**: Every report includes the ClawBio medical disclaimer
 - **No hallucinated science**: Every classification traces to specific evidence codes, database entries, and published thresholds
 - **Audit trail**: Full evidence provenance logged to `reproducibility/database_versions.json`

--- a/skills/clinical-variant-reporter/clinical_variant_reporter.py
+++ b/skills/clinical-variant-reporter/clinical_variant_reporter.py
@@ -42,7 +42,9 @@ DISCLAIMER = (
 VEP_REST_URL = "https://rest.ensembl.org/vep/homo_sapiens/region"
 VEP_BATCH_SIZE = 200
 VEP_RATE_LIMIT_SECONDS = 0.07  # ~15 requests/second
-ENSEMBL_INFO_SOFTWARE_URL = "https://rest.ensembl.org/info/software"
+ENSEMBL_INFO_VARIATION_URL = "https://rest.ensembl.org/info/variation/homo_sapiens"
+GNOMAD_VERSION_LABEL = "v4.1"  # info/variation does not list gnomAD; no live source exists
+DEMO_CLINVAR_LABEL = "2025-03-01 release"
 
 
 # ---------------------------------------------------------------------------
@@ -269,26 +271,43 @@ def _extract_evidence_from_vep(vep_result: dict, record: VcfRecord) -> VariantEv
     )
 
 
-def _fetch_ensembl_release() -> int | None:
-    """Query the Ensembl release actually queried, for the Data Sources report section."""
+def _fetch_ensembl_data_versions() -> dict[str, str] | None:
+    """Query the live source versions bundled with Ensembl's variation data
+    (ClinVar, dbSNP, OMIM), for the Data Sources report section. gnomAD is not
+    listed by this endpoint and stays a hardcoded constant (GNOMAD_VERSION_LABEL)."""
     try:
         import requests
         resp = requests.get(
-            ENSEMBL_INFO_SOFTWARE_URL,
+            ENSEMBL_INFO_VARIATION_URL,
             headers={"Content-Type": "application/json"},
             timeout=10,
         )
         resp.raise_for_status()
-        return resp.json().get("release")
-    except Exception:
+        sources = resp.json()
+    except Exception as exc:
+        print(f"WARNING: could not fetch Ensembl data source versions ({exc}).", file=sys.stderr)
         return None
+
+    versions: dict[str, str] = {}
+    name_to_key = {"ClinVar": "clinvar", "dbSNP": "dbsnp", "OMIM": "omim"}
+    for src in sources if isinstance(sources, list) else []:
+        key = name_to_key.get(src.get("name", ""))
+        if key and src.get("version"):
+            versions[key] = src["version"]
+    return versions or None
 
 
 def annotate_variants_vep(
     records: list[VcfRecord],
     assembly: str = "GRCh38",
-) -> list[VariantEvidence]:
-    """Annotate variants via Ensembl VEP REST API and return evidence objects."""
+) -> tuple[list[VariantEvidence], dict[str, str] | None]:
+    """Annotate variants via Ensembl VEP REST API.
+
+    Returns (evidence_list, source_versions). source_versions is fetched once,
+    only if at least one VEP batch succeeded, so a run where every batch fails
+    never stamps a report with data-source versions for annotation that never
+    happened.
+    """
     try:
         import requests
     except ImportError:
@@ -296,6 +315,7 @@ def annotate_variants_vep(
         sys.exit(1)
 
     evidence_list: list[VariantEvidence] = []
+    any_batch_succeeded = False
 
     for batch_start in range(0, len(records), VEP_BATCH_SIZE):
         batch = records[batch_start:batch_start + VEP_BATCH_SIZE]
@@ -320,6 +340,7 @@ def annotate_variants_vep(
                 ))
             continue
 
+        any_batch_succeeded = True
         result_map: dict[str, dict] = {}
         for vr in vep_results:
             loc = vr.get("input", "")
@@ -337,7 +358,8 @@ def annotate_variants_vep(
 
         time.sleep(VEP_RATE_LIMIT_SECONDS)
 
-    return evidence_list
+    source_versions = _fetch_ensembl_data_versions() if any_batch_succeeded else None
+    return evidence_list, source_versions
 
 
 # ---------------------------------------------------------------------------
@@ -348,13 +370,19 @@ def run_classification(
     demo: bool = False,
     gene_filter: set[str] | None = None,
     assembly: str = "GRCh38",
-) -> list[ClassifiedVariant]:
-    """Run the full ACMG classification pipeline on VCF records."""
+) -> tuple[list[ClassifiedVariant], dict[str, str] | None]:
+    """Run the full ACMG classification pipeline on VCF records.
+
+    Returns (classified, source_versions); source_versions is always None in
+    demo mode and is the Ensembl data-source versions captured at annotation
+    time in live mode (None if annotation never succeeded).
+    """
     if demo:
         cache = load_demo_evidence_cache()
         evidence_list = [build_evidence_from_cache(r, cache) for r in records]
+        source_versions = None
     else:
-        evidence_list = annotate_variants_vep(records, assembly=assembly)
+        evidence_list, source_versions = annotate_variants_vep(records, assembly=assembly)
 
     if gene_filter:
         evidence_list = [e for e in evidence_list if e.gene in gene_filter]
@@ -372,7 +400,7 @@ def run_classification(
         if not audit.passed:
             cv.classification = ABSTAIN_LABEL
         classified.append(cv)
-    return classified
+    return classified, source_versions
 
 
 # ---------------------------------------------------------------------------
@@ -382,14 +410,52 @@ CLASS_ORDER = ["Pathogenic", "Likely Pathogenic", "Uncertain Significance", "Lik
 CLASS_SHORT = {"Pathogenic": "P", "Likely Pathogenic": "LP", "Uncertain Significance": "VUS", "Likely Benign": "LB", "Benign": "B"}
 
 
+def _data_source_versions_for_report(
+    demo: bool, source_versions: dict[str, str] | None,
+) -> dict[str, str]:
+    """Single source of truth for the Data Sources table, result.json and
+    database_versions.json, so the three can't drift independently.
+
+    Never performs a network call: source_versions must already be captured
+    (annotate_variants_vep, at annotation time) or None.
+    """
+    if demo:
+        return {
+            "ClinVar": f"{DEMO_CLINVAR_LABEL} (demo cache)",
+            "gnomAD": f"{GNOMAD_VERSION_LABEL} (demo cache)",
+        }
+
+    if not source_versions:
+        note = "unavailable (no variant was successfully annotated this run)"
+        return {"ClinVar": note, "gnomAD": note}
+
+    clinvar_v = source_versions.get("clinvar")
+    clinvar_label = (
+        f"{clinvar_v} (via Ensembl VEP colocated variants)" if clinvar_v
+        else "unavailable (Ensembl did not report a ClinVar version this run)"
+    )
+    return {
+        "ClinVar": clinvar_label,
+        "gnomAD": f"{GNOMAD_VERSION_LABEL} (via Ensembl VEP colocated variants)",
+    }
+
+
 def generate_report(
     classified: list[ClassifiedVariant],
     output_dir: Path,
     demo: bool = False,
     assembly: str = "GRCh38",
     input_path: str = "demo",
+    source_versions: dict[str, str] | None = None,
 ) -> None:
-    """Generate all output files: report.md, result.json, tables/, figures/, reproducibility/."""
+    """Generate all output files: report.md, result.json, tables/, figures/, reproducibility/.
+
+    source_versions is the Ensembl data-source versions captured at annotation
+    time (see annotate_variants_vep / run_classification); this function makes
+    no network call of its own, so regenerating a report from stored
+    ClassifiedVariant objects without passing source_versions again correctly
+    shows "unavailable" rather than re-fetching today's release for an old run.
+    """
     output_dir.mkdir(parents=True, exist_ok=True)
     (output_dir / "tables").mkdir(exist_ok=True)
     (output_dir / "figures").mkdir(exist_ok=True)
@@ -402,13 +468,14 @@ def generate_report(
         counts[cv.classification] = counts.get(cv.classification, 0) + 1
 
     sf_variants = [cv for cv in classified if cv.is_secondary_finding]
+    data_sources = _data_source_versions_for_report(demo, source_versions)
 
-    _write_markdown_report(classified, counts, sf_variants, output_dir, timestamp, demo, assembly, input_path)
+    _write_markdown_report(classified, counts, sf_variants, output_dir, timestamp, demo, assembly, input_path, data_sources)
     _write_classification_table(classified, output_dir)
     _write_secondary_findings_table(sf_variants, output_dir)
-    _write_result_json(classified, counts, sf_variants, output_dir, timestamp, demo, assembly)
+    _write_result_json(classified, counts, sf_variants, output_dir, timestamp, demo, assembly, data_sources)
     _write_classification_figure(counts, output_dir)
-    _write_reproducibility(output_dir, demo, assembly, input_path, timestamp)
+    _write_reproducibility(output_dir, demo, assembly, input_path, timestamp, data_sources)
 
 
 def _write_markdown_report(
@@ -420,6 +487,7 @@ def _write_markdown_report(
     demo: bool,
     assembly: str,
     input_path: str,
+    data_sources: dict[str, str],
 ) -> None:
     lines: list[str] = []
     lines.append("# Clinical Variant Report — ACMG/AMP Classification")
@@ -529,14 +597,8 @@ def _write_markdown_report(
     lines.append("")
     lines.append("| Source | Version / Release |")
     lines.append("|--------|-------------------|")
-    if demo:
-        lines.append("| ClinVar | 2025-03-01 release (demo cache) |")
-        lines.append("| gnomAD | v4.1 (demo cache) |")
-    else:
-        release = _fetch_ensembl_release()
-        release_label = f"Ensembl release {release}" if release is not None else "Ensembl release unavailable"
-        lines.append(f"| ClinVar | bundled with {release_label} (via Ensembl VEP REST) |")
-        lines.append(f"| gnomAD | bundled with {release_label} (via Ensembl VEP colocated variants) |")
+    lines.append(f"| ClinVar | {data_sources['ClinVar']} |")
+    lines.append(f"| gnomAD | {data_sources['gnomAD']} |")
     lines.append("| Ensembl VEP | REST API, assembly %s |" % assembly)
     lines.append("| ACMG SF list | v3.2 (Miller et al., 2023; 81 genes) |")
     lines.append("")
@@ -603,6 +665,7 @@ def _write_result_json(
     timestamp: str,
     demo: bool,
     assembly: str,
+    data_sources: dict[str, str],
 ) -> None:
     result = {
         "tool": "ClawBio Clinical Variant Reporter",
@@ -612,6 +675,7 @@ def _write_result_json(
         "assembly": assembly,
         "timestamp": timestamp,
         "mode": "demo" if demo else "live",
+        "data_source_versions": data_sources,
         "total_variants": len(classified),
         "classification_counts": counts,
         "secondary_findings_count": len(sf_variants),
@@ -677,6 +741,7 @@ def _write_reproducibility(
     assembly: str,
     input_path: str,
     timestamp: str,
+    data_sources: dict[str, str],
 ) -> None:
     cmd = f"python {Path(__file__).name}"
     if demo:
@@ -694,6 +759,7 @@ def _write_reproducibility(
         "sf_list": "ACMG SF v3.2 (Miller et al. 2023)",
         "sf_gene_count": len(ACMG_SF_V32_GENES),
         "annotation_backend": "demo_cache" if demo else "Ensembl VEP REST (GRCh38)",
+        "data_source_versions": data_sources,
         "generated": timestamp,
     }
     (output_dir / "reproducibility" / "database_versions.json").write_text(
@@ -746,12 +812,15 @@ def main() -> None:
         print(f"[CVR] Filtering to genes: {', '.join(sorted(gene_filter))}")
 
     print(f"[CVR] Running ACMG classification ({'demo mode' if args.demo else 'live mode'})...")
-    classified = run_classification(
+    classified, source_versions = run_classification(
         records, demo=args.demo, gene_filter=gene_filter, assembly=args.assembly,
     )
 
     print(f"[CVR] Generating report in: {output_dir}")
-    generate_report(classified, output_dir, demo=args.demo, assembly=args.assembly, input_path=input_label)
+    generate_report(
+        classified, output_dir, demo=args.demo, assembly=args.assembly,
+        input_path=input_label, source_versions=source_versions,
+    )
 
     counts = {}
     for cv in classified:

--- a/skills/clinical-variant-reporter/clinical_variant_reporter.py
+++ b/skills/clinical-variant-reporter/clinical_variant_reporter.py
@@ -46,7 +46,6 @@ ENSEMBL_INFO_VARIATION_PATH = "/info/variation/homo_sapiens"
 VEP_REST_URL = VEP_REST_HOST + VEP_REST_PATH
 VEP_BATCH_SIZE = 200
 VEP_RATE_LIMIT_SECONDS = 0.07  # ~15 requests/second
-ENSEMBL_INFO_VARIATION_URL = VEP_REST_HOST + ENSEMBL_INFO_VARIATION_PATH
 GNOMAD_VERSION_LABEL = "v4.1"  # info/variation does not list gnomAD; no live source exists
 DEMO_CLINVAR_LABEL = "2025-03-01 release"
 
@@ -485,7 +484,7 @@ def _data_source_versions_for_report(
 
     clinvar_v = source_versions.get("clinvar")
     clinvar_label = (
-        f"{clinvar_v} (via Ensembl VEP colocated variants)" if clinvar_v
+        f"{clinvar_v} (via Ensembl /info/variation/homo_sapiens)" if clinvar_v
         else "unavailable (Ensembl did not report a ClinVar version this run)"
     )
     return {
@@ -837,7 +836,7 @@ def _write_reproducibility(
         "acmg_framework": "Richards et al. 2015 (PMID 25741868)",
         "sf_list": "ACMG SF v3.2 (Miller et al. 2023)",
         "sf_gene_count": len(ACMG_SF_V32_GENES),
-        "annotation_backend": "demo_cache" if demo else "Ensembl VEP REST (GRCh38)",
+        "annotation_backend": "demo_cache" if demo else f"Ensembl VEP REST ({assembly})",
         "data_source_versions": data_source_versions,
         "generated": timestamp,
     }

--- a/skills/clinical-variant-reporter/clinical_variant_reporter.py
+++ b/skills/clinical-variant-reporter/clinical_variant_reporter.py
@@ -42,6 +42,7 @@ DISCLAIMER = (
 VEP_REST_URL = "https://rest.ensembl.org/vep/homo_sapiens/region"
 VEP_BATCH_SIZE = 200
 VEP_RATE_LIMIT_SECONDS = 0.07  # ~15 requests/second
+ENSEMBL_INFO_SOFTWARE_URL = "https://rest.ensembl.org/info/software"
 
 
 # ---------------------------------------------------------------------------
@@ -266,6 +267,21 @@ def _extract_evidence_from_vep(vep_result: dict, record: VcfRecord) -> VariantEv
         is_synonymous=consequence in SYNONYMOUS_CONSEQUENCES,
         is_inframe_indel=consequence in INFRAME_CONSEQUENCES,
     )
+
+
+def _fetch_ensembl_release() -> int | None:
+    """Query the Ensembl release actually queried, for the Data Sources report section."""
+    try:
+        import requests
+        resp = requests.get(
+            ENSEMBL_INFO_SOFTWARE_URL,
+            headers={"Content-Type": "application/json"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        return resp.json().get("release")
+    except Exception:
+        return None
 
 
 def annotate_variants_vep(
@@ -513,8 +529,14 @@ def _write_markdown_report(
     lines.append("")
     lines.append("| Source | Version / Release |")
     lines.append("|--------|-------------------|")
-    lines.append("| ClinVar | 2025-03-01 release (via Ensembl VEP REST) |")
-    lines.append("| gnomAD | v4.1 (via Ensembl VEP colocated variants) |")
+    if demo:
+        lines.append("| ClinVar | 2025-03-01 release (demo cache) |")
+        lines.append("| gnomAD | v4.1 (demo cache) |")
+    else:
+        release = _fetch_ensembl_release()
+        release_label = f"Ensembl release {release}" if release is not None else "Ensembl release unavailable"
+        lines.append(f"| ClinVar | bundled with {release_label} (via Ensembl VEP REST) |")
+        lines.append(f"| gnomAD | bundled with {release_label} (via Ensembl VEP colocated variants) |")
     lines.append("| Ensembl VEP | REST API, assembly %s |" % assembly)
     lines.append("| ACMG SF list | v3.2 (Miller et al., 2023; 81 genes) |")
     lines.append("")

--- a/skills/clinical-variant-reporter/clinical_variant_reporter.py
+++ b/skills/clinical-variant-reporter/clinical_variant_reporter.py
@@ -39,12 +39,26 @@ DISCLAIMER = (
     "professional before making any medical decisions."
 )
 
-VEP_REST_URL = "https://rest.ensembl.org/vep/homo_sapiens/region"
+VEP_REST_HOST = "https://rest.ensembl.org"
+VEP_REST_HOST_GRCH37 = "https://grch37.rest.ensembl.org"
+VEP_REST_PATH = "/vep/homo_sapiens/region"
+ENSEMBL_INFO_VARIATION_PATH = "/info/variation/homo_sapiens"
+VEP_REST_URL = VEP_REST_HOST + VEP_REST_PATH
 VEP_BATCH_SIZE = 200
 VEP_RATE_LIMIT_SECONDS = 0.07  # ~15 requests/second
-ENSEMBL_INFO_VARIATION_URL = "https://rest.ensembl.org/info/variation/homo_sapiens"
+ENSEMBL_INFO_VARIATION_URL = VEP_REST_HOST + ENSEMBL_INFO_VARIATION_PATH
 GNOMAD_VERSION_LABEL = "v4.1"  # info/variation does not list gnomAD; no live source exists
 DEMO_CLINVAR_LABEL = "2025-03-01 release"
+
+
+def _ensembl_rest_host(assembly: str) -> str:
+    """The main Ensembl REST host always serves GRCh38 and silently ignores
+    an ``assembly`` query parameter; GRCh37 data (and its ClinVar/dbSNP/OMIM
+    versions, which the two hosts do not agree on) lives only on the separate
+    grch37.rest.ensembl.org mirror. Both the VEP annotation POST and the
+    data-source version GET must route through this, so a GRCh37 run never
+    certifies data, or a version, that actually came from the GRCh38 host."""
+    return VEP_REST_HOST_GRCH37 if assembly == "GRCh37" else VEP_REST_HOST
 
 
 # ---------------------------------------------------------------------------
@@ -271,15 +285,20 @@ def _extract_evidence_from_vep(vep_result: dict, record: VcfRecord) -> VariantEv
     )
 
 
-def _fetch_ensembl_data_versions() -> dict[str, str] | None:
+def _fetch_ensembl_data_versions(assembly: str = "GRCh38") -> dict[str, str] | None:
     """Query the live source versions bundled with Ensembl's variation data
     (ClinVar, dbSNP, OMIM), for the Data Sources report section. gnomAD is not
-    listed by this endpoint and stays a hardcoded constant (GNOMAD_VERSION_LABEL)."""
+    listed by this endpoint and stays a hardcoded constant (GNOMAD_VERSION_LABEL).
+
+    Uses the same assembly-selected host as the VEP annotation call
+    (_ensembl_rest_host) — see that function's docstring for why a GRCh37 run
+    must not hit the GRCh38 host here either.
+    """
     try:
         import requests
         resp = requests.get(
-            ENSEMBL_INFO_VARIATION_URL,
-            headers={"Content-Type": "application/json"},
+            _ensembl_rest_host(assembly) + ENSEMBL_INFO_VARIATION_PATH,
+            headers={"Accept": "application/json"},  # GET, not a body: Accept, not Content-Type
             timeout=10,
         )
         resp.raise_for_status()
@@ -303,10 +322,18 @@ def annotate_variants_vep(
 ) -> tuple[list[VariantEvidence], dict[str, str] | None]:
     """Annotate variants via Ensembl VEP REST API.
 
-    Returns (evidence_list, source_versions). source_versions is fetched once,
-    only if at least one VEP batch succeeded, so a run where every batch fails
-    never stamps a report with data-source versions for annotation that never
-    happened.
+    Returns (evidence_list, source_versions). source_versions distinguishes
+    two failure states rather than collapsing both to None:
+      - None: no VEP batch succeeded this run (nothing was annotated), so a
+        report must not make any data-source claim at all.
+      - {} (empty dict): at least one VEP batch succeeded, but the separate
+        Ensembl data-source version lookup itself failed. Annotation is real;
+        the version check is what's missing.
+      - a non-empty dict: the lookup succeeded (individual sources may still
+        be absent from Ensembl's response).
+
+    The POST is routed through the assembly-selected host (_ensembl_rest_host)
+    so a GRCh37 run does not silently get GRCh38 annotations from the main host.
     """
     try:
         import requests
@@ -316,6 +343,7 @@ def annotate_variants_vep(
 
     evidence_list: list[VariantEvidence] = []
     any_batch_succeeded = False
+    vep_url = _ensembl_rest_host(assembly) + VEP_REST_PATH
 
     for batch_start in range(0, len(records), VEP_BATCH_SIZE):
         batch = records[batch_start:batch_start + VEP_BATCH_SIZE]
@@ -323,7 +351,7 @@ def annotate_variants_vep(
 
         try:
             resp = requests.post(
-                VEP_REST_URL,
+                vep_url,
                 json={"variants": regions},
                 headers={"Content-Type": "application/json", "Accept": "application/json"},
                 params={"assembly": assembly, "transcript_version": 1},
@@ -358,7 +386,14 @@ def annotate_variants_vep(
 
         time.sleep(VEP_RATE_LIMIT_SECONDS)
 
-    source_versions = _fetch_ensembl_data_versions() if any_batch_succeeded else None
+    if not any_batch_succeeded:
+        source_versions = None
+    else:
+        fetched = _fetch_ensembl_data_versions(assembly=assembly)
+        # Annotation succeeded even if this lookup didn't: {} (not None) marks
+        # "tried and failed" so the report can't confuse this with "nothing
+        # was annotated" (see _data_source_versions_for_report).
+        source_versions = fetched if fetched is not None else {}
     return evidence_list, source_versions
 
 
@@ -413,11 +448,22 @@ CLASS_SHORT = {"Pathogenic": "P", "Likely Pathogenic": "LP", "Uncertain Signific
 def _data_source_versions_for_report(
     demo: bool, source_versions: dict[str, str] | None,
 ) -> dict[str, str]:
-    """Single source of truth for the Data Sources table, result.json and
-    database_versions.json, so the three can't drift independently.
+    """Prose labels for the Markdown Data Sources table. Never performs a
+    network call: source_versions must already be captured
+    (annotate_variants_vep, at annotation time), and is one of three states
+    that each get their own label rather than collapsing into one sentence:
 
-    Never performs a network call: source_versions must already be captured
-    (annotate_variants_vep, at annotation time) or None.
+      - None: no VEP batch succeeded this run, so no claim can be made about
+        any source, including gnomAD's hardcoded constant.
+      - {} (empty dict): at least one VEP batch succeeded, but the separate
+        Ensembl data-source version lookup itself failed (network/HTTP/JSON
+        error) — annotation is real, only the version check is missing.
+      - a non-empty dict: the lookup succeeded; an individual source can
+        still be absent from Ensembl's response (e.g. no ClinVar entry),
+        reported per-source rather than as a run-wide failure.
+
+    See _structured_data_source_versions for the machine-readable form used
+    by result.json / database_versions.json.
     """
     if demo:
         return {
@@ -425,9 +471,17 @@ def _data_source_versions_for_report(
             "gnomAD": f"{GNOMAD_VERSION_LABEL} (demo cache)",
         }
 
-    if not source_versions:
+    gnomad_label = f"{GNOMAD_VERSION_LABEL} (hardcoded; Ensembl serves no gnomAD version endpoint)"
+
+    if source_versions is None:
         note = "unavailable (no variant was successfully annotated this run)"
         return {"ClinVar": note, "gnomAD": note}
+
+    if not source_versions:
+        return {
+            "ClinVar": "unavailable (annotation succeeded, but the Ensembl version lookup failed)",
+            "gnomAD": gnomad_label,
+        }
 
     clinvar_v = source_versions.get("clinvar")
     clinvar_label = (
@@ -436,7 +490,31 @@ def _data_source_versions_for_report(
     )
     return {
         "ClinVar": clinvar_label,
-        "gnomAD": f"{GNOMAD_VERSION_LABEL} (via Ensembl VEP colocated variants)",
+        "gnomAD": gnomad_label,
+    }
+
+
+def _structured_data_source_versions(
+    demo: bool, source_versions: dict[str, str] | None,
+) -> dict[str, str | None]:
+    """Machine-readable counterpart to _data_source_versions_for_report, for
+    result.json / database_versions.json: real values or null, never prose,
+    so the audit trail can be parsed rather than grepped (review on #303/#327:
+    'data_source_versions currently receives English prose ... emit the
+    structured form there and keep prose for the Markdown table')."""
+    if demo:
+        return {
+            "clinvar": DEMO_CLINVAR_LABEL,
+            "dbsnp": None,
+            "omim": None,
+            "gnomad": GNOMAD_VERSION_LABEL,
+        }
+    sv = source_versions or {}
+    return {
+        "clinvar": sv.get("clinvar"),
+        "dbsnp": sv.get("dbsnp"),
+        "omim": sv.get("omim"),
+        "gnomad": GNOMAD_VERSION_LABEL,
     }
 
 
@@ -469,13 +547,14 @@ def generate_report(
 
     sf_variants = [cv for cv in classified if cv.is_secondary_finding]
     data_sources = _data_source_versions_for_report(demo, source_versions)
+    structured_versions = _structured_data_source_versions(demo, source_versions)
 
     _write_markdown_report(classified, counts, sf_variants, output_dir, timestamp, demo, assembly, input_path, data_sources)
     _write_classification_table(classified, output_dir)
     _write_secondary_findings_table(sf_variants, output_dir)
-    _write_result_json(classified, counts, sf_variants, output_dir, timestamp, demo, assembly, data_sources)
+    _write_result_json(classified, counts, sf_variants, output_dir, timestamp, demo, assembly, structured_versions)
     _write_classification_figure(counts, output_dir)
-    _write_reproducibility(output_dir, demo, assembly, input_path, timestamp, data_sources)
+    _write_reproducibility(output_dir, demo, assembly, input_path, timestamp, structured_versions)
 
 
 def _write_markdown_report(
@@ -665,7 +744,7 @@ def _write_result_json(
     timestamp: str,
     demo: bool,
     assembly: str,
-    data_sources: dict[str, str],
+    data_source_versions: dict[str, str | None],
 ) -> None:
     result = {
         "tool": "ClawBio Clinical Variant Reporter",
@@ -675,7 +754,7 @@ def _write_result_json(
         "assembly": assembly,
         "timestamp": timestamp,
         "mode": "demo" if demo else "live",
-        "data_source_versions": data_sources,
+        "data_source_versions": data_source_versions,
         "total_variants": len(classified),
         "classification_counts": counts,
         "secondary_findings_count": len(sf_variants),
@@ -741,7 +820,7 @@ def _write_reproducibility(
     assembly: str,
     input_path: str,
     timestamp: str,
-    data_sources: dict[str, str],
+    data_source_versions: dict[str, str | None],
 ) -> None:
     cmd = f"python {Path(__file__).name}"
     if demo:
@@ -759,7 +838,7 @@ def _write_reproducibility(
         "sf_list": "ACMG SF v3.2 (Miller et al. 2023)",
         "sf_gene_count": len(ACMG_SF_V32_GENES),
         "annotation_backend": "demo_cache" if demo else "Ensembl VEP REST (GRCh38)",
-        "data_source_versions": data_sources,
+        "data_source_versions": data_source_versions,
         "generated": timestamp,
     }
     (output_dir / "reproducibility" / "database_versions.json").write_text(

--- a/skills/clinical-variant-reporter/clinical_variant_reporter.py
+++ b/skills/clinical-variant-reporter/clinical_variant_reporter.py
@@ -508,7 +508,14 @@ def _structured_data_source_versions(
             "omim": None,
             "gnomad": GNOMAD_VERSION_LABEL,
         }
-    sv = source_versions or {}
+    # source_versions is None only when no VEP batch succeeded this run, i.e.
+    # nothing was annotated -- report.md's prose form says as much for gnomAD
+    # too (_data_source_versions_for_report's `note` branch), so the
+    # structured form must not assert the hardcoded gnomAD constant here
+    # either (review on #327, blocking item 2: the two artefacts disagreed).
+    if source_versions is None:
+        return {"clinvar": None, "dbsnp": None, "omim": None, "gnomad": None}
+    sv = source_versions
     return {
         "clinvar": sv.get("clinvar"),
         "dbsnp": sv.get("dbsnp"),

--- a/skills/clinical-variant-reporter/tests/test_clinical_variant_reporter.py
+++ b/skills/clinical-variant-reporter/tests/test_clinical_variant_reporter.py
@@ -27,6 +27,10 @@ from acmg_engine import (
     is_secondary_finding_gene,
 )
 from clinical_variant_reporter import (
+    ENSEMBL_INFO_VARIATION_PATH,
+    VEP_REST_HOST,
+    VEP_REST_HOST_GRCH37,
+    VEP_REST_PATH,
     VEP_REST_URL,
     annotate_variants_vep,
     build_evidence_from_cache,
@@ -410,6 +414,67 @@ class TestVepLivePath:
             f"Expected transcript_version=1 in VEP params, got: {params}"
         )
 
+    @staticmethod
+    def _mock_vep_response():
+        from unittest.mock import MagicMock
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = [{
+            "input": "1 100 100 A/G 1",
+            "most_severe_consequence": "missense_variant",
+            "transcript_consequences": [{
+                "gene_symbol": "FAKEGENE", "impact": "MODERATE",
+                "consequence_terms": ["missense_variant"],
+                "transcript_id": "ENST00000000001.3",
+            }],
+        }]
+        return resp
+
+    def test_vep_post_uses_grch38_host_by_default(self, monkeypatch):
+        """rest.ensembl.org always serves GRCh38 regardless of the assembly
+        query param, so the default (no --assembly) run must hit that host."""
+        from clinical_variant_reporter import VcfRecord
+
+        captured_urls: list[str] = []
+
+        def mock_post(*args, **kwargs):
+            captured_urls.append(args[0] if args else kwargs.get("url"))
+            return self._mock_vep_response()
+
+        import requests
+        monkeypatch.setattr(requests, "post", mock_post)
+        monkeypatch.setattr("clinical_variant_reporter.VEP_RATE_LIMIT_SECONDS", 0)
+
+        records = [VcfRecord(chrom="1", pos=100, id=".", ref="A", alt="G",
+                             qual=".", filt="PASS", info={})]
+        annotate_variants_vep(records, assembly="GRCh38")
+
+        assert captured_urls == [VEP_REST_HOST + VEP_REST_PATH]
+
+    def test_vep_post_switches_host_for_grch37(self, monkeypatch):
+        """--assembly GRCh37 must POST to grch37.rest.ensembl.org, not the
+        main host, which silently serves GRCh38 regardless of the assembly
+        query param (review on #327: 'derive the host from assembly for
+        both the VEP POST and the version GET')."""
+        from clinical_variant_reporter import VcfRecord
+
+        captured_urls: list[str] = []
+
+        def mock_post(*args, **kwargs):
+            captured_urls.append(args[0] if args else kwargs.get("url"))
+            return self._mock_vep_response()
+
+        import requests
+        monkeypatch.setattr(requests, "post", mock_post)
+        monkeypatch.setattr("clinical_variant_reporter.VEP_RATE_LIMIT_SECONDS", 0)
+
+        records = [VcfRecord(chrom="1", pos=100, id=".", ref="A", alt="G",
+                             qual=".", filt="PASS", info={})]
+        annotate_variants_vep(records, assembly="GRCh37")
+
+        assert captured_urls == [VEP_REST_HOST_GRCH37 + VEP_REST_PATH]
+        assert captured_urls != [VEP_REST_HOST + VEP_REST_PATH]
+
 
 # ---------------------------------------------------------------------------
 # Regression — VEP clin_sig_allele may be a string, not a dict
@@ -472,10 +537,13 @@ class TestDataSourcesVersioning:
             source_versions={"clinvar": "09/2025", "dbsnp": "156", "omim": "09/2025"},
         )
         assert "ClinVar | 09/2025 (via Ensembl VEP colocated variants)" in text
-        assert "gnomAD | v4.1 (via Ensembl VEP colocated variants)" in text
+        assert "gnomAD | v4.1 (hardcoded; Ensembl serves no gnomAD version endpoint)" in text
         assert "2025-03-01 release" not in text
 
     def test_live_mode_suppresses_claim_when_nothing_annotated(self, tmp_path):
+        # source_versions is None: annotate_variants_vep never had a
+        # successful VEP batch, so no source, including gnomAD's own
+        # hardcoded constant, may be claimed for this run.
         text = self._report_text(tmp_path, demo=False, source_versions=None)
         assert "unavailable (no variant was successfully annotated this run)" in text
         assert "v4.1" not in text
@@ -486,7 +554,20 @@ class TestDataSourcesVersioning:
         # response happened to carry no ClinVar entry this run.
         text = self._report_text(tmp_path, demo=False, source_versions={"dbsnp": "156"})
         assert "ClinVar | unavailable (Ensembl did not report a ClinVar version this run)" in text
-        assert "gnomAD | v4.1 (via Ensembl VEP colocated variants)" in text
+        assert "gnomAD | v4.1 (hardcoded; Ensembl serves no gnomAD version endpoint)" in text
+
+    def test_live_mode_flags_version_lookup_failure_distinctly_from_no_annotation(self, tmp_path):
+        # source_versions == {} (empty dict, not None): at least one VEP batch
+        # succeeded but the separate Ensembl version lookup itself failed.
+        # Before this fix both states printed the identical "no variant was
+        # successfully annotated this run" sentence, which is false when
+        # annotation actually ran (review on #327, blocking item 1).
+        text = self._report_text(tmp_path, demo=False, source_versions={})
+        assert "ClinVar | unavailable (annotation succeeded, but the Ensembl version lookup failed)" in text
+        assert "no variant was successfully annotated this run" not in text
+        # gnomAD is a hardcoded constant independent of this lookup, so
+        # annotation having succeeded still lets it be claimed.
+        assert "gnomAD | v4.1 (hardcoded; Ensembl serves no gnomAD version endpoint)" in text
 
     def test_demo_mode_labels_as_demo_cache(self, tmp_path, monkeypatch):
         import requests
@@ -520,6 +601,45 @@ class TestDataSourcesVersioning:
         assert source_versions is None
         generate_report(classified, tmp_path, demo=True, source_versions=source_versions)
         assert (tmp_path / "report.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Regression — result.json / database_versions.json must carry the
+# structured ClinVar/dbSNP/OMIM/gnomAD versions, not only prose (review on
+# #327 smaller items: "Keep the audit JSON machine-readable")
+# ---------------------------------------------------------------------------
+class TestStructuredDataSourceVersions:
+    def test_live_mode_writes_structured_versions_to_result_and_db_json(self, tmp_path):
+        generate_report(
+            [], tmp_path, demo=False,
+            source_versions={"clinvar": "09/2025", "dbsnp": "156", "omim": "09/2025"},
+        )
+        result = json.loads((tmp_path / "result.json").read_text())
+        assert result["data_source_versions"] == {
+            "clinvar": "09/2025", "dbsnp": "156", "omim": "09/2025", "gnomad": "v4.1",
+        }
+        db_versions = json.loads(
+            (tmp_path / "reproducibility" / "database_versions.json").read_text()
+        )
+        assert db_versions["data_source_versions"] == {
+            "clinvar": "09/2025", "dbsnp": "156", "omim": "09/2025", "gnomad": "v4.1",
+        }
+
+    def test_live_mode_nulls_missing_sources_rather_than_prose(self, tmp_path):
+        # source_versions == {}: annotation succeeded, lookup failed. The
+        # structured form must use null, not the "unavailable (...)" prose
+        # that the Markdown table shows, so it stays machine-parseable.
+        generate_report([], tmp_path, demo=False, source_versions={})
+        result = json.loads((tmp_path / "result.json").read_text())
+        assert result["data_source_versions"] == {
+            "clinvar": None, "dbsnp": None, "omim": None, "gnomad": "v4.1",
+        }
+
+    def test_demo_mode_structured_versions(self, tmp_path):
+        generate_report([], tmp_path, demo=True)
+        result = json.loads((tmp_path / "result.json").read_text())
+        assert result["data_source_versions"]["clinvar"] == "2025-03-01 release"
+        assert result["data_source_versions"]["gnomad"] == "v4.1"
 
 
 # ---------------------------------------------------------------------------
@@ -559,17 +679,34 @@ class TestAnnotateCapturesSourceVersions:
         monkeypatch.setattr(requests, "post", lambda *a, **k: self._mock_vep_success())
         monkeypatch.setattr("clinical_variant_reporter.VEP_RATE_LIMIT_SECONDS", 0)
 
+        captured_args: list[tuple] = []
+        captured_kwargs: list[dict] = []
+
         info_resp = MagicMock()
         info_resp.json.return_value = [
             {"name": "ClinVar", "version": "09/2025"},
             {"name": "dbSNP", "version": "156"},
             {"name": "OMIM", "version": "09/2025"},
         ]
-        monkeypatch.setattr(requests, "get", lambda *a, **k: info_resp)
+
+        def mock_get(*args, **kwargs):
+            captured_args.append(args)
+            captured_kwargs.append(kwargs)
+            return info_resp
+
+        monkeypatch.setattr(requests, "get", mock_get)
 
         evidence_list, source_versions = annotate_variants_vep([self._vcf_record()])
         assert len(evidence_list) == 1
         assert source_versions == {"clinvar": "09/2025", "dbsnp": "156", "omim": "09/2025"}
+
+        # The suite must not pass identically if the code reverts to the old
+        # /info/rest endpoint (review on #327, blocking item 3): assert the
+        # actual URL called, not just that requests.get was called at all.
+        assert len(captured_args) == 1
+        called_url = captured_args[0][0] if captured_args[0] else captured_kwargs[0].get("url")
+        assert called_url == VEP_REST_HOST + ENSEMBL_INFO_VARIATION_PATH
+        assert captured_kwargs[0].get("timeout") == 10
 
     def test_source_versions_none_when_every_batch_fails(self, monkeypatch):
         import requests
@@ -589,6 +726,79 @@ class TestAnnotateCapturesSourceVersions:
         assert len(evidence_list) == 1  # unannotated placeholder, still returned
         assert source_versions is None
 
+    def test_source_versions_empty_dict_when_annotation_succeeds_but_lookup_fails(self, monkeypatch):
+        """The bug behind blocking item 1: before this fix, a failed version
+        lookup after successful annotation was indistinguishable from no
+        annotation at all (both produced source_versions is None). Now the
+        two states must differ: None means nothing was annotated, {} means
+        annotation succeeded but the lookup itself failed."""
+        import requests
+        from clinical_variant_reporter import annotate_variants_vep
+
+        monkeypatch.setattr(requests, "post", lambda *a, **k: self._mock_vep_success())
+        monkeypatch.setattr("clinical_variant_reporter.VEP_RATE_LIMIT_SECONDS", 0)
+
+        def raise_connection_error(*args, **kwargs):
+            raise requests.exceptions.ConnectionError("version host unreachable")
+
+        monkeypatch.setattr(requests, "get", raise_connection_error)
+
+        evidence_list, source_versions = annotate_variants_vep([self._vcf_record()])
+        assert len(evidence_list) == 1
+        assert source_versions == {}
+        assert source_versions is not None
+
+    def test_version_get_uses_grch38_host_by_default(self, monkeypatch):
+        from unittest.mock import MagicMock
+        import requests
+        from clinical_variant_reporter import annotate_variants_vep
+
+        monkeypatch.setattr(requests, "post", lambda *a, **k: self._mock_vep_success())
+        monkeypatch.setattr("clinical_variant_reporter.VEP_RATE_LIMIT_SECONDS", 0)
+
+        captured_urls: list[str] = []
+        info_resp = MagicMock()
+        info_resp.json.return_value = [{"name": "ClinVar", "version": "09/2025"}]
+
+        def mock_get(*args, **kwargs):
+            captured_urls.append(args[0] if args else kwargs.get("url"))
+            return info_resp
+
+        monkeypatch.setattr(requests, "get", mock_get)
+
+        annotate_variants_vep([self._vcf_record()], assembly="GRCh38")
+        assert captured_urls == [VEP_REST_HOST + ENSEMBL_INFO_VARIATION_PATH]
+
+    def test_version_get_switches_host_for_grch37(self, monkeypatch):
+        """grch37.rest.ensembl.org and rest.ensembl.org disagree on ClinVar's
+        version (measured in the review: 06/2023 vs 09/2025, 28 months
+        apart), so a --assembly GRCh37 run must fetch from the GRCh37 host
+        or it certifies a version that was never served for GRCh37 data
+        (review on #327, blocking item 2)."""
+        from unittest.mock import MagicMock
+        import requests
+        from clinical_variant_reporter import annotate_variants_vep
+
+        monkeypatch.setattr(requests, "post", lambda *a, **k: self._mock_vep_success())
+        monkeypatch.setattr("clinical_variant_reporter.VEP_RATE_LIMIT_SECONDS", 0)
+
+        captured_urls: list[str] = []
+        info_resp = MagicMock()
+        info_resp.json.return_value = [{"name": "ClinVar", "version": "06/2023"}]
+
+        def mock_get(*args, **kwargs):
+            captured_urls.append(args[0] if args else kwargs.get("url"))
+            return info_resp
+
+        monkeypatch.setattr(requests, "get", mock_get)
+
+        evidence_list, source_versions = annotate_variants_vep(
+            [self._vcf_record()], assembly="GRCh37",
+        )
+        assert captured_urls == [VEP_REST_HOST_GRCH37 + ENSEMBL_INFO_VARIATION_PATH]
+        assert captured_urls != [VEP_REST_HOST + ENSEMBL_INFO_VARIATION_PATH]
+        assert source_versions == {"clinvar": "06/2023"}
+
 
 # ---------------------------------------------------------------------------
 # Regression — _fetch_ensembl_data_versions error handling and parsing
@@ -599,13 +809,45 @@ class TestFetchEnsemblDataVersions:
     response, a non-JSON body, or a payload missing the ClinVar entry."""
 
     def test_http_error_returns_none_and_warns(self, monkeypatch, capsys):
+        """requests.get itself raising (network error, DNS failure, etc.),
+        as opposed to a real HTTP response whose raise_for_status() raises
+        (covered separately below)."""
         import requests
         from clinical_variant_reporter import _fetch_ensembl_data_versions
 
+        captured_kwargs: list[dict] = []
+
         def raise_http_error(*args, **kwargs):
+            captured_kwargs.append(kwargs)
             raise requests.exceptions.HTTPError("500 Server Error")
 
         monkeypatch.setattr(requests, "get", raise_http_error)
+
+        assert _fetch_ensembl_data_versions() is None
+        assert "WARNING" in capsys.readouterr().err
+        assert captured_kwargs[0].get("timeout") == 10
+
+    def test_raise_for_status_real_failure_returns_none_and_warns(self, monkeypatch, capsys):
+        """The gap the review named explicitly: a MagicMock's
+        raise_for_status() is a silent no-op by default, so a prior version
+        of this suite never actually exercised the resp.raise_for_status()
+        call in _fetch_ensembl_data_versions. This test uses a response
+        object whose raise_for_status() genuinely raises for a 4xx/5xx
+        status, driving the real code path rather than short-circuiting at
+        requests.get() itself."""
+        import requests
+        from clinical_variant_reporter import _fetch_ensembl_data_versions
+
+        class RealFailureResponse:
+            status_code = 429
+
+            def raise_for_status(self):
+                raise requests.exceptions.HTTPError("429 Too Many Requests")
+
+            def json(self):
+                raise AssertionError("json() must not be called after raise_for_status() raises")
+
+        monkeypatch.setattr(requests, "get", lambda *a, **k: RealFailureResponse())
 
         assert _fetch_ensembl_data_versions() is None
         assert "WARNING" in capsys.readouterr().err
@@ -626,10 +868,24 @@ class TestFetchEnsemblDataVersions:
         import requests
         from clinical_variant_reporter import _fetch_ensembl_data_versions
 
+        captured_args: list[tuple] = []
+        captured_kwargs: list[dict] = []
+
         resp = MagicMock()
         resp.json.return_value = [{"name": "dbSNP", "version": "156"}]
-        monkeypatch.setattr(requests, "get", lambda *a, **k: resp)
+
+        def mock_get(*args, **kwargs):
+            captured_args.append(args)
+            captured_kwargs.append(kwargs)
+            return resp
+
+        monkeypatch.setattr(requests, "get", mock_get)
 
         versions = _fetch_ensembl_data_versions()
         assert versions == {"dbsnp": "156"}
         assert "clinvar" not in versions
+
+        called_url = captured_args[0][0] if captured_args[0] else captured_kwargs[0].get("url")
+        assert called_url == VEP_REST_HOST + ENSEMBL_INFO_VARIATION_PATH
+        assert captured_kwargs[0].get("timeout") == 10
+        assert captured_kwargs[0].get("headers", {}).get("Accept") == "application/json"

--- a/skills/clinical-variant-reporter/tests/test_clinical_variant_reporter.py
+++ b/skills/clinical-variant-reporter/tests/test_clinical_variant_reporter.py
@@ -536,7 +536,7 @@ class TestDataSourcesVersioning:
             tmp_path, demo=False,
             source_versions={"clinvar": "09/2025", "dbsnp": "156", "omim": "09/2025"},
         )
-        assert "ClinVar | 09/2025 (via Ensembl VEP colocated variants)" in text
+        assert "ClinVar | 09/2025 (via Ensembl /info/variation/homo_sapiens)" in text
         assert "gnomAD | v4.1 (hardcoded; Ensembl serves no gnomAD version endpoint)" in text
         assert "2025-03-01 release" not in text
 
@@ -634,6 +634,17 @@ class TestStructuredDataSourceVersions:
         assert result["data_source_versions"] == {
             "clinvar": None, "dbsnp": None, "omim": None, "gnomad": "v4.1",
         }
+
+    def test_annotation_backend_stamps_the_assembly_actually_used(self, tmp_path):
+        # review #327: annotation_backend hardcoded "GRCh38" regardless of
+        # the assembly argument, so a GRCh37 run's own database_versions.json
+        # contradicted its GRCh37 data_source_versions (a ClinVar version
+        # that host never served, stamped under a GRCh38 backend label).
+        generate_report([], tmp_path, demo=False, assembly="GRCh37")
+        db_versions = json.loads(
+            (tmp_path / "reproducibility" / "database_versions.json").read_text()
+        )
+        assert db_versions["annotation_backend"] == "Ensembl VEP REST (GRCh37)"
 
     def test_demo_mode_structured_versions(self, tmp_path):
         generate_report([], tmp_path, demo=True)

--- a/skills/clinical-variant-reporter/tests/test_clinical_variant_reporter.py
+++ b/skills/clinical-variant-reporter/tests/test_clinical_variant_reporter.py
@@ -448,3 +448,47 @@ class TestClinSigAlleleTypeGuard:
         ev = _extract_evidence_from_vep(
             self._vep({"review_status_stars": 3}), self._record())
         assert ev.clinvar_review_stars == 3
+
+
+# ---------------------------------------------------------------------------
+# Regression — Data Sources table hardcoded stale ClinVar/gnomAD versions
+# ---------------------------------------------------------------------------
+class TestDataSourcesVersioning:
+    """The Data Sources section must reflect the Ensembl release actually
+    queried in live mode, and label demo mode as a cache rather than
+    implying a live query (issue #303)."""
+
+    def _report_text(self, tmp_path, demo):
+        from clinical_variant_reporter import generate_report
+        generate_report([], tmp_path, demo=demo)
+        return (tmp_path / "report.md").read_text()
+
+    def test_live_mode_reports_fetched_ensembl_release(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"release": 999}
+
+        import requests
+        monkeypatch.setattr(requests, "get", lambda *a, **k: mock_response)
+
+        text = self._report_text(tmp_path, demo=False)
+        assert "Ensembl release 999" in text
+        assert "2025-03-01 release" not in text
+        assert "v4.1" not in text
+
+    def test_live_mode_degrades_gracefully_when_fetch_fails(self, tmp_path, monkeypatch):
+        import requests
+
+        def raise_connection_error(*args, **kwargs):
+            raise requests.exceptions.ConnectionError("no network")
+
+        monkeypatch.setattr(requests, "get", raise_connection_error)
+
+        text = self._report_text(tmp_path, demo=False)
+        assert "Ensembl release unavailable" in text
+
+    def test_demo_mode_labels_as_demo_cache(self, tmp_path):
+        text = self._report_text(tmp_path, demo=True)
+        assert "ClinVar | 2025-03-01 release (demo cache)" in text
+        assert "gnomAD | v4.1 (demo cache)" in text

--- a/skills/clinical-variant-reporter/tests/test_clinical_variant_reporter.py
+++ b/skills/clinical-variant-reporter/tests/test_clinical_variant_reporter.py
@@ -273,7 +273,7 @@ class TestDemoMode:
 
     def test_demo_classification_counts(self, demo_vcf_path):
         records = parse_vcf(demo_vcf_path)
-        classified = run_classification(records, demo=True)
+        classified, _ = run_classification(records, demo=True)
         assert len(classified) == 20
 
         counts: dict[str, int] = {}
@@ -289,7 +289,7 @@ class TestDemoMode:
     def test_demo_expected_classifications(self, demo_vcf_path):
         """Validate each demo variant against its EXPECTED INFO field."""
         records = parse_vcf(demo_vcf_path)
-        classified = run_classification(records, demo=True)
+        classified, _ = run_classification(records, demo=True)
 
         expected_map = {
             "Pathogenic": "Pathogenic",
@@ -310,7 +310,7 @@ class TestDemoMode:
 
     def test_demo_secondary_findings_screening(self, demo_vcf_path):
         records = parse_vcf(demo_vcf_path)
-        classified = run_classification(records, demo=True)
+        classified, _ = run_classification(records, demo=True)
 
         sf_variants = [cv for cv in classified if cv.is_secondary_finding]
         non_sf = [cv for cv in classified if not cv.is_secondary_finding]
@@ -320,7 +320,7 @@ class TestDemoMode:
 
     def test_demo_report_generation(self, demo_vcf_path, tmp_path):
         records = parse_vcf(demo_vcf_path)
-        classified = run_classification(records, demo=True)
+        classified, _ = run_classification(records, demo=True)
         generate_report(classified, tmp_path, demo=True)
 
         assert (tmp_path / "report.md").exists()
@@ -342,7 +342,7 @@ class TestDemoMode:
     def test_demo_transcripts_are_versioned(self, demo_vcf_path):
         """HGVS v21.1 requires versioned transcript accessions (e.g. ENST00000357654.9)."""
         records = parse_vcf(demo_vcf_path)
-        classified = run_classification(records, demo=True)
+        classified, _ = run_classification(records, demo=True)
         import re
         versioned_pattern = re.compile(r"^ENST\d+\.\d+$")
         for cv in classified:
@@ -355,7 +355,7 @@ class TestDemoMode:
 
     def test_gene_filter(self, demo_vcf_path):
         records = parse_vcf(demo_vcf_path)
-        classified = run_classification(records, demo=True, gene_filter={"BRCA1", "TP53"})
+        classified, _ = run_classification(records, demo=True, gene_filter={"BRCA1", "TP53"})
         genes = {cv.evidence.gene for cv in classified}
         assert genes <= {"BRCA1", "TP53"}
         assert len(classified) >= 2
@@ -454,41 +454,182 @@ class TestClinSigAlleleTypeGuard:
 # Regression — Data Sources table hardcoded stale ClinVar/gnomAD versions
 # ---------------------------------------------------------------------------
 class TestDataSourcesVersioning:
-    """The Data Sources section must reflect the Ensembl release actually
-    queried in live mode, and label demo mode as a cache rather than
-    implying a live query (issue #303)."""
+    """The Data Sources section must reflect the ClinVar/dbSNP version Ensembl
+    actually served for the run, keep gnomAD's own hardcoded version (Ensembl's
+    variation endpoint does not list gnomAD), and label demo mode as a cache
+    rather than implying a live query (issue #303)."""
 
-    def _report_text(self, tmp_path, demo):
+    def _report_text(self, tmp_path, demo, source_versions=None):
         from clinical_variant_reporter import generate_report
-        generate_report([], tmp_path, demo=demo)
+        generate_report([], tmp_path, demo=demo, source_versions=source_versions)
         return (tmp_path / "report.md").read_text()
 
-    def test_live_mode_reports_fetched_ensembl_release(self, tmp_path, monkeypatch):
-        from unittest.mock import MagicMock
-
-        mock_response = MagicMock()
-        mock_response.json.return_value = {"release": 999}
-
-        import requests
-        monkeypatch.setattr(requests, "get", lambda *a, **k: mock_response)
-
-        text = self._report_text(tmp_path, demo=False)
-        assert "Ensembl release 999" in text
+    def test_live_mode_reports_real_clinvar_version_and_keeps_gnomad(self, tmp_path):
+        # source_versions is threaded in from annotation time (see
+        # TestAnnotateCapturesSourceVersions below), not fetched by generate_report.
+        text = self._report_text(
+            tmp_path, demo=False,
+            source_versions={"clinvar": "09/2025", "dbsnp": "156", "omim": "09/2025"},
+        )
+        assert "ClinVar | 09/2025 (via Ensembl VEP colocated variants)" in text
+        assert "gnomAD | v4.1 (via Ensembl VEP colocated variants)" in text
         assert "2025-03-01 release" not in text
-        assert "v4.1" not in text
 
-    def test_live_mode_degrades_gracefully_when_fetch_fails(self, tmp_path, monkeypatch):
+    def test_live_mode_suppresses_claim_when_nothing_annotated(self, tmp_path):
+        text = self._report_text(tmp_path, demo=False, source_versions=None)
+        assert "unavailable (no variant was successfully annotated this run)" in text
+        assert "v4.1" not in text
+        assert "09/2025" not in text
+
+    def test_live_mode_flags_missing_clinvar_entry_even_if_annotation_ran(self, tmp_path):
+        # Some annotation succeeded (source_versions is not None) but Ensembl's
+        # response happened to carry no ClinVar entry this run.
+        text = self._report_text(tmp_path, demo=False, source_versions={"dbsnp": "156"})
+        assert "ClinVar | unavailable (Ensembl did not report a ClinVar version this run)" in text
+        assert "gnomAD | v4.1 (via Ensembl VEP colocated variants)" in text
+
+    def test_demo_mode_labels_as_demo_cache(self, tmp_path, monkeypatch):
         import requests
 
-        def raise_connection_error(*args, **kwargs):
-            raise requests.exceptions.ConnectionError("no network")
+        def fail_if_called(*args, **kwargs):
+            raise AssertionError("demo mode must not touch the network")
 
-        monkeypatch.setattr(requests, "get", raise_connection_error)
+        monkeypatch.setattr(requests, "get", fail_if_called)
 
-        text = self._report_text(tmp_path, demo=False)
-        assert "Ensembl release unavailable" in text
-
-    def test_demo_mode_labels_as_demo_cache(self, tmp_path):
         text = self._report_text(tmp_path, demo=True)
         assert "ClinVar | 2025-03-01 release (demo cache)" in text
         assert "gnomAD | v4.1 (demo cache)" in text
+
+    def test_demo_pipeline_makes_zero_network_calls(self, tmp_path, monkeypatch):
+        """End-to-end demo mode (parse -> classify -> report) must stay fully
+        offline: patch both requests.get and requests.post to fail loudly."""
+        import requests
+        from clinical_variant_reporter import (
+            generate_report, parse_vcf, run_classification,
+        )
+
+        def fail_if_called(*args, **kwargs):
+            raise AssertionError("demo pipeline must not touch the network")
+
+        monkeypatch.setattr(requests, "get", fail_if_called)
+        monkeypatch.setattr(requests, "post", fail_if_called)
+
+        demo_vcf = SKILL_DIR / "example_data" / "giab_acmg_panel.vcf"
+        records = parse_vcf(demo_vcf)
+        classified, source_versions = run_classification(records, demo=True)
+        assert source_versions is None
+        generate_report(classified, tmp_path, demo=True, source_versions=source_versions)
+        assert (tmp_path / "report.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Regression — annotation-time provenance: version capture must be tied to
+# whether VEP annotation actually succeeded, not to report-generation time
+# ---------------------------------------------------------------------------
+class TestAnnotateCapturesSourceVersions:
+    """annotate_variants_vep must capture Ensembl's data-source versions once,
+    only when at least one VEP batch actually succeeded, so a report can never
+    claim provenance for annotation that never happened (issue #303 review)."""
+
+    def _vcf_record(self):
+        from clinical_variant_reporter import VcfRecord
+        return VcfRecord(chrom="1", pos=100, id=".", ref="A", alt="G",
+                          qual=".", filt="PASS", info={})
+
+    def _mock_vep_success(self):
+        from unittest.mock import MagicMock
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = [{
+            "input": "1 100 100 A/G 1",
+            "most_severe_consequence": "missense_variant",
+            "transcript_consequences": [{
+                "gene_symbol": "FAKEGENE", "impact": "MODERATE",
+                "consequence_terms": ["missense_variant"],
+                "transcript_id": "ENST00000000001.3",
+            }],
+        }]
+        return resp
+
+    def test_source_versions_captured_when_batch_succeeds(self, monkeypatch):
+        from unittest.mock import MagicMock
+        import requests
+        from clinical_variant_reporter import annotate_variants_vep
+
+        monkeypatch.setattr(requests, "post", lambda *a, **k: self._mock_vep_success())
+        monkeypatch.setattr("clinical_variant_reporter.VEP_RATE_LIMIT_SECONDS", 0)
+
+        info_resp = MagicMock()
+        info_resp.json.return_value = [
+            {"name": "ClinVar", "version": "09/2025"},
+            {"name": "dbSNP", "version": "156"},
+            {"name": "OMIM", "version": "09/2025"},
+        ]
+        monkeypatch.setattr(requests, "get", lambda *a, **k: info_resp)
+
+        evidence_list, source_versions = annotate_variants_vep([self._vcf_record()])
+        assert len(evidence_list) == 1
+        assert source_versions == {"clinvar": "09/2025", "dbsnp": "156", "omim": "09/2025"}
+
+    def test_source_versions_none_when_every_batch_fails(self, monkeypatch):
+        import requests
+        from clinical_variant_reporter import annotate_variants_vep
+
+        def raise_timeout(*args, **kwargs):
+            raise requests.exceptions.Timeout("no response")
+
+        def fail_if_called(*args, **kwargs):
+            raise AssertionError("version fetch must not run when nothing was annotated")
+
+        monkeypatch.setattr(requests, "post", raise_timeout)
+        monkeypatch.setattr(requests, "get", fail_if_called)
+        monkeypatch.setattr("clinical_variant_reporter.VEP_RATE_LIMIT_SECONDS", 0)
+
+        evidence_list, source_versions = annotate_variants_vep([self._vcf_record()])
+        assert len(evidence_list) == 1  # unannotated placeholder, still returned
+        assert source_versions is None
+
+
+# ---------------------------------------------------------------------------
+# Regression — _fetch_ensembl_data_versions error handling and parsing
+# ---------------------------------------------------------------------------
+class TestFetchEnsemblDataVersions:
+    """The live-mode version fetch must name the exception and warn on stderr
+    (matching the VEP handler's style), and must not crash on a 4xx/5xx
+    response, a non-JSON body, or a payload missing the ClinVar entry."""
+
+    def test_http_error_returns_none_and_warns(self, monkeypatch, capsys):
+        import requests
+        from clinical_variant_reporter import _fetch_ensembl_data_versions
+
+        def raise_http_error(*args, **kwargs):
+            raise requests.exceptions.HTTPError("500 Server Error")
+
+        monkeypatch.setattr(requests, "get", raise_http_error)
+
+        assert _fetch_ensembl_data_versions() is None
+        assert "WARNING" in capsys.readouterr().err
+
+    def test_non_json_body_returns_none(self, monkeypatch):
+        from unittest.mock import MagicMock
+        import requests
+        from clinical_variant_reporter import _fetch_ensembl_data_versions
+
+        resp = MagicMock()
+        resp.json.side_effect = ValueError("not JSON")
+        monkeypatch.setattr(requests, "get", lambda *a, **k: resp)
+
+        assert _fetch_ensembl_data_versions() is None
+
+    def test_payload_missing_clinvar_entry(self, monkeypatch):
+        from unittest.mock import MagicMock
+        import requests
+        from clinical_variant_reporter import _fetch_ensembl_data_versions
+
+        resp = MagicMock()
+        resp.json.return_value = [{"name": "dbSNP", "version": "156"}]
+        monkeypatch.setattr(requests, "get", lambda *a, **k: resp)
+
+        versions = _fetch_ensembl_data_versions()
+        assert versions == {"dbsnp": "156"}
+        assert "clinvar" not in versions

--- a/skills/clinical-variant-reporter/tests/test_clinical_variant_reporter.py
+++ b/skills/clinical-variant-reporter/tests/test_clinical_variant_reporter.py
@@ -635,6 +635,21 @@ class TestStructuredDataSourceVersions:
             "clinvar": None, "dbsnp": None, "omim": None, "gnomad": "v4.1",
         }
 
+    def test_live_mode_nulls_gnomad_too_when_nothing_annotated(self, tmp_path):
+        # source_versions is None: no VEP batch succeeded this run, so no
+        # source-version claim can be made at all -- including gnomAD's
+        # hardcoded constant. report.md already says "unavailable (no
+        # variant was successfully annotated this run)" for both ClinVar and
+        # gnomAD in this case (_data_source_versions_for_report's `note`
+        # branch); result.json previously still asserted the gnomAD constant
+        # here, so the two artefacts of one run disagreed on whether a
+        # gnomAD claim may be made (review on #327, blocking item 2).
+        generate_report([], tmp_path, demo=False, source_versions=None)
+        result = json.loads((tmp_path / "result.json").read_text())
+        assert result["data_source_versions"] == {
+            "clinvar": None, "dbsnp": None, "omim": None, "gnomad": None,
+        }
+
     def test_annotation_backend_stamps_the_assembly_actually_used(self, tmp_path):
         # review #327: annotation_backend hardcoded "GRCh38" regardless of
         # the assembly argument, so a GRCh37 run's own database_versions.json
@@ -714,8 +729,13 @@ class TestAnnotateCapturesSourceVersions:
         # The suite must not pass identically if the code reverts to the old
         # /info/rest endpoint (review on #327, blocking item 3): assert the
         # actual URL called, not just that requests.get was called at all.
+        # Pinned against the LITERAL path, not just ENSEMBL_INFO_VARIATION_PATH --
+        # a constant-relative-only assertion stays green even if the constant
+        # itself regresses to the wrong endpoint (mutation-tested on review:
+        # changing the constant to "/info/software" left 72 tests unchanged).
         assert len(captured_args) == 1
         called_url = captured_args[0][0] if captured_args[0] else captured_kwargs[0].get("url")
+        assert called_url == "https://rest.ensembl.org/info/variation/homo_sapiens"
         assert called_url == VEP_REST_HOST + ENSEMBL_INFO_VARIATION_PATH
         assert captured_kwargs[0].get("timeout") == 10
 

--- a/skills/clinical-variant-reporter/tests/test_self_audit.py
+++ b/skills/clinical-variant-reporter/tests/test_self_audit.py
@@ -117,7 +117,7 @@ def test_run_classification_hard_abstains_on_identity_mismatch():
     rec = VcfRecord(chrom=chrom, pos=pos, id=".", ref=ref, alt=alt,
                     qual=".", filt="PASS",
                     info={"GENE": "BRCA1", "EXPECTED_HGVSP": "p.Thr67Ile"})
-    out = run_classification([rec], demo=True)
+    out, _ = run_classification([rec], demo=True)
     assert len(out) == 1
     assert out[0].classification == ABSTAIN_LABEL
     assert "IDENTITY_MISMATCH" in [v.code for v in out[0].audit_violations]


### PR DESCRIPTION
## Root cause

`_write_markdown_report`'s Data Sources section hardcoded `ClinVar 2025-03-01 release`
and `gnomAD v4.1` unconditionally, in both demo and live mode, and the GRCh37 code path
queried the GRCh38 Ensembl host for both variant annotation and version lookup. A report
generated against a newer live release, or against GRCh37 data, still claimed the
2025-03-01 GRCh38 ClinVar snapshot.

## Fix

In live mode, fetch ClinVar/dbSNP/OMIM versions from Ensembl's
`GET /info/variation/homo_sapiens` (not `info/software`, which doesn't carry them) and
report them as returned for the run, using the correct host for the requested assembly
(`grch37.rest.ensembl.org` for GRCh37, matching the VEP annotation call itself). gnomAD
stays hardcoded and labeled as such, since Ensembl's variation endpoint doesn't list it.
`annotation_backend` in `database_versions.json` now names the assembly actually used
instead of hardcoding GRCh38. A failed lookup (network error, timeout, non-JSON body)
degrades to an explicit "unavailable" label distinct from "annotation succeeded but the
lookup failed" vs. "nothing was annotated," rather than silently falling back to a stale
hardcode. Demo mode says "demo cache" explicitly instead of implying a live query.
`result.json`/`database_versions.json` carry these as structured fields (string or null),
not just prose in `report.md`.

## Verification

- New/updated tests fail on `main` (hardcoded strings, wrong host for GRCh37, wrong
  backend label) and pass with this fix: GRCh37 routes to the GRCh37 host for both the
  VEP call and the version lookup, `annotation_backend` matches the assembly, and the
  three annotation outcomes (succeeded, ran but lookup failed, nothing annotated) each
  get a distinct label.
- Full `skills/clinical-variant-reporter/tests/` suite: 72 passed.
- Live-verified this session against the real Ensembl REST API (not just fixtures):
  `GET /info/variation/homo_sapiens` on the GRCh38 and GRCh37 hosts returns ClinVar
  `09/2025` and `06/2023` respectively, confirming both the endpoint shape and the
  GRCh37 host-routing fix are load-bearing, not just internally consistent.
- Not checked: gnomAD's hardcoded version against a live source, since Ensembl exposes
  none; no end-to-end run against a real patient VCF.

Fixes #303
