### PR TITLE
Fix vcf-annotator CLI, and add a Token Factory agent example for Berlin

### DIFF
--- a/examples/nebius_agent.py
+++ b/examples/nebius_agent.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Drive ClawBio skills from a model hosted on Nebius Token Factory.
+
+ClawBio skills are deterministic Python: they do not need a language model and
+they consume no inference credit. This script is the missing half. It gives a
+Token Factory model a set of ClawBio skills as callable tools, lets it decide
+which to run, and prints the tool calls so the reasoning is auditable.
+
+    export NEBIUS_API_KEY=...            # tokenfactory.nebius.com/project/api-keys
+    uv run python examples/nebius_agent.py \
+        --ask "Which variants are genuinely rare and high-impact, and which can you not tell?"
+
+Use --dry-run to exercise the tool wiring with no API call and no spend.
+
+Only skills in SKILLS below can be run, and only with the flags listed there.
+The model chooses among them; it cannot compose an arbitrary command line.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_BASE_URL = "https://api.tokenfactory.nebius.com/v1/"
+# Verified present in the Token Factory catalogue on 2026-08-12. Note that the
+# model ID in Nebius's own function-calling docs
+# (meta-llama/Meta-Llama-3.1-8B-Instruct-fast) 404s: the docs are stale, so list
+# the catalogue rather than trusting them. Use --list-models to see what is live.
+DEFAULT_MODEL = "Qwen/Qwen3-235B-A22B-Instruct-2507"
+
+# Whitelist. Every entry was run end to end on 2026-08-12.
+SKILLS: dict[str, dict] = {
+    "rare_high_impact_variants": {
+        "script": "skills/rare-high-impact-variants/rare_high_impact_variants.py",
+        "args": ["--demo"],
+        "report": "report.md",
+        "description": (
+            "Count rare, high-impact loss-of-function variants carried in a VCF. "
+            "Reports separately those with NO population frequency data, which cannot "
+            "be confirmed rare. Absence of a frequency is not evidence of rarity."
+        ),
+    },
+    "vcf_annotator": {
+        "script": "skills/vcf-annotator/vcf_annotator.py",
+        "args": ["--demo"],
+        "report": "report.md",
+        "description": (
+            "Annotate VCF variants with Ensembl VEP, ClinVar and gnomAD, ranked by "
+            "predicted impact (HIGH/MODERATE/LOW/MODIFIER)."
+        ),
+    },
+    "clinical_variant_reporter": {
+        "script": "skills/clinical-variant-reporter/clinical_variant_reporter.py",
+        "args": ["--demo"],
+        "report": "report.md",
+        "description": (
+            "Classify germline variants under the ACMG/AMP 2015 28-criteria framework "
+            "and return the triggered evidence codes."
+        ),
+    },
+    "gwas_prs": {
+        "script": "skills/gwas-prs/gwas_prs.py",
+        "args": ["--demo"],
+        "report": "prs_report.md",
+        "description": (
+            "Compute polygenic risk scores from PGS Catalog scores. Note the reference "
+            "population stated in the report when interpreting any percentile."
+        ),
+    },
+}
+
+SYSTEM_PROMPT = """You are a genomics analyst working through ClawBio skills.
+
+Rules you must follow:
+1. Do not answer from memory. Call a skill and base every claim on its output.
+2. Quote the specific numbers the skill reported. Do not round or embellish them.
+3. State plainly what the evidence does NOT support. If variants lack population
+   frequency data, say they cannot be confirmed rare rather than assuming they are.
+4. If no available skill can answer the question, say so instead of guessing.
+
+Being explicit about what you cannot conclude is worth more than a confident answer."""
+
+
+def run_skill(name: str) -> str:
+    """Run one whitelisted skill and return its report text."""
+    spec = SKILLS.get(name)
+    if spec is None:
+        return f"ERROR: unknown skill {name!r}. Available: {', '.join(SKILLS)}"
+
+    script = REPO_ROOT / spec["script"]
+    if not script.exists():
+        return f"ERROR: {spec['script']} not found in this checkout"
+
+    with tempfile.TemporaryDirectory() as td:
+        cmd = [sys.executable, str(script), *spec["args"], "--output", td]
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+        if proc.returncode != 0:
+            tail = proc.stderr.strip().splitlines()[-3:]
+            return f"ERROR: {name} exited {proc.returncode}\n" + "\n".join(tail)
+
+        report = Path(td) / spec["report"]
+        if report.exists():
+            return report.read_text()[:6000]
+        return proc.stdout[-4000:] or f"{name} produced no report at {spec['report']}"
+
+
+def tool_schemas() -> list[dict]:
+    return [{
+        "type": "function",
+        "function": {
+            "name": "run_clawbio_skill",
+            "description": (
+                "Run one ClawBio bioinformatics skill on its bundled demo data and "
+                "return the report it produces. Available skills:\n" +
+                "\n".join(f"- {n}: {s['description']}" for n, s in SKILLS.items())
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "skill": {"type": "string", "enum": list(SKILLS)},
+                },
+                "required": ["skill"],
+            },
+        },
+    }]
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--ask", default=(
+        "Which variants in this genome are genuinely rare and high-impact, "
+        "and which ones can you not tell either way?"))
+    ap.add_argument("--model", default=DEFAULT_MODEL)
+    ap.add_argument("--base-url", default=os.environ.get("NEBIUS_BASE_URL", DEFAULT_BASE_URL))
+    ap.add_argument("--max-turns", type=int, default=6)
+    ap.add_argument("--max-tokens", type=int, default=1500,
+                    help="Per-response cap. Reasoning models need headroom: GLM-5.2 "
+                         "returns an empty answer if it spends the budget thinking")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Exercise the tool wiring with no API call and no spend")
+    ap.add_argument("--list-models", action="store_true",
+                    help="Print the live Token Factory catalogue and exit")
+    args = ap.parse_args()
+
+    if args.list_models:
+        from openai import OpenAI
+        key = os.environ.get("NEBIUS_API_KEY")
+        if not key:
+            sys.exit("NEBIUS_API_KEY is not set")
+        client = OpenAI(base_url=args.base_url, api_key=key)
+        for mid in sorted(m.id for m in client.models.list().data):
+            print(mid)
+        return
+
+    if args.dry_run:
+        print("DRY RUN: no API call, no credit spent.\n")
+        print(f"Base URL : {args.base_url}")
+        print(f"Model    : {args.model}")
+        print(f"Skills   : {', '.join(SKILLS)}\n")
+        schema = tool_schemas()[0]["function"]
+        print(f"Tool exposed to the model: {schema['name']}")
+        print(f"Enum offered            : {schema['parameters']['properties']['skill']['enum']}\n")
+        probe = "rare_high_impact_variants"
+        print(f"Calling {probe} locally to prove dispatch works:\n")
+        out = run_skill(probe)
+        print("\n".join(out.splitlines()[:14]))
+        print("\nDry run complete. Set NEBIUS_API_KEY and drop --dry-run to go live.")
+        return
+
+    api_key = os.environ.get("NEBIUS_API_KEY")
+    if not api_key:
+        sys.exit("NEBIUS_API_KEY is not set. Get one at "
+                 "https://tokenfactory.nebius.com/project/api-keys")
+
+    try:
+        from openai import OpenAI
+    except ImportError:
+        sys.exit("pip install openai")
+
+    client = OpenAI(base_url=args.base_url, api_key=api_key)
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": args.ask},
+    ]
+
+    print(f"Model    : {args.model}")
+    print(f"Question : {args.ask}\n")
+
+    calls = 0
+    for turn in range(args.max_turns):
+        response = client.chat.completions.create(
+            model=args.model, messages=messages,
+            tools=tool_schemas(), tool_choice="auto", temperature=0.2,
+            max_tokens=args.max_tokens,
+        )
+        choice = response.choices[0]
+        msg = choice.message
+
+        if choice.finish_reason == "length" and not msg.content and not msg.tool_calls:
+            sys.exit(
+                f"{args.model} used all {args.max_tokens} tokens without producing an "
+                f"answer. Reasoning models do this. Raise --max-tokens or pick another "
+                f"model (--list-models)."
+            )
+        messages.append(msg.model_dump(exclude_none=True))
+
+        if not msg.tool_calls:
+            print("--- ANSWER ---")
+            print(msg.content)
+            usage = getattr(response, "usage", None)
+            if usage:
+                print(f"\nTokens: {usage.prompt_tokens} in, "
+                      f"{usage.completion_tokens} out, over {calls} skill call(s).")
+            return
+
+        for call in msg.tool_calls:
+            skill = json.loads(call.function.arguments).get("skill", "")
+            calls += 1
+            print(f"[tool call {calls}] run_clawbio_skill(skill={skill!r})")
+            result = run_skill(skill)
+            first = next((l for l in result.splitlines() if l.strip()), "")
+            print(f"             -> {len(result)} chars, starting {first[:60]!r}\n")
+            messages.append({
+                "role": "tool", "tool_call_id": call.id, "content": result,
+            })
+
+    print(f"Stopped after {args.max_turns} turns without a final answer.")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/vcf-annotator/tests/test_vcf_annotator.py
+++ b/skills/vcf-annotator/tests/test_vcf_annotator.py
@@ -5,6 +5,7 @@ Run with: pytest skills/vcf-annotator/tests/test_vcf_annotator.py -v
 
 import csv
 import json
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -215,3 +216,52 @@ class TestDemoData:
         impacts = [v["impact"] for v in DEMO_ANNOTATIONS]
         ranks   = [IMPACT_RANK.get(i, 5) for i in impacts]
         assert ranks == sorted(ranks)
+
+
+# ── CLI entry point ────────────────────────────────────────────────────────────
+#
+# These invoke the script the way a user does, in a subprocess. Importing
+# functions directly cannot catch a missing import inside main(), which is how
+# `import argparse` stayed absent behind 28 green tests.
+
+SCRIPT = Path(__file__).parent.parent / "vcf_annotator.py"
+
+
+class TestCLI:
+    def test_help_exits_zero(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--help"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, (
+            f"--help failed with exit {result.returncode}:\n{result.stderr}"
+        )
+        assert "--input" in result.stdout
+
+    def test_no_args_errors_cleanly(self):
+        """Missing --input/--demo must be an argparse error, not a traceback."""
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 2
+        assert "Traceback" not in result.stderr
+
+    def test_demo_runs_end_to_end(self, tmp_path):
+        out = tmp_path / "report"
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--demo", "--output", str(out)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, (
+            f"--demo failed with exit {result.returncode}:\n{result.stderr}"
+        )
+        assert (out / "report.md").exists()
+
+    def test_missing_input_file_exits_one(self, tmp_path):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT), "--input", str(tmp_path / "nope.vcf")],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 1
+        assert "not found" in result.stderr.lower()

--- a/skills/vcf-annotator/vcf_annotator.py
+++ b/skills/vcf-annotator/vcf_annotator.py
@@ -9,6 +9,7 @@ Usage:
     python vcf_annotator.py --demo --output /tmp/demo
 """
 
+import argparse
 import os
 import csv
 import hashlib


### PR DESCRIPTION
Two changes, both needed for the Berlin hackathon on 18 August. The docs site references `examples/nebius_agent.py`, so this needs to land on `main` before those pages publish.

## 1. `vcf-annotator` could not run at all

`main()` used `argparse` at line 512 and the module imported it nowhere. Every CLI invocation died on `NameError`.

The 28 existing tests all passed. Each imports functions directly from the module and none exercises the entry point, so a green suite said nothing about whether the script runs.

Adds a `TestCLI` class that invokes the script in a subprocess the way a user does:

- `--help` exits 0
- no args is an argparse error, not a traceback
- `--demo` writes a report
- a missing input file exits 1

All four fail without the import. Swept the other 93 skills for the same defect: none affected.

## 2. `examples/nebius_agent.py`

ClawBio skills are deterministic Python and 93 of 94 need no model, so running them consumes no inference credit and is not agentic. This is the missing half: a tool-calling loop that gives a Nebius Token Factory model a whitelisted set of skills, lets it choose, and prints every call as a provenance trail.

Verified live on 2026-08-12. A full question-to-grounded-answer cycle cost 1,268 tokens, and the model correctly declined to call a variant rare when it had no population frequency data.

Two things found while testing, both handled in the code:

- The model ID in Nebius's own function-calling documentation (`meta-llama/Meta-Llama-3.1-8B-Instruct-fast`) returns 404. Added `--list-models`.
- GLM-5.2 is a reasoning model: given `max_tokens=1200` it spent the entire budget in `reasoning_content` and returned an empty answer. Added an explicit error rather than printing nothing.

`--dry-run` exercises the whole tool path with no API call and no spend. Skills are whitelisted, so the model picks from a fixed menu and cannot compose a shell command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are a one-line import fix, additive tests, and a new example script with whitelisted subprocess dispatch—no auth, data-model, or production pipeline changes.
> 
> **Overview**
> **Fixes `vcf-annotator` CLI** by adding the missing `import argparse`, which previously caused every script invocation to fail with `NameError` while unit tests still passed because they never ran the entry point.
> 
> **Adds subprocess `TestCLI` coverage** for `--help`, missing-args handling, `--demo`, and missing input file so CLI regressions are caught.
> 
> **Introduces `examples/nebius_agent.py`**, a tool-calling loop against Nebius Token Factory that exposes a **whitelisted** set of ClawBio skills (`run_clawbio_skill`), runs them via subprocess on demo data, and prints tool calls for auditability. Includes `--dry-run` (no API spend), `--list-models` (live catalogue), handling for reasoning models that exhaust `max_tokens` without content, and a system prompt that grounds answers in skill output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fb8ef221635c48da279ffcafbc67af49e331938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->