### PR TITLE
fix(rnaseq-wrapper): read manifest.version, not custom_config_version

### DIFF
--- a/skills/nfcore-rnaseq-wrapper/pipeline_source.py
+++ b/skills/nfcore-rnaseq-wrapper/pipeline_source.py
@@ -21,9 +21,12 @@ from schemas import DEFAULT_LOCAL_PIPELINE_DIR, DEFAULT_REMOTE_PIPELINE, PIPELIN
 _GIT_TIMEOUT = 10
 
 # Matches `version = '3.26.0'` inside the manifest block of nextflow.config.
-# nextflow.config also carries `nextflowVersion`; the trailing-boundary group
-# (`\b`) prevents `nextflowVersion` from matching the bare `version` key.
-_MANIFEST_VERSION_RE = re.compile(r"(?<![A-Za-z])version\s*=\s*['\"]([^'\"]+)['\"]")
+# The lookbehind must reject every identifier that merely ends in `version`.
+# Excluding letters alone is not enough: nf-core configs declare
+# `custom_config_version = 'master'` in the params block, which sits above the
+# manifest, so that key matched first and every local checkout was reported as
+# version `master`. Excluding `_` as well also keeps `nextflowVersion` out.
+_MANIFEST_VERSION_RE = re.compile(r"(?<![A-Za-z_])version\s*=\s*['\"]([^'\"]+)['\"]")
 
 
 def _path_has_whitespace(path: Path) -> bool:

--- a/skills/nfcore-rnaseq-wrapper/tests/test_pipeline_source.py
+++ b/skills/nfcore-rnaseq-wrapper/tests/test_pipeline_source.py
@@ -77,6 +77,35 @@ def test_local_checkout_manifest_version_ignores_nextflow_version(tmp_path):
     assert result["manifest_version"] == "3.20.0"
 
 
+def test_local_checkout_manifest_version_ignores_custom_config_version(tmp_path):
+    """A real nf-core config declares `custom_config_version` above the manifest block.
+
+    The synthetic fixture used by the tests above does not, which is why the previous
+    regex could read `master` from every real checkout while these tests stayed green.
+    """
+    local = tmp_path / "rnaseq"
+    local.mkdir(parents=True)
+    (local / "main.nf").write_text("// main", encoding="utf-8")
+    (local / "nextflow.config").write_text(
+        "params {\n"
+        "    version                    = false\n"
+        "    custom_config_version      = 'master'\n"
+        "    custom_config_base         = \"https://example.invalid/${params.custom_config_version}\"\n"
+        "}\n"
+        "manifest {\n"
+        "    name            = 'nf-core/rnaseq'\n"
+        "    version         = '3.26.0'\n"
+        "    nextflowVersion = '!>=25.04.3'\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    assets = local / "assets"
+    assets.mkdir()
+    (assets / "schema_input.json").write_text("{}", encoding="utf-8")
+    result = resolve_pipeline_source(requested_version="3.26.0", local_pipeline_dir=local)
+    assert result["manifest_version"] == "3.26.0"
+
+
 def test_local_checkout_manifest_version_empty_when_absent(tmp_path):
     local = tmp_path / "rnaseq"
     _make_valid_local_checkout(local)  # config has no manifest block


### PR DESCRIPTION
## Summary

- The rnaseq wrapper read `custom_config_version = 'master'` instead of `manifest.version`, so **every** local `nf-core/rnaseq` checkout was detected as version `master`.
- The wrapper then rejected that checkout against its pinned `3.26.0` contract with `PIPELINE_SOURCE_INVALID`, which made the sibling-checkout path unusable unless `--allow-pipeline-version-override` was passed.
- Fixed by excluding `_` in the lookbehind, plus a regression test that reproduces the real nf-core config layout.

## Skill affected

`nfcore-rnaseq-wrapper` — `skills/nfcore-rnaseq-wrapper/pipeline_source.py`. It is the only wrapper that defines this regex, so the scrnaseq and sarek wrappers are unaffected.

## Root cause

`_MANIFEST_VERSION_RE` was:

```python
re.compile(r"(?<![A-Za-z])version\s*=\s*['\"]([^'\"]+)['\"]")
```

The lookbehind was added to stop `nextflowVersion` from matching, but `_` is not a letter, so any `*_version` parameter satisfies it too. nf-core pipelines declare those parameters in the `params` block, which sits **above** `manifest`, and `re.search` returns the first hit:

```groovy
params {
    version               = false      // unquoted, no match
    custom_config_version = 'master'   // first quoted match -> returned
}

manifest {
    version = '3.26.0'                 // the intended value
}
```

## Impact

`_read_manifest_version()` returned `master` for every real checkout. Since the wrapper enforces its pinned contract against that value, `resolve_pipeline_source()` failed with:

> Local nf-core/rnaseq checkout is version 'master', but this wrapper's validations are pinned to 3.26.0.

So `clawbio run rnaseq-pipeline` could not use a sibling `rnaseq/` checkout at all — not even a clean one at exactly the pinned tag. The documented `local_checkout_then_remote` source preference silently became "remote only", or failed outright with `--require-local-pipeline`.

## Verification

The new pattern was checked against the released `nextflow.config` of six pinned nf-core versions:

| pipeline | tag | before | after |
|---|---|---|---|
| rnaseq | 3.26.0 | `master` | `3.26.0` |
| rnaseq | 3.25.0 | `master` | `3.25.0` |
| scrnaseq | 4.1.0 | `master` | `4.1.0` |
| scrnaseq | 4.2.0 | `master` | `4.2.0` |
| sarek | 3.8.1 | `115.0-0` | `3.8.1` |
| sarek | 3.9.0 | `115.2-1` | `3.9.0` |

The two sarek values come from `vep_version`, another `*_version` parameter declared above the manifest — the same failure mode, a different key.

End to end, with a clean `nf-core/rnaseq` 3.26.0 checkout placed next to the repo so the `local_checkout_then_remote` path resolves to it: `clawbio run rnaseq-pipeline --check --input <samplesheet> --output <dir> --profile docker --aligner star_salmon --genome GRCh38` exits **1** with `PIPELINE_SOURCE_INVALID` before this change and exits **0** after it. `--check --demo` behaves the same way.

## Checklist

- [ ] SKILL.md is present and complete — n/a: bug fix to an existing skill, no SKILL.md change needed
- [x] Tests included and passing (`pytest -v`)
- [ ] Demo data included for reviewers to test — n/a: the regression test builds its own fixture in `tmp_path`
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](https://github.com/ClawBio/ClawBio/blob/main/CONTRIBUTING.md) conventions

## Test output

Full wrapper suite with the fix applied:

```
$ python -m pytest skills/nfcore-rnaseq-wrapper/tests/ -q
507 passed, 144 warnings in 1.69s
```

The new test is a real regression test — it fails on `main` without the one-line change:

```
$ python -m pytest skills/nfcore-rnaseq-wrapper/tests/test_pipeline_source.py -k custom_config -q
E       AssertionError: assert 'master' == '3.26.0'
1 failed
```

The existing tests stayed green because their synthetic config contains only a `manifest` block, which is why this went unnoticed.
