### PR TITLE
fix: handle list-valued ClinVar significance

### DIFF
--- a/skills/clinical-variant-reporter/acmg_engine.py
+++ b/skills/clinical-variant-reporter/acmg_engine.py
@@ -118,7 +118,7 @@ class VariantEvidence:
     hgvsp: str = ""
     transcript: str = ""
 
-    clinvar_significance: str = ""
+    clinvar_significance: str | list[str] = ""
     clinvar_review_stars: int = 0
 
     gnomad_af: float | None = None
@@ -162,6 +162,23 @@ class ClassifiedVariant:
 # ---------------------------------------------------------------------------
 # Criteria evaluation
 # ---------------------------------------------------------------------------
+def _clinvar_terms(significance: str | list[str]) -> set[str]:
+    """Normalize ClinVar's string and list forms into comparable terms."""
+    values = significance if isinstance(significance, list) else significance.split(",")
+    return {value.strip().lower().replace(" ", "_") for value in values if value.strip()}
+
+
+def _clinvar_directions(significance: str | list[str]) -> tuple[bool, bool]:
+    """Return pathogenic and benign flags, rejecting conflicting assertions."""
+    terms = _clinvar_terms(significance)
+    pathogenic = {"pathogenic", "likely_pathogenic"}
+    benign = {"benign", "likely_benign"}
+    conflicting = "conflicting_interpretations" in terms or (
+        bool(terms & pathogenic) and bool(terms & benign)
+    )
+    return bool(terms & pathogenic) and not conflicting, bool(terms & benign) and not conflicting
+
+
 def _eval_ba1(ev: VariantEvidence) -> EvidenceCriterion:
     """BA1: gnomAD AF > 5% → stand-alone benign."""
     triggered = ev.gnomad_af is not None and ev.gnomad_af > THRESHOLD_BA1_AF
@@ -231,8 +248,7 @@ def _eval_pvs1(ev: VariantEvidence) -> EvidenceCriterion:
 
 def _eval_ps1(ev: VariantEvidence) -> EvidenceCriterion:
     """PS1: Same amino acid change as an established pathogenic variant in ClinVar."""
-    clinvar_lower = ev.clinvar_significance.lower()
-    is_pathogenic_clinvar = "pathogenic" in clinvar_lower and "conflicting" not in clinvar_lower
+    is_pathogenic_clinvar, _ = _clinvar_directions(ev.clinvar_significance)
     triggered = (
         ev.is_missense
         and is_pathogenic_clinvar
@@ -306,8 +322,7 @@ def _eval_pp3(ev: VariantEvidence) -> EvidenceCriterion:
 
 def _eval_pp5(ev: VariantEvidence) -> EvidenceCriterion:
     """PP5: Reputable source reports variant as pathogenic."""
-    clinvar_lower = ev.clinvar_significance.lower()
-    is_pathogenic = "pathogenic" in clinvar_lower and "conflicting" not in clinvar_lower
+    is_pathogenic, _ = _clinvar_directions(ev.clinvar_significance)
     triggered = is_pathogenic and ev.clinvar_review_stars >= CLINVAR_MIN_STARS
     return EvidenceCriterion(
         code="PP5",
@@ -349,8 +364,7 @@ def _eval_bp4(ev: VariantEvidence) -> EvidenceCriterion:
 
 def _eval_bp6(ev: VariantEvidence) -> EvidenceCriterion:
     """BP6: Reputable source reports variant as benign."""
-    clinvar_lower = ev.clinvar_significance.lower()
-    is_benign = ("benign" in clinvar_lower or "likely benign" in clinvar_lower) and "pathogenic" not in clinvar_lower
+    _, is_benign = _clinvar_directions(ev.clinvar_significance)
     triggered = is_benign and ev.clinvar_review_stars >= CLINVAR_MIN_STARS
     return EvidenceCriterion(
         code="BP6",

--- a/skills/clinical-variant-reporter/tests/test_clinical_variant_reporter.py
+++ b/skills/clinical-variant-reporter/tests/test_clinical_variant_reporter.py
@@ -229,6 +229,29 @@ class TestCriteriaEvaluation:
         bp6 = next(c for c in criteria if c.code == "BP6")
         assert bp6.triggered is True
 
+    @pytest.mark.parametrize("significance", [
+        "Pathogenic", ["pathogenic", "pathogenic"],
+    ])
+    def test_clinvar_pathogenic_terms_trigger_pp5(self, significance):
+        ev = VariantEvidence(
+            chrom="chr1", pos=100, ref="A", alt="G",
+            clinvar_significance=significance, clinvar_review_stars=3,
+        )
+        pp5 = next(c for c in evaluate_criteria(ev) if c.code == "PP5")
+        assert pp5.triggered is True
+
+    @pytest.mark.parametrize("significance", [
+        ["benign", "pathogenic"], ["conflicting_interpretations"], ["novel_value"],
+    ])
+    def test_clinvar_conflicting_or_unknown_terms_do_not_trigger(self, significance):
+        ev = VariantEvidence(
+            chrom="chr1", pos=100, ref="A", alt="G",
+            clinvar_significance=significance, clinvar_review_stars=3,
+        )
+        criteria = evaluate_criteria(ev)
+        assert next(c for c in criteria if c.code == "PP5").triggered is False
+        assert next(c for c in criteria if c.code == "BP6").triggered is False
+
 
 # ---------------------------------------------------------------------------
 # Unit tests — SF v3.2 screening
@@ -513,6 +536,27 @@ class TestClinSigAlleleTypeGuard:
         ev = _extract_evidence_from_vep(
             self._vep({"review_status_stars": 3}), self._record())
         assert ev.clinvar_review_stars == 3
+
+    def test_list_clin_sig_classifies_conflicts_without_crashing(self):
+        from clinical_variant_reporter import _extract_evidence_from_vep
+        ev = _extract_evidence_from_vep(
+            {
+                **self._vep({"review_status_stars": 3}),
+                "most_severe_consequence": "missense_variant",
+                "transcript_consequences": [{
+                    "gene_symbol": "BRCA2",
+                    "impact": "MODERATE",
+                    "consequence_terms": ["missense_variant"],
+                }],
+                "colocated_variants": [{
+                    "clin_sig": ["benign", "pathogenic"],
+                    "clin_sig_allele": {"review_status_stars": 3},
+                }],
+            },
+            self._record(),
+        )
+        classified = classify_variant(ev)
+        assert all(code not in classified.triggered_codes for code in ("PS1", "PP5", "BP6"))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #328

## Summary

- Normalize ClinVar significance values received as strings or lists into exact terms.
- Treat conflicting pathogenic and benign assertions as neither direction, avoiding both crashes and silent misclassification.

## Skill affected

clinical-variant-reporter

## Checklist

- [ ] SKILL.md is present and complete (YAML frontmatter + methodology)
- [x] Tests included and passing (`pytest -v`)
- [ ] Demo data included for reviewers to test (not needed for this bug fix)
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

`pytest skills/clinical-variant-reporter/tests/test_clinical_variant_reporter.py -q` — 68 passed.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
