### PR TITLE
Separate artefact licences from the wrapper licence, and state the policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,54 @@ Follow the [ClawHub submission guide](https://clawhub.ai/docs/submit).
 4. **Documented**: Include example queries, expected outputs, and dependency lists.
 5. **Safe**: Minimal permissions. Warn before destructive actions. No hardcoded credentials.
 
+## Licensing
+
+Two separate things carry licences, and conflating them is how people get
+this wrong. Declare both.
+
+### 1. Your skill code: MIT or Apache-2.0
+
+```yaml
+license: MIT
+```
+
+ClawBio is the open trust layer for agentic genomics. A trust layer that
+hospitals, diagnostics companies and pharma cannot build on is not a trust
+layer, and a single restrictively-licensed file triggers legal review of the
+whole repository rather than of that one skill. So contributed skill code is
+expected to be permissive.
+
+Anything else is an exception. Ask in the PR and say why; we grant them (the
+catalog already carries a few) but they are declared, not assumed.
+
+### 2. Models, weights and reference data: declare, do not relicense
+
+If your skill downloads or requires a third-party model, weights, or a
+reference dataset, declare its terms separately:
+
+```yaml
+license: MIT                          # your wrapper code
+model_license: cc-by-nc-sa-4.0        # the weights it downloads
+data_license: CC0-1.0                 # any bundled reference data
+```
+
+**Putting MIT on a wrapper does not make non-commercial weights commercially
+usable.** The restriction lives in the artefact, not in your code, and no
+licence in this repository can grant rights over someone else's model. Marking
+the wrapper MIT while staying silent about NC weights publishes a promise that
+is false, which is worse for a downstream user than an honest restriction.
+
+Equally, do not apply a non-commercial licence to your *own* wrapper code
+because the weights are non-commercial. That adds a second, redundant
+restriction on top of one that already binds, and it propagates the limit to
+code that did not need it.
+
+Many academic genomics models are non-commercial, and skills wrapping them are
+welcome. Declare the fields honestly and the catalog will carry the signal.
+
+Omit `model_license` / `data_license` if your skill has no such dependency.
+The most restrictive of the three fields governs any given use; see `LICENSE`.
+
 ## Naming Conventions
 
 - Skill folder: lowercase, hyphens (`vcf-annotator`, not `VCF_Annotator`)

--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,30 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+## Scope of this licence
+
+The MIT licence above covers the ClawBio repository: the runner, the CLI, the
+shared tooling, and skill code that does not declare otherwise.
+
+It does **not** automatically cover:
+
+1. **Skills that declare their own `license:`** in their SKILL.md frontmatter.
+   A per-skill declaration overrides this file for that skill's directory.
+   Contributed skill code is expected to be MIT or Apache-2.0 (see
+   CONTRIBUTING.md); anything else is an exception granted case by case and is
+   surfaced in `skills/catalog.json`.
+
+2. **Third-party models, weights, reference data and databases** that a skill
+   downloads or requires at runtime. These carry their own terms, which are
+   frequently non-commercial, and no licence in this repository can grant
+   rights over them. Where a skill depends on such an artefact it declares
+   `model_license:` and/or `data_license:` in its frontmatter. Those fields are
+   the authoritative signal for whether a given use is permitted.
+
+If you are evaluating ClawBio for commercial use, read a skill's `license`,
+`model_license` and `data_license` fields together. The most restrictive of
+the three governs. `skills/catalog.json` carries all three for every skill so
+they can be audited in bulk.

--- a/scripts/generate_catalog.py
+++ b/scripts/generate_catalog.py
@@ -58,7 +58,10 @@ def parse_yaml_frontmatter(text: str) -> dict:
         if desc_match:
             result["description"] = _strip(desc_match.group(1))
 
-        for field in ("version", "author", "domain", "license"):
+        for field in (
+            "version", "author", "domain", "license",
+            "model_license", "data_license",
+        ):
             match = re.search(rf"^{field}:\s*(.+)", raw, re.MULTILINE)
             if match:
                 result[field] = _strip(match.group(1))
@@ -137,6 +140,12 @@ def normalize_skill_metadata(raw: dict) -> dict:
         "name": raw.get("name", ""),
         "description": raw.get("description", ""),
         "license": raw.get("license", ""),
+        # Declared separately from `license` on purpose. A permissive
+        # wrapper licence grants no rights over third-party weights or
+        # reference data, which are frequently non-commercial. Empty means
+        # "no such dependency declared", never "permissive".
+        "model_license": raw.get("model_license", ""),
+        "data_license": raw.get("data_license", ""),
         "version": raw.get("version", metadata.get("version", "0.1.0")),
         "author": raw.get("author", metadata.get("author", "")),
         "domain": raw.get("domain", metadata.get("domain", "")),
@@ -489,6 +498,14 @@ def build_catalog() -> list[dict]:
             "tags": tags,
             "trigger_keywords": trigger_keywords,
             "chaining_partners": CHAINING.get(folder_name, []),
+            # Three separate fields, because they restrict independently and
+            # the most restrictive governs. `license` covers the skill's own
+            # code; the other two cover third-party weights and reference data
+            # the skill pulls at runtime, over which no licence in this repo
+            # can grant rights. Empty means "none declared", not "permissive".
+            "license": str(skill_meta.get("license", "")),
+            "model_license": str(skill_meta.get("model_license", "")),
+            "data_license": str(skill_meta.get("data_license", "")),
         }
         entries.append(entry)
 

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -46,7 +46,10 @@
         "plasma proteomics",
         "ADAT"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "analyze-fasta",
@@ -101,7 +104,10 @@
         "struct-predictor",
         "variant-annotation",
         "pubmed-summariser"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "ancestry-risk-profiler",
@@ -145,7 +151,10 @@
         "KCNQ1 East Asian diabetes",
         "genetic super-population disease risk"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "archaic-introgression",
@@ -178,7 +187,10 @@
         "hmmix",
         "introgressed segments"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "article-data-fetcher",
@@ -234,7 +246,10 @@
         "get files from zenodo",
         "fetch data from figshare"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "bgpt-mcp",
@@ -283,7 +298,10 @@
         "full-text data",
         "methods and results"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "bigquery-public",
@@ -320,7 +338,10 @@
         "bigquery public data",
         "public genomics dataset"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "bio-orchestrator",
@@ -349,7 +370,10 @@
         "which skill",
         "orchestrator"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "bioconductor-bridge",
@@ -401,7 +425,10 @@
         "scrna-orchestrator",
         "diff-visualizer",
         "bio-orchestrator"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "bioqc-mcp",
@@ -444,7 +471,10 @@
         "sequencing quality control",
         "generate chart qc"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "busco-assessor",
@@ -497,7 +527,10 @@
         "BUSCO bacteria",
         "run BUSCO"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "cell-detection",
@@ -539,7 +572,10 @@
         "cell counting",
         "segmentation mask"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "celltype-specificity-profiler",
@@ -591,7 +627,10 @@
         "expression specificity",
         "marker gene specificity"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "claw-ancestry-pca",
@@ -630,7 +669,10 @@
       ],
       "chaining_partners": [
         "genome-compare"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "claw-metagenomics",
@@ -669,7 +711,10 @@
         "HUMAnN3",
         "microbiome"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "claw-methylation-cycle",
@@ -708,7 +753,10 @@
         "metilación",
         "neurotransmitter synthesis"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "claw-semantic-sim",
@@ -748,7 +796,10 @@
       ],
       "chaining_partners": [
         "equity-scorer"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "clawpathy-autoresearch",
@@ -789,7 +840,10 @@
         "replicate paper",
         "reproduce paper"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "clinical-trial-finder",
@@ -833,7 +887,10 @@
         "rsID",
         "variant"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "clinical-variant-prioritizer",
@@ -872,7 +929,10 @@
         "carrier status",
         "disease risk variants"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "clinical-variant-reporter",
@@ -918,7 +978,10 @@
         "ACMG SF",
         "variant interpretation"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "clinpgx",
@@ -952,7 +1015,10 @@
       "chaining_partners": [
         "pharmgx-reporter",
         "gwas-lookup"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "cnv-acmg-classifier",
@@ -991,7 +1057,10 @@
         "ClinGen dosage sensitivity",
         "deletion duplication pathogenic"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "crispr-screen-triage",
@@ -1030,7 +1099,10 @@
       "chaining_partners": [
         "target-validation-scorer",
         "omics-target-evidence-mapper"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "data-extractor",
@@ -1055,7 +1127,10 @@
       "dependencies": [],
       "tags": [],
       "trigger_keywords": [],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "de-summary",
@@ -1094,7 +1169,10 @@
         "volcano summary",
         "gene expression summary"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "diff-visualizer",
@@ -1136,7 +1214,10 @@
       "chaining_partners": [
         "rnaseq-de",
         "scrna-orchestrator"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "dnasp",
@@ -1219,7 +1300,10 @@
         "singleton excess",
         "minor allele frequency distribution"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "drug-photo",
@@ -1256,7 +1340,10 @@
       ],
       "chaining_partners": [
         "pharmgx-reporter"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "drug-repurposing-screen",
@@ -1303,7 +1390,10 @@
         "pooled viability analysis",
         "context-selective compound"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "eqtl-catalogue-region-fetch",
@@ -1346,7 +1436,10 @@
         "cis-eqtl region pull",
         "GTEx eqtl region"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "equity-scorer",
@@ -1379,7 +1472,10 @@
       ],
       "chaining_partners": [
         "claw-semantic-sim"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "fastreer",
@@ -1431,7 +1527,10 @@
         "cosine distance VCF",
         "sample phylogeny"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "GPL-3.0",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "fine-mapping",
@@ -1482,7 +1581,10 @@
         "fine map locus",
         "causal SNP"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "flow-bio",
@@ -1529,7 +1631,10 @@
         "flow upload",
         "run on flow"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "galaxy-bridge",
@@ -1577,7 +1682,10 @@
         "claw-metagenomics",
         "equity-scorer",
         "vcf-annotator"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "genome-compare",
@@ -1618,7 +1726,10 @@
       "chaining_partners": [
         "claw-ancestry-pca",
         "profile-report"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "genome-match",
@@ -1656,7 +1767,10 @@
         "heterozygosity score",
         "breeding pairs"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "gi-annotation",
@@ -1704,7 +1818,10 @@
         "gi annotation",
         "genomic intelligence annotation"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "gi-chromatin",
@@ -1756,7 +1873,10 @@
         "gi chromatin",
         "genomic intelligence chromatin"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "gi-enhancer",
@@ -1805,7 +1925,10 @@
         "gi enhancer",
         "genomic intelligence enhancer"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "gi-expression",
@@ -1852,7 +1975,10 @@
         "G0 expression",
         "genomic intelligence expression"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "gi-promoter",
@@ -1900,7 +2026,10 @@
         "G0 promoter",
         "GENA-LM promoter"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "gi-splice",
@@ -1949,7 +2078,10 @@
         "G0 splice",
         "genomic intelligence splice"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "gwas-catalog-region-fetch",
@@ -1992,7 +2124,10 @@
         "GCST harmonised tabix",
         "GWAS catalog tabix"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "gwas-lookup",
@@ -2027,7 +2162,10 @@
         "clinpgx",
         "gwas-prs",
         "lit-synthesizer"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "gwas-pipeline",
@@ -2070,7 +2208,10 @@
         "polygenic",
         "case-control"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "gwas-prs",
@@ -2103,7 +2244,10 @@
       "chaining_partners": [
         "profile-report",
         "gwas-lookup"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "hla-typing",
@@ -2139,7 +2283,10 @@
         "typing",
         "from"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "illumina-bridge",
@@ -2178,7 +2325,10 @@
         "sample sheet",
         "samplesheet"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "just-prs-mcp",
@@ -2220,7 +2370,10 @@
         "wgs-prs",
         "gwas-prs",
         "profile-report"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "labstep",
@@ -2262,7 +2415,10 @@
         "lab inventory",
         "LIMS"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "ld-1000g-region-compute",
@@ -2306,7 +2462,10 @@
         "locuszoom ld coloring",
         "1000 genomes ld panel"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "lit-synthesizer",
@@ -2351,7 +2510,10 @@
         "pubmed search",
         "recent papers on"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "locuscompare-region-render",
@@ -2403,7 +2565,10 @@
         "colocalization plot for a lead variant",
         "regional plot for coloc lead"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "marker-dominance-mapper",
@@ -2441,7 +2606,10 @@
       "chaining_partners": [
         "scrna-orchestrator",
         "diff-visualizer"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "mendelian-randomisation",
@@ -2491,7 +2659,10 @@
         "drug target validation MR",
         "GWAS causal"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "methylation-clock",
@@ -2534,7 +2705,10 @@
         "GEO",
         "GSE"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "multiqc-reporter",
@@ -2580,7 +2754,10 @@
         "combine QC",
         "QC aggregation"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "ncbi-datasets",
@@ -2635,7 +2812,10 @@
         "GCF",
         "GCA"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "nfcore-rnaseq-wrapper",
@@ -2684,7 +2864,10 @@
         "rnaseq-de",
         "diff-visualizer",
         "bio-orchestrator"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "nfcore-sarek-wrapper",
@@ -2741,7 +2924,10 @@
         "variant-annotation",
         "clinical-variant-reporter",
         "bio-orchestrator"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "nfcore-scrnaseq-wrapper",
@@ -2797,7 +2983,10 @@
         "scrna-orchestrator",
         "scrna-embedding",
         "bio-orchestrator"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "nutrigx",
@@ -2848,7 +3037,10 @@
       "chaining_partners": [
         "profile-report",
         "pharmgx-reporter"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "omics-target-evidence-mapper",
@@ -2885,7 +3077,10 @@
         "omics evidence",
         "gene disease mapper"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "organ-aging-studio",
@@ -2929,7 +3124,10 @@
         "Goeminne clock explain",
         "which proteins drive organ age"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "pathway-enricher",
@@ -2954,7 +3152,10 @@
       "dependencies": [],
       "tags": [],
       "trigger_keywords": [],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "pharmgx-reporter",
@@ -2996,7 +3197,10 @@
         "drug-photo",
         "profile-report",
         "clinpgx"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "phylogenetics-builder",
@@ -3041,7 +3245,10 @@
       ],
       "chaining_partners": [
         "profile-report"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "polars-bio",
@@ -3093,7 +3300,10 @@
         "BigBed",
         "genomic pileup depth"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "Apache-2.0",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "profile-report",
@@ -3133,7 +3343,10 @@
         "nutrigx",
         "gwas-prs",
         "genome-compare"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "proteomics-clock",
@@ -3181,7 +3394,10 @@
         "plasma protein aging",
         "organ-specific aging"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "proteomics-de",
@@ -3208,7 +3424,10 @@
       "trigger_keywords": [
         "Differential expression analysis of proteomics data from MaxQuant or DIA-NN output"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "protocols-io",
@@ -3248,7 +3467,10 @@
         "protocol DOI",
         "methods repository"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "pubmed-summariser",
@@ -3282,7 +3504,10 @@
         "gene papers",
         "disease papers"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "rare-disease-rnaseq",
@@ -3317,7 +3542,10 @@
         "haploinsufficiency"
       ],
       "trigger_keywords": [],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "rare-high-impact-variants",
@@ -3355,7 +3583,10 @@
         "rare,",
         "high-impact"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "recombinator",
@@ -3395,7 +3626,10 @@
         "genomebook breed",
         "next generation"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "repro-enforcer",
@@ -3420,7 +3654,10 @@
       "dependencies": [],
       "tags": [],
       "trigger_keywords": [],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "rnaseq-de",
@@ -3467,7 +3704,10 @@
       ],
       "chaining_partners": [
         "diff-visualizer"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "sample-qc-triage",
@@ -3507,7 +3747,10 @@
       "chaining_partners": [
         "multiqc-reporter",
         "seq-wrangler"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "scrna-embedding",
@@ -3554,7 +3797,10 @@
       ],
       "chaining_partners": [
         "scrna-orchestrator"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "scrna-orchestrator",
@@ -3603,7 +3849,10 @@
         "doublet",
         "celltypist"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "seq-wrangler",
@@ -3656,7 +3905,10 @@
         "sort and index bam",
         "process fastq"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "skill-builder",
@@ -3695,7 +3947,10 @@
         "build a skill",
         "make a skill"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "soul2dna",
@@ -3732,7 +3987,10 @@
         "synthetic genome",
         "character genome"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "struct-predictor",
@@ -3757,7 +4015,10 @@
       "dependencies": [],
       "tags": [],
       "trigger_keywords": [],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "target-validation-scorer",
@@ -3798,7 +4059,10 @@
         "evaluate drug target",
         "GO NO-GO decision for target"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "turingdb-graph",
@@ -3850,7 +4114,10 @@
         "comorbidity analysis",
         "comedication analysis"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "ukb-navigator",
@@ -3882,7 +4149,10 @@
       ],
       "chaining_partners": [
         "llm-biobank-bench"
-      ]
+      ],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "ukb-ppp-region-fetch",
@@ -3925,7 +4195,10 @@
         "protein qtl summary stats",
         "plasma pqtl regional fetch"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "variant-annotation",
@@ -3965,7 +4238,10 @@
         "annotate variants",
         "pathogenic variants"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "vcf-annotator",
@@ -4011,7 +4287,10 @@
         "annotate my vcf",
         "what variants are pathogenic"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "wes-clinical-report-en",
@@ -4050,7 +4329,10 @@
         "Novogene report english",
         "WES report PDF"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "PROPRIETARY",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "wgs-prs",
@@ -4099,7 +4381,10 @@
         "WGS pipeline",
         "raw sequencing to risk scores"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     },
     {
       "name": "xena-tcga-gene-query",
@@ -4149,7 +4434,10 @@
         "生存分析",
         "预后"
       ],
-      "chaining_partners": []
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
     }
   ]
 }

--- a/tests/test_generate_catalog.py
+++ b/tests/test_generate_catalog.py
@@ -87,3 +87,62 @@ def test_fallback_demo_script_selection_is_deterministic():
         ).name
         == "turingdb_graph.py"
     )
+
+
+# --- Upstream artefact licences are declared separately from the wrapper's own
+# licence. Putting MIT on a wrapper does not make non-commercial weights
+# commercially usable, so the catalog must carry the artefact terms as their
+# own fields rather than letting `license` imply anything about them.
+
+def test_normalize_carries_model_and_data_licences():
+    generate_catalog = _load_generate_catalog_module()
+
+    normalized = generate_catalog.normalize_skill_metadata(
+        {
+            "name": "demo",
+            "license": "MIT",
+            "model_license": "cc-by-nc-sa-4.0",
+            "data_license": "CC0-1.0",
+        }
+    )
+
+    assert normalized["license"] == "MIT"
+    assert normalized["model_license"] == "cc-by-nc-sa-4.0"
+    assert normalized["data_license"] == "CC0-1.0"
+
+
+def test_normalize_defaults_artefact_licences_to_empty():
+    """A skill with no third-party artefact declares nothing; absence is not
+    a claim that the artefact is permissive."""
+    generate_catalog = _load_generate_catalog_module()
+
+    normalized = generate_catalog.normalize_skill_metadata(
+        {"name": "demo", "license": "MIT"}
+    )
+
+    assert normalized["model_license"] == ""
+    assert normalized["data_license"] == ""
+
+
+def test_frontmatter_parser_reads_artefact_licences():
+    """Both fields survive frontmatter parsing end to end."""
+    generate_catalog = _load_generate_catalog_module()
+
+    raw = "\n".join(
+        [
+            "---",
+            "name: demo",
+            "description: A demo skill",
+            "license: MIT",
+            "model_license: cc-by-nc-sa-4.0",
+            "data_license: CC0-1.0",
+            "---",
+            "",
+            "## Trigger",
+        ]
+    )
+
+    parsed = generate_catalog.parse_yaml_frontmatter(raw)
+
+    assert parsed["model_license"] == "cc-by-nc-sa-4.0"
+    assert parsed["data_license"] == "CC0-1.0"


### PR DESCRIPTION
Splits "the licence" into the three things that actually restrict independently, and writes down the contribution policy.

## Why

A permissive licence on a skill wrapper grants no rights over the model weights or reference data that skill downloads at runtime, and in genomics those are frequently non-commercial. With one `license` field, the catalog could report a skill as MIT while the weights it pulls are CC-BY-NC-SA. A downstream user reads MIT, builds on it, and finds the restriction later. That is a false promise, and worse for them than an honest restriction.

The converse failure is just as real: applying a non-commercial licence to your own wrapper because the weights are non-commercial adds a second, redundant restriction on top of one that already binds, and propagates it to code that did not need it.

## What changed

- `model_license` and `data_license` parsed, normalized and emitted per skill.
- `license` also emitted per skill. It was already in every SKILL.md frontmatter and simply was not surfaced.
- `LICENSE` gains a scope note: what the MIT grant covers, that a per-skill declaration overrides it, that no licence here can grant rights over third-party artefacts, and that the most restrictive of the three fields governs.
- `CONTRIBUTING.md` gains a Licensing section: contributed skill **code** is expected to be MIT or Apache-2.0; artefact terms are declared, not relicensed. Skills wrapping non-commercial academic models stay welcome.

Empty means "none declared", never "permissive".

## Rationale for the MIT expectation

ClawBio is positioned as the open trust layer for agentic genomics. Hospitals, diagnostics companies and pharma are exactly the commercial users a non-commercial licence excludes, and a single restrictive file triggers legal review of the whole repository rather than of that one skill. Legal-review friction is how adoption dies quietly. Exceptions remain available, but they are asked for and declared rather than assumed.

## Audit of the 96 current skills

| Licence | Count |
|---|---|
| MIT | 92 |
| Apache-2.0 | 1 (`polars-bio`) |
| GPL-3.0 | 1 (`fastreer`) |
| PROPRIETARY | 1 (`wes-clinical-report-en`) |
| **none declared** | 1 (`rare-disease-rnaseq`) |

None declare a model or data licence yet, so nothing is reclassified by this PR; it only makes the fields expressible.

Two worth a look separately: `rare-disease-rnaseq` declares nothing, which defaults to all rights reserved and is the one genuinely unclear case; and `fastreer` is GPL-3.0, a different hazard from the proprietary one, since copyleft can reach combined works and this repo composes skills by design.

## Note for #331

That PR also adds `"license": str(skill_meta.get("license", ""))` to the same dict, so it will conflict here. @KalinNonchev, after this lands please rebase and drop that one line; the field arrives with this change. Your `license: PolyForm-Noncommercial-1.0.0` becomes `license: MIT` plus `model_license: cc-by-nc-sa-4.0` under the new policy, which I have asked about on the PR itself.

Tests written first: three cases covering both fields carried, defaulting empty, and surviving frontmatter parsing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and catalog metadata only; no runtime execution or auth paths change. Main follow-up is ensuring contributors and downstream tools interpret empty artefact fields correctly.
> 
> **Overview**
> Introduces **three independent licence signals** for skills: `license` (wrapper code), `model_license`, and `data_license`, instead of treating a single field as covering everything.
> 
> **Catalog generation** now parses `model_license` and `data_license` from SKILL.md frontmatter, normalizes them (empty means *not declared*, not permissive), and emits `license`, `model_license`, and `data_license` on every entry in `skills/catalog.json`.
> 
> **Policy docs** add a **Licensing** section in `CONTRIBUTING.md` (permissive MIT/Apache-2.0 for contributed skill code; separate declaration for weights/data; most restrictive field governs) and a **Scope of this licence** section in `LICENSE` clarifying what repo MIT covers and what per-skill / third-party terms override.
> 
> **Tests** cover normalization defaults, frontmatter parsing, and carrying both artefact fields through the pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49a74befc26a769a1b22519a0a325b445ad9cc0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->