### PR TITLE
fix(nfcore-rnaseq-wrapper): scope manifest version parse to the manifest block (#333)

### DIFF
--- a/skills/nfcore-rnaseq-wrapper/pipeline_source.py
+++ b/skills/nfcore-rnaseq-wrapper/pipeline_source.py
@@ -20,10 +20,44 @@ from schemas import DEFAULT_LOCAL_PIPELINE_DIR, DEFAULT_REMOTE_PIPELINE, PIPELIN
 
 _GIT_TIMEOUT = 10
 
-# Matches `version = '3.26.0'` inside the manifest block of nextflow.config.
-# nextflow.config also carries `nextflowVersion`; the trailing-boundary group
-# (`\b`) prevents `nextflowVersion` from matching the bare `version` key.
-_MANIFEST_VERSION_RE = re.compile(r"(?<![A-Za-z])version\s*=\s*['\"]([^'\"]+)['\"]")
+# Matches `version = '3.26.0'` *within the manifest block only* (ClawBio#333).
+#
+# Scanning the whole file is unsafe. nf-core's standard config template sets
+# `custom_config_version = 'master'` in the params block, and pipelines such as
+# sarek add tool-version keys like `vep_version = "111.0-0"`, both several
+# hundred lines ABOVE the manifest block. `re.search` returns the first match,
+# so a file-wide scan reported 'master' (or a plausible-looking '111.0-0') for a
+# genuinely correct checkout on every nf-core pipeline tested.
+#
+# A leading-boundary lookbehind alone is not sufficient: it does not exclude a
+# dotted `params.version = '...'`, a commented-out `// version = '...'`, or a
+# `version` key belonging to some other block. Scoping to the manifest block
+# handles all of those, and any future `*_version` key, by construction.
+_MANIFEST_BLOCK_RE = re.compile(r"(?m)^[ \t]*manifest[ \t]*\{")
+_LINE_COMMENT_RE = re.compile(r"//[^\n]*")
+_MANIFEST_VERSION_RE = re.compile(r"(?<![A-Za-z_.])version\s*=\s*['\"]([^'\"]+)['\"]")
+
+
+def _manifest_block(text: str) -> str:
+    """Return the brace-balanced body of the top-level `manifest { ... }` block.
+
+    Returns "" when there is no manifest block or its braces never balance;
+    callers treat "" as "unknown version", never as a mismatch.
+    """
+    match = _MANIFEST_BLOCK_RE.search(text)
+    if not match:
+        return ""
+    start = text.index("{", match.start())
+    depth = 0
+    for index in range(start, len(text)):
+        char = text[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : index + 1]
+    return ""
 
 
 def _path_has_whitespace(path: Path) -> bool:
@@ -41,7 +75,8 @@ def _read_manifest_version(local_dir: Path) -> str:
         text = config_path.read_text(encoding="utf-8")
     except (OSError, UnicodeError):
         return ""
-    match = _MANIFEST_VERSION_RE.search(text)
+    block = _LINE_COMMENT_RE.sub("", _manifest_block(text))
+    match = _MANIFEST_VERSION_RE.search(block)
     return match.group(1).strip() if match else ""
 
 

--- a/skills/nfcore-rnaseq-wrapper/tests/test_pipeline_source.py
+++ b/skills/nfcore-rnaseq-wrapper/tests/test_pipeline_source.py
@@ -43,13 +43,28 @@ _remove_skill_dir_from_sys_path()
 _requires_git = pytest.mark.skipif(shutil.which("git") is None, reason="git not on PATH")
 
 
+# Mirrors the shape of a real nf-core nextflow.config: the standard template sets
+# `custom_config_version` (and pipelines such as sarek add tool-version keys like
+# `vep_version`) in the params block, ~300 lines ABOVE the manifest block. A
+# file-wide version scan therefore reads one of those instead of manifest.version
+# (ClawBio#333). Keeping this preamble in the shared fixture means every test in
+# this module exercises the real config shape rather than a thin idealised one.
+_NFCORE_PARAMS_PREAMBLE = (
+    "params {\n"
+    "    version                 = false\n"
+    "    vep_version             = \"111.0-0\"\n"
+    "    custom_config_version   = 'master'\n"
+    "    custom_config_base      = \"https://raw.githubusercontent.com/nf-core/configs/${params.custom_config_version}\"\n"
+    "}\n"
+)
+
+
 def _make_valid_local_checkout(path: Path, *, manifest_version: str | None = None) -> None:
     path.mkdir(parents=True, exist_ok=True)
     (path / "main.nf").write_text("// main", encoding="utf-8")
-    if manifest_version is None:
-        config_text = "// config"
-    else:
-        config_text = (
+    config_text = _NFCORE_PARAMS_PREAMBLE
+    if manifest_version is not None:
+        config_text += (
             "manifest {\n"
             "    name = 'nf-core/rnaseq'\n"
             f"    version = '{manifest_version}'\n"
@@ -75,6 +90,91 @@ def test_local_checkout_manifest_version_ignores_nextflow_version(tmp_path):
     result = resolve_pipeline_source(requested_version="3.26.0", local_pipeline_dir=local)
     # Must read manifest.version, not manifest.nextflowVersion.
     assert result["manifest_version"] == "3.20.0"
+
+
+def test_local_checkout_manifest_version_ignores_custom_config_version(tmp_path):
+    """ClawBio#333: `custom_config_version = 'master'` precedes the manifest block.
+
+    A file-wide scan returns 'master' and the pinned-version gate then rejects a
+    genuinely correct checkout, pushing users towards
+    --allow-pipeline-version-override, which would also mask a real mismatch.
+    """
+    local = tmp_path / "rnaseq"
+    _make_valid_local_checkout(local, manifest_version="3.26.0")
+    config_text = (local / "nextflow.config").read_text(encoding="utf-8")
+    assert "custom_config_version   = 'master'" in config_text, "fixture must carry the real trap"
+    assert config_text.index("custom_config_version") < config_text.index("manifest {")
+
+    result = resolve_pipeline_source(requested_version="3.26.0", local_pipeline_dir=local)
+    assert result["manifest_version"] == "3.26.0"
+
+
+def test_local_checkout_manifest_version_ignores_tool_version_keys(tmp_path):
+    """nf-core/sarek carries `vep_version = "111.0-0"` above the manifest block.
+
+    Worse than the 'master' case: '111.0-0' reads as a plausible pipeline version,
+    so the resulting mismatch error misdirects debugging rather than looking absurd.
+    """
+    local = tmp_path / "rnaseq"
+    _make_valid_local_checkout(local, manifest_version="3.26.0")
+    result = resolve_pipeline_source(requested_version="3.26.0", local_pipeline_dir=local)
+    assert result["manifest_version"] != "111.0-0"
+    assert result["manifest_version"] == "3.26.0"
+
+
+def test_local_checkout_manifest_version_ignores_dotted_assignment(tmp_path):
+    """`params.version = '9.9.9'` is not the manifest version.
+
+    A leading-boundary lookbehind alone does not exclude this, because the
+    preceding character is '.', which is why the fix scopes to the manifest block.
+    """
+    local = tmp_path / "rnaseq"
+    _make_valid_local_checkout(local, manifest_version="3.26.0")
+    config = local / "nextflow.config"
+    config.write_text("params.version = '9.9.9'\n" + config.read_text(encoding="utf-8"), encoding="utf-8")
+    result = resolve_pipeline_source(requested_version="3.26.0", local_pipeline_dir=local)
+    assert result["manifest_version"] == "3.26.0"
+
+
+def test_local_checkout_manifest_version_ignores_commented_out_version(tmp_path):
+    """A commented-out version above the manifest block must not win."""
+    local = tmp_path / "rnaseq"
+    _make_valid_local_checkout(local, manifest_version="3.26.0")
+    config = local / "nextflow.config"
+    config.write_text("// version = '0.0.1-dev'\n" + config.read_text(encoding="utf-8"), encoding="utf-8")
+    result = resolve_pipeline_source(requested_version="3.26.0", local_pipeline_dir=local)
+    assert result["manifest_version"] == "3.26.0"
+
+
+def test_local_checkout_manifest_version_ignores_comment_inside_manifest(tmp_path):
+    """A commented-out version *inside* the manifest block must not win either."""
+    local = tmp_path / "rnaseq"
+    _make_valid_local_checkout(local, manifest_version="3.26.0")
+    config = local / "nextflow.config"
+    config.write_text(
+        config.read_text(encoding="utf-8").replace(
+            "manifest {\n", "manifest {\n    // version = '0.0.1-dev'\n"
+        ),
+        encoding="utf-8",
+    )
+    result = resolve_pipeline_source(requested_version="3.26.0", local_pipeline_dir=local)
+    assert result["manifest_version"] == "3.26.0"
+
+
+def test_local_checkout_manifest_version_handles_nested_braces(tmp_path):
+    """The manifest scan must be brace-balanced, not stop at the first '}'."""
+    local = tmp_path / "rnaseq"
+    _make_valid_local_checkout(local, manifest_version="3.26.0")
+    config = local / "nextflow.config"
+    config.write_text(
+        config.read_text(encoding="utf-8").replace(
+            "manifest {\n    name = 'nf-core/rnaseq'\n",
+            "manifest {\n    name = 'nf-core/rnaseq'\n    defaultBranch = \"${x ? 'a' : 'b'}\"\n",
+        ),
+        encoding="utf-8",
+    )
+    result = resolve_pipeline_source(requested_version="3.26.0", local_pipeline_dir=local)
+    assert result["manifest_version"] == "3.26.0"
 
 
 def test_local_checkout_manifest_version_empty_when_absent(tmp_path):


### PR DESCRIPTION
Fixes #333, reported with an unusually complete diagnosis by @javrodriguez.

## The bug

`_read_manifest_version` scanned the whole `nextflow.config`, and `re.search` returns the first match. nf-core's standard template sets `custom_config_version = 'master'` in the params block a few hundred lines above the manifest block, so a genuinely correct checkout was read as version `master` and rejected by the pinned-version gate. `--pipeline-local` was effectively unusable.

Verified end to end against the reporter's exact `git clone --depth 1 --branch 3.26.0` checkout:

| Code state | `_read_manifest_version()` |
|---|---|
| before | `'master'` → `PIPELINE_SOURCE_INVALID` |
| after | `'3.26.0'` → passes |

## Scope is wider than reported

Reproduced on **6/6** real nf-core configs:

| Pipeline | before | after |
|---|---|---|
| rnaseq 3.26.0 | `master` | 3.26.0 |
| rnaseq 3.14.0 | `master` | 3.14.0 |
| scrnaseq 4.0.0 | `master` | 4.0.0 |
| fetchngs 1.12.0 | `master` | 1.12.0 |
| methylseq 2.7.1 | `master` | 2.7.1 |
| **sarek 3.5.1** | **`111.0-0`** | 3.5.1 |

Sarek is the worse case. Its first match is `vep_version = "111.0-0"` (nextflow.config:102), a VEP tool version that reads as a plausible pipeline version, so the resulting error misdirects debugging rather than looking obviously absurd.

## The fix

The reporter's one-character change (adding `_` to the lookbehind) resolves all six pipelines above, but not these:

| Case | one-char fix | this PR |
|---|---|---|
| `custom_config_version` (the bug) | 3.26.0 | 3.26.0 |
| `params.version = '9.9.9'` (dotted) | **9.9.9** | 3.26.0 |
| `// version = '0.0.1-dev'` (comment) | **0.0.1-dev** | 3.26.0 |
| version inside `profiles {}` | **test-snapshot** | 3.26.0 |

So this takes their secondary suggestion: scope the search to a brace-balanced `manifest { ... }` block with line comments stripped. That handles any future `*_version` key by construction rather than by enumeration.

## Why this survived review

Worth recording, because the failure mode is more interesting than the bug.

**The old comment described a guard that did not exist, against a threat that was not possible.** It claimed a trailing `\b` prevented `nextflowVersion` matching. There was no `\b`, only a leading lookbehind, and `nextflowVersion` carries a capital V so a case-sensitive `version` pattern could never have matched it. Deleting the lookbehind entirely left output byte-identical on real files. It never did anything.

**The test named for that guard was tautological.** `test_local_checkout_manifest_version_ignores_nextflow_version` passed with the lookbehind removed completely. Its fixture wrote only `name`, `version` and `nextflowVersion`, never `custom_config_version`, so it encoded the imagined failure rather than the real one.

The shared fixture now carries the real nf-core params preamble, so every test in the module exercises the real config shape. That change alone turns two previously green tests red against the old parser, which is the point.

## Also fixed

A config with **no manifest block at all** previously returned a bogus version (`111.0-0` from the preamble) instead of `""`. `""` is the documented "unknown" sentinel that callers must not treat as a mismatch, so this was feeding the version gate a fabricated value.

## Tests

512 pass, up from 506. Six new regression tests cover `custom_config_version`, tool-version keys, dotted assignment, comments inside and outside the manifest block, and nested braces. Each was confirmed to fail against the old parser before the fix landed.

Validation was run against the six real downloaded configs and a real shallow tag clone, not only against fixtures.

## Not changed here

- `nfcore-scrnaseq-wrapper` is unaffected: it already avoids the regex via `git describe --tags --exact-match`, which I confirmed returns `3.26.0` on a shallow tag clone. Converging the wrappers on that approach is worth a separate discussion.
- `nfcore-sarek-wrapper` is unaffected by this bug because it performs no local manifest/version validation at all. That is a separate gap, not this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the local-checkout version gate that decides whether a sibling pipeline is accepted or rejected. Incorrect parsing could still mis-classify checkouts, though coverage for the known false positives is strong.
> 
> **Overview**
> **Fixes false version mismatches** that made `--pipeline-local` unusable on real nf-core checkouts (ClawBio#333).
> 
> `_read_manifest_version` previously scanned all of `nextflow.config` and took the first `version = '...'` match. That hit earlier params keys such as `custom_config_version = 'master'` or sarek's `vep_version = "111.0-0"`, so correct local checkouts were rejected by the pinned-version gate.
> 
> The parser now extracts a brace-balanced `manifest { ... }` block, strips `//` line comments, and only then matches `version`. The shared test fixture includes the real nf-core params preamble, and six regression tests cover the reported trap plus dotted assignments, comments, and nested braces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16fc881a0e172e294890e51138f1906af72024c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->