### PR TITLE
Make scientific-audit able to fail: gate on a committed bench baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,14 @@ jobs:
       - name: Run bot security tests
         run: uv run pytest bot/tests/test_security.py -v
 
+      # Repo-level tests were never run by this job. The steps above name skill
+      # test files individually, so `tests/` was invisible to CI: both
+      # test_generate_catalog.py and the bench-baseline gate's own tests could
+      # have gone red on main without anything reporting it. A gate whose tests
+      # do not run is the #342 problem one level up. (See also #337.)
+      - name: Run repo-level tests
+        run: uv run pytest tests/ -v
+
       # The steps above are a hardcoded allowlist, so a NEW skill's tests never
       # run: ClawBio#329 shipped a test that cannot pass and CI was still green,
       # and ClawBio#324's just-prs suite never executed here at all. Any skill
@@ -265,6 +273,12 @@ jobs:
       - name: Install clawbio-bench
         run: uv pip install "clawbio-bench @ git+https://github.com/biostochastics/clawbio_bench.git@49a0f11a8393b87a90f0721261a9bec5d52b61db"
 
+      # The bench's own exit code is intentionally not the gate: it returns
+      # non-zero whenever `overall.pass` is false, which is true today for
+      # seven harnesses of pre-existing debt (#106). Gating on it would block
+      # every unrelated PR, and the `|| true` that this job carried for months
+      # (#342) would go straight back on. So the bench is allowed to report,
+      # and the *baseline comparison* below is the gate.
       - name: Run scientific correctness audit (smoke)
         run: |
           mkdir -p results
@@ -295,3 +309,18 @@ jobs:
           else
             echo "Bench ran but no markdown summary was generated. Check artifacts." >> $GITHUB_STEP_SUMMARY
           fi
+
+      # THE GATE (#342). Everything above this point is `|| true` or
+      # `if: always()`, so without this step the job cannot fail and its green
+      # tick carries no information. Deliberately NOT `if: always()`: it must
+      # run, and a missing report exits 2 rather than passing quietly.
+      - name: Fail on regression against the committed baseline
+        run: |
+          REPORT=$(ls -t results/suite/*/aggregate_report.json 2>/dev/null | head -1)
+          if [ -z "$REPORT" ]; then
+            echo "::error::The bench produced no aggregate_report.json. Treating as failure, not as a pass."
+            exit 2
+          fi
+          uv run python scripts/check_bench_baseline.py "$REPORT" \
+            --baseline bench_baseline.json \
+            --summary "$GITHUB_STEP_SUMMARY"

--- a/bench_baseline.json
+++ b/bench_baseline.json
@@ -1,0 +1,41 @@
+{
+  "_comment": [
+    "Per-harness pass rates recorded from a real CI run. The scientific-audit",
+    "job fails if any harness drops below its rate here (see #342).",
+    "These are NOT targets. Seven harnesses are below 100% and that debt is",
+    "tracked in #106. Raising a number is a reviewable commit; lowering one",
+    "should be treated as a bug report, not routine maintenance."
+  ],
+  "recorded_from": {
+    "clawbio_commit": "056826d",
+    "benchmark_suite_version": "0.1.5",
+    "date": "2026-08-13",
+    "mode": "smoke",
+    "overall_pass_rate": 87.9,
+    "bench_own_verdict_pass": false
+  },
+  "harnesses": {
+    "bio-orchestrator": 98.1,
+    "claw-metagenomics": 100.0,
+    "clawbio-finemapping": 95.0,
+    "clinical-variant-reporter": 80.0,
+    "cvr-acmg-correctness": 69.2,
+    "cvr-variant-identity": 100.0,
+    "equity-scorer": 100.0,
+    "gwas-prs": 62.5,
+    "nutrigx-advisor": 0.0,
+    "pharmgx-reporter": 95.5
+  },
+  "harness_errors": {
+    "bio-orchestrator": 0,
+    "claw-metagenomics": 0,
+    "clawbio-finemapping": 1,
+    "clinical-variant-reporter": 0,
+    "cvr-acmg-correctness": 0,
+    "cvr-variant-identity": 0,
+    "equity-scorer": 0,
+    "gwas-prs": 0,
+    "nutrigx-advisor": 0,
+    "pharmgx-reporter": 0
+  }
+}

--- a/scripts/check_bench_baseline.py
+++ b/scripts/check_bench_baseline.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Fail CI when clawbio-bench regresses against a committed baseline.
+
+Provenance: #342. The `scientific-audit` job ran the bench as
+
+    uv run clawbio-bench --smoke --repo . || true
+
+so the exit code was discarded and every later step was `if: always()`. The job
+reported SUCCESS on every PR for months while the bench itself returned
+`pass: false` with seven blocking harnesses, and `nutrigx-advisor` sat at 0/10
+in the shipped catalog the whole time (#237). A verification step that reports
+success for something nobody checked converts an unknown into a false
+assurance, and then nobody looks again.
+
+Why this gate does not simply assert `overall.pass`
+---------------------------------------------------
+Seven harnesses are below 100% today. Requiring a clean bench would block every
+unrelated PR on pre-existing debt, and the pressure to re-add `|| true` would be
+immediate and would win. So the gate fails on *regression* from a recorded
+baseline: new breakage goes red, existing debt stays visible in `bench_baseline.json`
+and is tracked in #106.
+
+Raising a baseline number is a deliberate, reviewable commit. Lowering one
+should be treated as a bug report.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Bench rates are floats rendered to one decimal place. Anything smaller than
+# this is representation noise, not a regression.
+TOLERANCE = 0.05
+
+
+def load_baseline(path: Path) -> dict:
+    """Load the committed baseline. A malformed or absent baseline is fatal:
+    silently treating it as empty would make the gate vacuous, which is the
+    #342 failure mode again."""
+    data = json.loads(Path(path).read_text())
+    if not isinstance(data, dict) or not isinstance(data.get("harnesses"), dict):
+        raise ValueError(f"{path}: expected an object with a 'harnesses' mapping")
+    return data
+
+
+def compare(
+    report: dict,
+    baseline: dict,
+    baseline_errors: dict | None = None,
+) -> list[str]:
+    """Return a list of human-readable regressions. Empty means clean.
+
+    Three distinct regressions are detected, and the second matters as much as
+    the first: deleting a failing harness must not turn the build green.
+    """
+    failures: list[str] = []
+    harnesses = report.get("harnesses", {})
+    expected = baseline.get("harnesses", {})
+
+    for name, want in expected.items():
+        entry = harnesses.get(name)
+        if entry is None:
+            failures.append(
+                f"{name}: missing from this run, baseline expects {want}% "
+                "(a harness that disappears is a regression, not a pass)"
+            )
+            continue
+
+        got = entry.get("pass_rate")
+        if got is None:
+            failures.append(f"{name}: no pass_rate reported, baseline expects {want}%")
+            continue
+
+        if got < want - TOLERANCE:
+            failures.append(
+                f"{name}: pass rate fell from {want}% to {got}% "
+                f"(-{round(want - got, 2)} points)"
+            )
+
+    if baseline_errors is not None:
+        for name, want_errors in baseline_errors.items():
+            entry = harnesses.get(name)
+            if entry is None:
+                continue
+            got_errors = entry.get("harness_errors", 0)
+            if got_errors > want_errors:
+                failures.append(
+                    f"{name}: harness errors rose from {want_errors} to {got_errors} "
+                    "(an errored harness proves nothing, so this is not a pass)"
+                )
+
+    return failures
+
+
+def _render(report: dict, baseline: dict) -> str:
+    """Per-harness table, printed on pass as well as on failure so the rates are
+    visible in the job log without downloading an artifact."""
+    expected = baseline.get("harnesses", {})
+    lines = ["| Harness | Baseline | This run | Delta |", "|---|---|---|---|"]
+    for name, entry in sorted(report.get("harnesses", {}).items()):
+        got = entry.get("pass_rate")
+        want = expected.get(name)
+        if want is None:
+            lines.append(f"| {name} | (new) | {got}% | - |")
+            continue
+        delta = round((got or 0) - want, 2)
+        marker = "" if delta >= -TOLERANCE else " **REGRESSION**"
+        sign = "+" if delta > 0 else ""
+        lines.append(f"| {name} | {want}% | {got}%{marker} | {sign}{delta} |")
+    overall = report.get("overall", {})
+    if overall:
+        lines.append("")
+        lines.append(
+            f"Bench overall: {overall.get('total_pass')}/{overall.get('total_cases')} "
+            f"= {overall.get('total_pass_rate')}% "
+            f"(bench's own verdict: pass={overall.get('pass')})"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", help="path to the bench aggregate_report.json")
+    parser.add_argument(
+        "--baseline",
+        default=str(Path(__file__).resolve().parents[1] / "bench_baseline.json"),
+    )
+    parser.add_argument(
+        "--summary",
+        help="append the rendered table to this file (e.g. $GITHUB_STEP_SUMMARY)",
+    )
+    args = parser.parse_args(argv)
+
+    report_path = Path(args.report)
+    if not report_path.is_file():
+        # The bench producing no report at all is the #342 failure mode wearing
+        # a different hat: absence of evidence read as evidence of absence.
+        print(
+            f"ERROR: no bench report at {report_path}. The bench did not run to "
+            "completion; this is a failure, not a pass.",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        report = json.loads(report_path.read_text())
+        baseline = load_baseline(Path(args.baseline))
+    except (json.JSONDecodeError, ValueError, OSError) as exc:
+        print(f"ERROR: could not read bench report or baseline: {exc}", file=sys.stderr)
+        return 2
+
+    table = _render(report, baseline)
+    print(table)
+    if args.summary:
+        with open(args.summary, "a", encoding="utf-8") as handle:
+            handle.write("\n## Scientific Correctness Audit\n\n" + table + "\n")
+
+    baseline_errors = baseline.get("harness_errors")
+    failures = compare(report, baseline, baseline_errors=baseline_errors)
+    if failures:
+        print("\nBench regressed against the committed baseline:\n", file=sys.stderr)
+        for line in failures:
+            print(f"  - {line}", file=sys.stderr)
+        print(
+            "\nIf a drop is intentional and understood, update bench_baseline.json "
+            "in the same PR and say why in the description.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nNo regression against bench_baseline.json.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_bench_baseline.py
+++ b/tests/test_bench_baseline.py
@@ -1,0 +1,128 @@
+"""Tests for the scientific-audit baseline regression gate.
+
+Provenance: #342. The bench was invoked as `clawbio-bench --smoke || true`, so
+the job reported SUCCESS on every PR while the bench itself returned
+`pass: false` with seven blocking harnesses. A gate that cannot fail is worse
+than no gate, because the green tick stops anyone looking.
+
+The gate deliberately does NOT require `overall.pass`. Seven harnesses are
+below 100% today; demanding a clean bench would block every PR on pre-existing
+debt and the `|| true` would go straight back on. It fails on *regression*
+against a committed baseline instead.
+"""
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _load():
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "check_bench_baseline.py"
+    spec = importlib.util.spec_from_file_location("check_bench_baseline", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+MOD = _load()
+
+BASELINE = {"harnesses": {"alpha": 90.0, "beta": 0.0}}
+
+
+def _report(rates, harness_errors=None):
+    harness_errors = harness_errors or {}
+    return {
+        "harnesses": {
+            name: {"pass_rate": rate, "harness_errors": harness_errors.get(name, 0)}
+            for name, rate in rates.items()
+        }
+    }
+
+
+def test_unchanged_rates_pass():
+    failures = MOD.compare(_report({"alpha": 90.0, "beta": 0.0}), BASELINE)
+    assert failures == []
+
+
+def test_improvement_passes():
+    failures = MOD.compare(_report({"alpha": 97.5, "beta": 40.0}), BASELINE)
+    assert failures == []
+
+
+def test_regression_fails_and_names_the_harness():
+    failures = MOD.compare(_report({"alpha": 80.0, "beta": 0.0}), BASELINE)
+    assert len(failures) == 1
+    assert "alpha" in failures[0]
+    assert "90.0" in failures[0] and "80.0" in failures[0]
+
+
+def test_regression_below_a_zero_baseline_is_impossible_but_beta_cannot_silently_vanish():
+    """A harness present in the baseline and absent from the report is a
+    regression, not a pass. Deleting a failing harness must not go green."""
+    failures = MOD.compare(_report({"alpha": 90.0}), BASELINE)
+    assert len(failures) == 1
+    assert "beta" in failures[0]
+    assert "missing" in failures[0].lower()
+
+
+def test_new_harness_without_baseline_does_not_fail():
+    """A newly added harness has no recorded rate; record it, do not block."""
+    failures = MOD.compare(_report({"alpha": 90.0, "beta": 0.0, "gamma": 55.0}), BASELINE)
+    assert failures == []
+
+
+def test_float_noise_within_tolerance_passes():
+    failures = MOD.compare(_report({"alpha": 89.995, "beta": 0.0}), BASELINE)
+    assert failures == []
+
+
+def test_drop_beyond_tolerance_fails():
+    failures = MOD.compare(_report({"alpha": 89.9, "beta": 0.0}), BASELINE)
+    assert len(failures) == 1
+
+
+def test_new_harness_error_is_a_regression():
+    """A harness that starts erroring reports pass_rate 0.0 or vanishes; catch
+    the explicit error count too, since an errored harness proves nothing."""
+    report = _report({"alpha": 90.0, "beta": 0.0}, harness_errors={"alpha": 2})
+    failures = MOD.compare(report, BASELINE, baseline_errors={"alpha": 0, "beta": 0})
+    assert len(failures) == 1
+    assert "error" in failures[0].lower()
+
+
+def test_committed_baseline_matches_schema():
+    """The checked-in baseline must be loadable and non-empty, or the gate is
+    silently vacuous."""
+    baseline = MOD.load_baseline(
+        Path(__file__).resolve().parents[1] / "bench_baseline.json"
+    )
+    assert baseline["harnesses"]
+    assert "nutrigx-advisor" in baseline["harnesses"]
+    for name, rate in baseline["harnesses"].items():
+        assert isinstance(rate, (int, float)), name
+
+
+def test_main_exits_nonzero_on_regression(tmp_path):
+    report = tmp_path / "aggregate_report.json"
+    report.write_text(json.dumps(_report({"alpha": 10.0, "beta": 0.0})))
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps(BASELINE))
+    assert MOD.main([str(report), "--baseline", str(baseline)]) == 1
+
+
+def test_main_exits_zero_when_clean(tmp_path):
+    report = tmp_path / "aggregate_report.json"
+    report.write_text(json.dumps(_report({"alpha": 90.0, "beta": 0.0})))
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps(BASELINE))
+    assert MOD.main([str(report), "--baseline", str(baseline)]) == 0
+
+
+def test_missing_report_is_an_error_not_a_pass(tmp_path):
+    """The bench failing to produce a report at all must not read as success.
+    That is the #342 failure mode in a different costume."""
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps(BASELINE))
+    assert MOD.main([str(tmp_path / "nope.json"), "--baseline", str(baseline)]) == 2


### PR DESCRIPTION
Closes #342.

## The problem

```yaml
uv run clawbio-bench --smoke --repo . || true
```

Exit code discarded, every later step `if: always()`. The `scientific-audit` job has been structurally incapable of failing, and has reported SUCCESS on every PR for months.

What it was concealing, from the artifact of the most recent main run (`31733997982` at `056826d`):

```json
"overall": {"pass": false, "total_pass": 160, "total_cases": 183, "total_pass_rate": 87.9,
            "blocking_skills": ["bio-orchestrator", "nutrigx-advisor", "pharmgx-reporter",
                                "clawbio-finemapping", "clinical-variant-reporter",
                                "gwas-prs", "cvr-acmg-correctness"]}
```

`nutrigx-advisor` has been at **0/10** with `harness_errors: 0`. Not a harness failure, ten genuine `score_incorrect` / `snp_invalid` results. The cause is #237, open since 7 May: the rs4988235 lactase polarity is inverted, so the skill tells lactase-persistent users to avoid dairy. The bench said so on every single CI run and one `|| true` swallowed it.

## Why the gate is not `overall.pass`

Seven harnesses are below 100% today. Gating on the bench own verdict would turn every unrelated PR red, and the `|| true` would be back within a week for entirely understandable reasons. So the gate compares against per-harness rates in `bench_baseline.json` and fails only on **regression**. New breakage goes red; existing debt stays visible and tracked in #106.

## Three regression classes

Validated against real artifacts, not only fixtures:

| Class | Why it matters |
|---|---|
| Pass rate drops | The obvious one |
| Harness missing from the run | Deleting a failing harness must not turn the build green |
| Harness error count rises | An errored harness proves nothing, so it is not a pass |

A missing `aggregate_report.json` exits **2** rather than passing quietly, because absence of evidence read as evidence of absence is the same bug wearing a different hat.

Verified end to end by injecting each class into the real report:

```
- gwas-prs: missing from this run, baseline expects 62.5% (a harness that disappears is a regression, not a pass)
- pharmgx-reporter: pass rate fell from 95.5% to 88.0% (-7.5 points)
- equity-scorer: harness errors rose from 0 to 3 (an errored harness proves nothing, so this is not a pass)
exit=1
```

And confirmed the unmodified report against its own baseline exits 0, as does the older 4 August artifact.

The per-harness table now prints to `$GITHUB_STEP_SUMMARY` on pass as well as failure, so the rates are visible without downloading an artifact. That visibility is half the fix: nobody knew nutrigx was at zero.

## Second finding, fixed here too

**The entire top-level `tests/` directory has never run in CI.** The `test` job names skill test files individually, so `tests/test_generate_catalog.py` and this PR own 12 tests were all invisible. A gate whose tests never run is #342 one level up. Added a `Run repo-level tests` step; all 169 currently pass.

That is the same class as #337 (vcf-annotator tests not in the allowlist) and argues for deriving the list rather than hardcoding it, but that is a bigger change and belongs in its own PR.

## Baseline

Recorded from `056826d`. **These are not targets.** Raising a number is a deliberate, reviewable commit; lowering one should be treated as a bug report, not routine maintenance.

| Harness | Rate |
|---|---|
| equity-scorer | 100.0 |
| claw-metagenomics | 100.0 |
| cvr-variant-identity | 100.0 |
| bio-orchestrator | 98.1 |
| pharmgx-reporter | 95.5 |
| clawbio-finemapping | 95.0 |
| clinical-variant-reporter | 80.0 |
| cvr-acmg-correctness | 69.2 |
| gwas-prs | 62.5 |
| nutrigx-advisor | 0.0 |

Tests written first: 12 cases covering unchanged, improved, regressed, missing-harness, new-harness, float tolerance, error-count rise, malformed baseline, and both CLI exit paths.

Refs #106, #237, #313, #337.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI gating for scientific correctness and adds a committed baseline file; incorrect baseline updates or gate logic could block PRs or miss regressions, but scope is CI/verification rather than runtime product code.
> 
> **Overview**
> Fixes **#342**: the `scientific-audit` job could not fail because the bench ran with `|| true` and later steps used `if: always()`. The bench still runs for reporting, but a new **Fail on regression against the committed baseline** step is the actual gate—it compares `aggregate_report.json` to `bench_baseline.json` via `scripts/check_bench_baseline.py`, fails on pass-rate drops, missing harnesses, or rising harness errors, and exits **2** if no report exists.
> 
> The gate intentionally does **not** require `overall.pass` (seven harnesses are below 100% today); only **regression** from the recorded baseline fails CI, with per-harness tables appended to `$GITHUB_STEP_SUMMARY`.
> 
> The **test** job now runs `uv run pytest tests/ -v` so repo-level tests (including the new baseline gate tests) are no longer skipped by the hardcoded skill test allowlist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 514580b78273aa85db45e5e54207180fff0f552d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->