### PR TITLE
fix(ci): scope changed-skill tests to the PR's own diff, install extras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --locked
+          # --all-extras: skill-level deps live in [project.optional-dependencies]
+          # (just-prs declares typer and fastmcp). A plain sync omits them, so
+          # skills/just-prs-mcp/tests failed to import typer and took the whole
+          # job down with it on any PR that reached those tests.
+          uv sync --locked --all-extras
           uv pip install pytest requests
 
       - name: Test ClawBio CLI
@@ -157,8 +161,17 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           set -euo pipefail
-          base="${{ github.event.pull_request.base.sha }}"
-          changed=$(git diff --name-only "$base" HEAD -- 'skills/*' \
+          # Diff the PR head against its FORK POINT, not against the base tip.
+          # actions/checkout resolves a pull_request to refs/pull/N/merge, so
+          # HEAD is a merge commit containing main's later commits too, and
+          # pull_request.base.sha is the base tip as of when the PR was opened.
+          # Using either directly attributes everything merged into main since
+          # to the PR: on #327 that turned one touched skill into five, and an
+          # unrelated skill's broken import was reported as the PR's failure.
+          head="${{ github.event.pull_request.head.sha }}"
+          base=$(git merge-base "${{ github.event.pull_request.base.sha }}" "$head")
+          echo "Diffing $base..$head"
+          changed=$(git diff --name-only "$base" "$head" -- 'skills/*' \
                     | cut -d/ -f2 | sort -u)
           if [ -z "$changed" ]; then
             echo "No skills touched by this PR."
@@ -166,6 +179,11 @@ jobs:
           fi
           status=0
           for skill in $changed; do
+            # skills/ holds files as well as skill dirs (catalog.json), and a
+            # deleted skill still shows up in the diff.
+            if [ ! -d "skills/$skill" ]; then
+              continue
+            fi
             if [ -d "skills/$skill/tests" ]; then
               echo "::group::pytest skills/$skill/tests"
               uv run pytest "skills/$skill/tests" -v || status=1


### PR DESCRIPTION
The `Run tests for skills changed in this PR` step from #330 is reporting unrelated failures against innocent PRs. Found while auditing the three open PRs; both causes verified against live data.

## 1. Base selection picks up everything merged into main since the PR opened

`actions/checkout` resolves a `pull_request` to `refs/pull/N/merge`, so `HEAD` is a merge commit that also contains main's later commits. `pull_request.base.sha` is the base tip *as of when the PR was opened*. Diffing against either attributes unrelated work to the PR.

On #327 (opened 30 Jul, touches `clinical-variant-reporter` only):

```
base.sha..HEAD    ->  bio-orchestrator  catalog.json  clinical-variant-reporter
                      just-prs-mcp  pharmgx-reporter
merge-base..head  ->  clinical-variant-reporter
```

The job then failed on `just-prs-mcp`, which that contributor never touched. Their own suite passed in the same run (`61 passed in 2.72s`).

## 2. Skill extras are never installed

Skill-level deps live in `[project.optional-dependencies]`; `just-prs` declares `typer` and `fastmcp`. `uv sync --locked` omits them, so `skills/just-prs-mcp/tests` raised `ModuleNotFoundError: No module named 'typer'` at collection and took the job down.

Verified locally with `--all-extras`: that suite is **37 passed, 2 skipped**.

## Verification

Each open PR now resolves to exactly the skills it touches:

| PR | Resolved |
|----|----------|
| #331 | `deepspot-m` |
| #329 | `claw-amplicon-qc` |
| #327 | `clinical-variant-reporter` |

Also skips non-directory entries under `skills/`, so `skills/catalog.json` stops producing a spurious "has no tests/ directory" warning.

Left deliberately unchanged: #329 still fails, correctly. Its only test drives `amplicon_qc.py` while the skill ships `amplicon_qc.R`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes to test scoping and dependency install; no runtime or application logic.
> 
> **Overview**
> Fixes the **Run tests for skills changed in this PR** job so it only exercises skills the contributor actually changed and can import skill-specific optional dependencies.
> 
> **Dependency install** now uses `uv sync --locked --all-extras` instead of a plain sync, so extras like `just-prs` (`typer`, `fastmcp`) are available when pytest runs touched skill suites.
> 
> **Changed-skill detection** diffs `merge-base(base.sha, head.sha)..head` instead of `base.sha..HEAD`, avoiding false positives when checkout’s merge ref includes main commits that landed after the PR opened.
> 
> The loop **skips** `skills/*` path segments that are not directories (e.g. `catalog.json`) or deleted skills, so stray warnings and bogus “no tests” entries are avoided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5e4cdd57c1c9ea7aed589528a41612968170204. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->