### PR TITLE
ci: run the tests of any skill a PR touches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+          # Needed to diff against the PR base and find which skills changed.
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
@@ -145,6 +147,34 @@ jobs:
 
       - name: Run bot security tests
         run: uv run pytest bot/tests/test_security.py -v
+
+      # The steps above are a hardcoded allowlist, so a NEW skill's tests never
+      # run: ClawBio#329 shipped a test that cannot pass and CI was still green,
+      # and ClawBio#324's just-prs suite never executed here at all. Any skill
+      # touched by a PR now has its own tests run, which is the minimum bar for
+      # a contribution to be considered verified.
+      - name: Run tests for skills changed in this PR
+        if: github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          base="${{ github.event.pull_request.base.sha }}"
+          changed=$(git diff --name-only "$base" HEAD -- 'skills/*' \
+                    | cut -d/ -f2 | sort -u)
+          if [ -z "$changed" ]; then
+            echo "No skills touched by this PR."
+            exit 0
+          fi
+          status=0
+          for skill in $changed; do
+            if [ -d "skills/$skill/tests" ]; then
+              echo "::group::pytest skills/$skill/tests"
+              uv run pytest "skills/$skill/tests" -v || status=1
+              echo "::endgroup::"
+            else
+              echo "WARNING: skills/$skill has no tests/ directory"
+            fi
+          done
+          exit $status
 
   benchmark:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CI green did not mean a contribution was tested.

The `test` job runs a **hardcoded allowlist** of eleven named test files, so a skill outside that list is never exercised and a brand-new skill never can be.

Live consequences, all from this week:
- **#329** ships a test that cannot pass (it drives `amplicon_qc.py` while the PR adds `amplicon_qc.R`) and CI reported **success**.
- **#324**'s `just-prs-mcp` suite never ran here at all — it was merged on locally run tests alone.
- **#327** touches `clinical-variant-reporter`, also absent from the allowlist, so its 54 tests have never gated a PR.

This adds a step that runs the tests of any skill directory a PR touches. The allowlist stays as the baseline for pushes to `main`; this fills the gap. `fetch-depth: 0` is needed so the base commit is present to diff against.

Verified against the open PRs: #329 resolves to `claw-amplicon-qc` (and goes red, correctly), #327 resolves to `clinical-variant-reporter`.

**Caveat worth a maintainer's eye:** this makes a PR touching a skill whose tests currently fail go red. That is the intended contract, but it may surface pre-existing breakage the allowlist has been shielding.

Separately: fork PRs from first-time contributors park in `action_required` until approved, which surfaces as "no checks reported" and reads like a pass. I approved the pending runs for #327 and #329. The approval policy itself is GitHub's recommended default and I have left it alone.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Stricter gating on PRs may turn CI red for skills with failing tests that the allowlist never ran; change is limited to CI workflow logic, not runtime product code.
> 
> **Overview**
> The **`test` job** still runs the existing hardcoded pytest allowlist on every run, but **pull requests** now also exercise tests for any `skills/<name>/` directory that changed relative to the PR base.
> 
> Checkout in that job sets **`fetch-depth: 0`** so `github.event.pull_request.base.sha` is available for `git diff`. A new step ( **`if: github.event_name == 'pull_request'`** ) lists paths under `skills/*`, derives unique skill folder names, runs `uv run pytest skills/$skill/tests` when `tests/` exists (with GitHub log grouping), warns when there is no `tests/` directory, and fails the job if any targeted suite fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5230cae9b8f1fad13684f8db37e1677fb141d1eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->