### PR TITLE
Add claim-provenance-check skill

### DIFF
--- a/clawbio/cli.py
+++ b/clawbio/cli.py
@@ -1220,6 +1220,13 @@ SKILLS = {
         "no_input_required": True,
         "accepts_genotypes": False,
     },
+    "provcheck": {
+        "script": SKILLS_DIR / "claim-provenance-check" / "claim_provenance_check.py",
+        "demo_args": ["--demo"],
+        "description": "Bind every citation in a claim to a retrieved evidence row and report which evidence classes were reached, refusing invented citations with no partial credit.",
+        "allowed_extra_flags": set(),
+        "accepts_genotypes": False,
+    },
 }
 
 try:

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "generated_by": "scripts/generate_catalog.py",
-  "skill_count": 96,
+  "skill_count": 97,
   "galaxy_tool_count": 8182,
   "skills": [
     {
@@ -626,6 +626,54 @@
         "cell-type-specific expression",
         "expression specificity",
         "marker gene specificity"
+      ],
+      "chaining_partners": [],
+      "license": "MIT",
+      "model_license": "",
+      "data_license": ""
+    },
+    {
+      "name": "claim-provenance-check",
+      "cli_alias": "provcheck",
+      "description": "Bind every citation in a claim to a retrieved evidence row and report which evidence classes were reached, refusing invented citations with no partial credit",
+      "version": "0.1.0",
+      "status": "planned",
+      "maturity_tier": "cli-registered",
+      "maturity_evidence": {
+        "has_skill_md": true,
+        "has_script": true,
+        "has_tests": true,
+        "has_demo": true,
+        "cli_registered": true,
+        "ci_tested": false,
+        "benchmark_validated": false
+      },
+      "has_script": true,
+      "has_tests": true,
+      "has_demo": true,
+      "demo_command": "python clawbio.py run provcheck --demo",
+      "dependencies": [
+        "python>=3.9"
+      ],
+      "tags": [
+        "citation-verification",
+        "provenance",
+        "coverage-report",
+        "hallucination-detection",
+        "evidence-binding",
+        "report-qa"
+      ],
+      "trigger_keywords": [
+        "check citations",
+        "citation binder",
+        "verify claim citations",
+        "coverage report",
+        "no coverage",
+        "invented citation",
+        "hallucinated citation",
+        "does this claim have evidence",
+        "bind claim to evidence",
+        "unbindable claim"
       ],
       "chaining_partners": [],
       "license": "MIT",

--- a/skills/claim-provenance-check/SKILL.md
+++ b/skills/claim-provenance-check/SKILL.md
@@ -1,0 +1,336 @@
+---
+name: claim-provenance-check
+description: Bind every citation in a claim to a retrieved evidence row and report which evidence classes were reached, refusing invented citations with no partial credit
+license: MIT
+metadata:
+  version: 0.1.0
+  author: Sippar (Nuru-AI) <elad@sippar.network>
+  domain: clinical
+  tags:
+    - citation-verification
+    - provenance
+    - coverage-report
+    - hallucination-detection
+    - evidence-binding
+    - report-qa
+  inputs:
+    - name: input_file
+      type: file
+      format:
+        - json
+      description: >-
+        Case file (conventionally named demo_input.txt or *.json): a JSON object with
+        "subject" (string), "rows" (retrieved EvidenceRow objects: tag, source_class, text,
+        url?, cohort?, n?), "outcomes" (SourceOutcome objects: source_class, ok, rows?,
+        reason?, route?, cost_usd?), and "claims" (strings containing "[class:index]"
+        citation tags).
+      required: false
+    - name: demo
+      type: flag
+      description: Run on the bundled synthetic demo_input.txt instead of --input
+      required: false
+  outputs:
+    - name: report
+      type: file
+      format:
+        - md
+      description: Coverage map + per-claim verdict (SUPPORTED / CONTESTED / NO COVERAGE) with refusal reasons and the safety disclaimer (report.md)
+    - name: result
+      type: file
+      format:
+        - json
+      description: Machine-readable coverage map and claim verdicts (result.json)
+  dependencies:
+    python: ">=3.9"
+  demo_data:
+    - path: demo_input.txt
+      description: Synthetic evidence case with one SUPPORTED claim, one CONTESTED claim, one uncited claim, and one claim with an invented citation tag -- exercises every verdict path
+  endpoints:
+    cli: python skills/claim-provenance-check/claim_provenance_check.py --input {input_file} --output {output_dir}
+    cli_demo: python skills/claim-provenance-check/claim_provenance_check.py --demo --output {output_dir}
+  openclaw:
+    requires:
+      bins:
+        - python3
+    always: false
+    emoji: "🔗"
+    homepage: https://github.com/ClawBio/ClawBio
+    os:
+      - darwin
+      - linux
+    trigger_keywords:
+      - check citations
+      - citation binder
+      - verify claim citations
+      - coverage report
+      - no coverage
+      - invented citation
+      - hallucinated citation
+      - does this claim have evidence
+      - bind claim to evidence
+      - unbindable claim
+---
+
+# 🔗 Claim Provenance Check
+
+You are **Claim Provenance Check**, a specialised ClawBio skill for verifying that scientific
+claims cite real, retrieved evidence. Your role is to mechanically bind every `[class:index]`
+citation tag in a claim to a retrieved evidence row, and to report which evidence classes a
+subject actually reached versus `NO COVERAGE` -- so an agent's drafted narrative can be checked
+before it ships, not trusted on faith.
+
+## Trigger
+
+**Fire this skill when the user says any of:**
+- "check citations" / "verify these citations" / "citation binder"
+- "does this claim have evidence" / "is this citation real"
+- "coverage report" / "what evidence classes did we reach"
+- "invented citation" / "hallucinated citation" / "no coverage"
+- "bind claim to evidence" / "unbindable claim"
+- "did every citation in this report resolve"
+- "run the claim provenance check"
+
+**Do NOT fire when:**
+- The user wants the skill to *retrieve* evidence itself (e.g. "find me trials for BRCA1"). This
+  skill only binds claims to rows it is *given*; route retrieval to `clinical-trial-finder` or
+  `lit-synthesizer` first, then bring the retrieved rows back here as a case file.
+- The user wants a judgement on whether a claim is scientifically *true*. This skill checks
+  whether a citation resolves and how many independent evidence classes support it -- never the
+  correctness of the underlying evidence itself.
+- The user has no case file (subject + rows + outcomes + claims) and no intention of assembling
+  one -- there is nothing to bind against.
+
+## Why This Exists
+
+- **Without it**: an agent drafts a claim with a citation tag that looks plausible -- `[trials:2]`
+  -- and nobody mechanically checks whether row `trials:2` was ever actually retrieved. The tag
+  reads as evidence to anyone who does not re-run the retrieval themselves.
+- **With it**: every citation is checked against the rows that were actually retrieved, in
+  milliseconds, before a report ships. A claim with one invented tag is refused outright.
+- **Why ClawBio**: this is arithmetic, not judgement -- a fixed-cost, deterministic gate that
+  catches the specific failure mode (an invented citation) that a model judge is neither
+  guaranteed to catch nor cheap to run for.
+
+## Scope
+
+**One skill, one task.** This skill binds already-retrieved evidence to already-drafted claims
+and reports evidence-class coverage for a subject. It does not retrieve evidence, does not draft
+claims, and does not judge scientific correctness. If you need retrieval too, chain with
+`clinical-trial-finder` / `lit-synthesizer` first and feed their output in as `rows`.
+
+## Core Capabilities
+
+1. **Citation binding**: extract every `[class:index]` tag from a claim and check it resolves to a retrieved evidence row's tag
+2. **No partial credit**: refuse a claim outright on an invented citation, a missing citation, or an 8+ word verbatim run copied from a cited source row
+3. **Claim states**: classify every bindable claim as SUPPORTED (2+ independent evidence classes cited), CONTESTED (one class, or a citation flagged as disagreeing), or NO COVERAGE (fails the binder)
+4. **Coverage report**: render which evidence classes were reached for a subject vs NO COVERAGE, with each gap carrying the named source and route that would close it
+5. **Zero network, zero model**: standard-library-only, deterministic, no HTTP calls -- runs the same way with or without connectivity
+
+## Input Formats
+
+| Format | Extension | Required Fields | Example |
+|--------|-----------|-----------------|---------|
+| Case JSON | `.json` / `.txt` | `subject`, `rows`, `outcomes`, `claims` | `demo_input.txt` |
+
+## Workflow
+
+1. **Parse** the case file (`--input <path>` or `--demo`); require `subject`, `rows`, `outcomes`, `claims`.
+2. **Build** `EvidenceRow` objects from `rows` and `SourceOutcome` objects from `outcomes`.
+3. **Coverage**: for every outcome, record reached vs `NO COVERAGE`; an unreached class keeps its named `route` -- never dropped from the map.
+4. **Bind** each claim: extract its citation tags, check every tag matches a retrieved row's tag, check for an 8+ word run copied verbatim from a cited row. Any single issue refuses the claim as `NO COVERAGE` -- no partial credit.
+5. **Classify** every claim that survives step 4 as `SUPPORTED` (2+ distinct cited evidence classes) or `CONTESTED` (exactly one class, or a tag in `disagreeing_tags`).
+6. **Report**: write `report.md` (coverage map + claim verdicts + safety disclaimer) and `result.json` (machine-readable) to `--output`.
+
+## CLI Reference
+
+```bash
+# Standard usage
+python skills/claim-provenance-check/claim_provenance_check.py \
+  --input <case.json> --output <report_dir>
+
+# Demo mode (bundled synthetic data, no user files needed)
+python skills/claim-provenance-check/claim_provenance_check.py --demo --output /tmp/demo
+
+# Via ClawBio runner
+python clawbio.py run provcheck --input <case.json> --output <dir>
+python clawbio.py run provcheck --demo
+```
+
+## Demo
+
+```bash
+python skills/claim-provenance-check/claim_provenance_check.py --demo --output /tmp/demo
+```
+
+Expected output: `report.md` showing 3/5 evidence classes reached for the synthetic subject
+(2 `NO COVERAGE` gaps, each with a named route) and 4 claim verdicts -- 1 `SUPPORTED`, 1
+`CONTESTED`, and 2 refused as `NO COVERAGE` (one uncited, one with an invented citation tag) --
+"2 shipped, 2 refused."
+
+## Algorithm / Methodology
+
+1. **Tag extraction**: `TAG_RE = r"\[([a-z0-9_-]+:\d+)\]"` (case-insensitive), lowercased on
+   extraction. Non-matching bracketed text (e.g. `[3]`, figure references) is ignored.
+2. **Binder**: a claim fails if it has zero tags (`citation-floor`), any tag that is not in the
+   set of retrieved rows' tags (`citation-invalid`), or an 8+ consecutive-word run shared with
+   any cited row's text (`verbatim-run`). Any one failure refuses the whole claim.
+3. **Claim state**: a claim that fails the binder is always `NO_COVERAGE`, never a downgraded
+   `SUPPORTED`. A claim that binds clean is `SUPPORTED` when its cited tags span 2+ distinct
+   `source_class` values, `CONTESTED` when they span exactly one, or when a cited tag is in the
+   caller-supplied `disagreeing_tags` set.
+4. **Coverage**: a subject's evidence classes are declared by the caller via `outcomes`; each is
+   either reached (`ok=True`, with a row count) or a gap (`ok=False`, with a `reason` and a
+   `route` that names what would close it). Gaps are rendered, never omitted.
+
+**Key thresholds / parameters** (source: `provenance_core.py`, ported from Sippar's production
+`reportQuality.ts`):
+- `VERBATIM_RUN_WORDS = 8` -- chosen empirically upstream: shorter fires on ordinary English, longer lets a whole lifted clause through.
+- `2` distinct evidence classes required for `SUPPORTED` -- a single class is not independent corroboration.
+
+## Example Queries
+
+- "Check these claims against the evidence I retrieved and tell me what's actually supported"
+- "Did any of these citations get invented?"
+- "Give me a coverage report for this subject -- what evidence classes did we actually reach?"
+- "Run the claim provenance check on this case file"
+
+## Example Output
+
+Rendered `report.md` from the bundled demo (`--demo`), unedited:
+
+```markdown
+# Claim Provenance Report — SYNTH-TARGET-01 (synthetic demo subject, not a real gene or drug target)
+
+> This report is a mechanical citation check, not a scientific, clinical, or factual judgement. [...]
+
+## Coverage
+
+\```
+COVERAGE  SYNTH-TARGET-01 (synthetic demo subject, not a real gene or drug target)  (3/5 classes)
+  [reached] expression  (1 rows)
+  [reached] literature  (1 rows)
+  [reached] trials  (1 rows)
+  [NO COVERAGE] population  cohort ancestry does not cover the question asked  route: a cohort matched to the population in question
+  [NO COVERAGE] ip  supplier unreachable  route: patent prior-art search (synthetic route, no real supplier)
+  cost: $0.0062
+\```
+
+## Claims
+
+- **[SUPPORTED]** Expression is raised against matched normal tissue [expression:0], and the direction replicates independently [literature:0].
+- **[CONTESTED]** An earlier interventional study against this target closed without meeting its endpoint [trials:0].
+- **[NO COVERAGE]** This is the strongest available target for this indication.
+    - refused: `citation-floor` — claim carries no citation
+- **[NO COVERAGE]** Population-matched evidence supports the same conclusion [population:4].
+    - refused: `citation-invalid` — [population:4] does not match any retrieved row
+
+**2 shipped, 2 refused.** A refusal is an outcome, not an error.
+```
+
+## Output Structure
+
+```
+output_directory/
+├── report.md    # Coverage map + per-claim verdict + safety disclaimer
+└── result.json  # Machine-readable coverage map + claim verdicts
+```
+
+This skill is a deterministic check, not a data pipeline -- it does not produce figures, tables,
+or a reproducibility bundle, and does not claim to.
+
+## Domain Decisions
+
+- **`VERBATIM_RUN_WORDS = 8`**: the shortest run of consecutive shared words between a claim and
+  a cited row that counts as copying rather than coincidence. Chosen empirically upstream in
+  Sippar's `reportQuality.ts`: a shorter run fires constantly on ordinary English phrasing; a
+  longer run lets a whole lifted clause through undetected.
+- **`require_citation=True` by default**: an uncited claim always fails (`citation-floor`).
+  Silence is not evidence.
+- **No partial credit**: a claim with one invalid tag is refused *in full*, even if it also
+  carries a valid tag elsewhere. A claim is one unit; it does not get to keep the good half.
+- **2+ distinct `source_class` values required for `SUPPORTED`**: one cited class is not
+  independent corroboration, so a single-class claim is `CONTESTED`, never `SUPPORTED`, even if
+  its one citation is perfectly valid.
+- **A binder failure is always `NO_COVERAGE`, never a downgraded `SUPPORTED`**: an unbindable
+  claim carries no evidence at all, which is a coverage fact, not a confidence level.
+- **A `SourceOutcome` with `ok=False` must always carry a `route`**: a coverage gap is reported
+  with what would close it, never as a bare absence.
+- **Tags are retrieval-layer-only**: `EvidenceRow.tag` must be assigned by whatever retrieved the
+  row, never by the model drafting the claim. A model that can mint its own tags can mint its own
+  evidence.
+
+## Dependencies
+
+**Required**: none -- Python 3.9+ standard library only (`re`, `dataclasses`, `enum`, `typing`,
+`argparse`, `json`, `pathlib`, `datetime`). No network calls, no third-party packages.
+
+## Gotchas
+
+- **The model will want to summarise the coverage map** instead of showing it verbatim ("most
+  evidence was found"). Do not -- the whole point of `report.md` is that gaps stay visible with
+  their routes; paraphrasing one away re-creates the exact failure this skill exists to prevent.
+- **The model will want to invent a citation tag** for a claim it believes is true but was not
+  given evidence for (e.g. writing `[trials:0]` because "it sounds right"). Do not -- tags are
+  assigned only by the retrieval layer that produced `rows`. Never author or edit `rows` /
+  `outcomes` in a case file just to make a claim pass.
+- **The model will want to treat `NO COVERAGE` as weak support** and hedge with language like
+  "there is some evidence that...". Do not -- `NO COVERAGE` means the claim could not be bound at
+  all (missing citation, invalid citation, or a verbatim lift), which is categorically different
+  from `CONTESTED` (bound, but only one class, or disagreeing evidence). Report it as a refusal.
+- **The model will want to loosen the 8-word verbatim threshold** when its own paraphrase
+  coincidentally overlaps with a source row. Do not override `VERBATIM_RUN_WORDS`; rewrite the
+  claim instead. The threshold is a fixed Domain Decision, not a per-run knob.
+- **The model will want to smooth over a refused claim** after the fact, treating it as a
+  copy-edit problem rather than a missing-evidence problem. A refused claim must be removed or
+  re-drafted with a real citation from `rows`, not rephrased to sound less citation-dependent.
+
+## Safety
+
+- **Local-first**: zero network calls anywhere in `provenance_core.py` or
+  `claim_provenance_check.py`. No data leaves the machine.
+- **Disclaimer**: every `report.md` includes the ClawBio research/educational disclaimer plus a
+  citation-check-specific caveat that `SUPPORTED` / `CONTESTED` describe what cited evidence
+  *says*, not whether it is correct.
+- **No hallucinated science**: the skill never invents a citation, a source, or a claim -- it
+  only checks tags the caller already retrieved.
+- **No partial credit**: reiterated here because it is the load-bearing safety property -- a
+  claim with any invented citation is refused in full, not scored down.
+
+## Agent Boundary
+
+The agent (LLM) drafts claim prose and evidence retrieval, and dispatches this skill. The skill
+(Python, `provenance_core.py`) verifies every citation mechanically and computes
+`SUPPORTED` / `CONTESTED` / `NO COVERAGE` deterministically.
+
+The agent must NOT:
+- Override a `NO_COVERAGE` verdict, or describe a refused claim as supported in surrounding prose.
+- Author or edit `rows` / `outcomes` in a case file to make a claim pass -- those must come from
+  an actual retrieval layer, never from the model's own belief.
+- Invent a citation tag for a claim it believes is true.
+- Change `VERBATIM_RUN_WORDS` or the 2-class `SUPPORTED` threshold per run -- they are fixed
+  Domain Decisions, not agent-tunable parameters.
+- Drop or hide a `NO COVERAGE` row from the coverage map when summarising it to a user.
+
+## Integration with Bio Orchestrator
+
+**Trigger conditions**: the orchestrator routes here when the user asks to check, verify, or
+bind citations, or asks for a coverage report -- see `## Trigger` above for the full phrase list.
+
+**Chaining partners**:
+- `clinical-trial-finder`: reshape its trial search results into `trials`-class `EvidenceRow`s
+  and feed them into this skill's case file so drafted claims about trial outcomes get checked.
+- `lit-synthesizer`: its literature search output supplies `literature`-class rows the same way.
+
+## Maintenance
+
+- **Review cadence**: revisit if the upstream provenance engine in Nuru-AI/sippar
+  (`hackathon/clawbio-berlin/provenance/`) changes its binder or coverage logic.
+- **Staleness signals**: none from an external API or database -- this skill is pure stdlib
+  logic. The only drift risk is `provenance_core.py` here diverging from its upstream source
+  without a deliberate, documented reason.
+- **Deprecation**: no criteria today; revisit if ClawBio drops LLM-assisted report generation as
+  a use case entirely.
+
+## Citations
+
+- Sippar (sippar.network) `reportQuality.ts` -- the production TypeScript implementation this Python port is adapted from. Sippar's GitHub repository is private; this skill is a from-scratch Python port of its citation-binding logic, built for and packaged at the ClawBio + Nebius Berlin hackathon (2026-08-18).

--- a/skills/claim-provenance-check/claim_provenance_check.py
+++ b/skills/claim-provenance-check/claim_provenance_check.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+claim_provenance_check.py — ClawBio Claim Provenance Check Skill
+==================================================================
+Bind every citation tag in a claim to a retrieved evidence row, and report which evidence
+classes were reached for the subject versus NO COVERAGE. Refuses claims with an invented or
+missing citation instead of scoring them — no partial credit.
+
+Author:  Sippar (Nuru-AI)
+Version: 0.1.0
+
+Usage:
+    python claim_provenance_check.py --input <case.json> --output <output_dir>
+    python claim_provenance_check.py --demo --output /tmp/claim-provenance-check_demo
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from provenance_core import (
+    ClaimState,
+    CoverageReport,
+    EvidenceRow,
+    SourceOutcome,
+    state_for_claim,
+)
+
+# No external dependencies required — standard library only.
+
+SAFETY_DISCLAIMER = (
+    "This report is a mechanical citation check, not a scientific, clinical, or factual "
+    "judgement. SUPPORTED / CONTESTED describe what the cited evidence rows say, not whether "
+    "the underlying evidence is correct. NO COVERAGE means the claim could not be bound to any "
+    "retrieved evidence row and must be treated as a refusal, never as a weaker form of "
+    "support. ClawBio is a research and educational tool, not a medical device, and does not "
+    "provide clinical diagnoses. Consult a healthcare professional before making any medical "
+    "decisions."
+)
+
+REQUIRED_CASE_KEYS = ("subject", "rows", "outcomes", "claims")
+
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+def load_case(input_path: Path) -> dict:
+    """Parse and shape-check a case JSON file."""
+    try:
+        case = json.loads(input_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{input_path} is not valid JSON: {exc}") from exc
+
+    missing = [key for key in REQUIRED_CASE_KEYS if key not in case]
+    if missing:
+        raise ValueError(f"{input_path} is missing required key(s): {', '.join(missing)}")
+    return case
+
+
+def build_rows(raw_rows: list[dict]) -> list[EvidenceRow]:
+    return [EvidenceRow(**row) for row in raw_rows]
+
+
+def build_outcomes(raw_outcomes: list[dict]) -> list[SourceOutcome]:
+    return [SourceOutcome(**outcome) for outcome in raw_outcomes]
+
+
+def evaluate_claims(claims: list[str], rows: list[EvidenceRow]) -> list[dict]:
+    """Bind every claim and return its verdict, in the order given."""
+    verdicts = []
+    for claim in claims:
+        state, issues = state_for_claim(claim, rows)
+        verdicts.append(
+            {
+                "claim": claim,
+                "state": state.value,
+                "issues": [{"code": i.code, "detail": i.detail} for i in issues],
+            }
+        )
+    return verdicts
+
+
+def render_report(subject: str, coverage: CoverageReport, verdicts: list[dict]) -> str:
+    shipped = sum(1 for v in verdicts if v["state"] != ClaimState.NO_COVERAGE.value)
+    refused = len(verdicts) - shipped
+
+    lines = [
+        f"# Claim Provenance Report — {subject}",
+        "",
+        f"> {SAFETY_DISCLAIMER}",
+        "",
+        "## Coverage",
+        "",
+        "```",
+        coverage.render(),
+        "```",
+        "",
+        "## Claims",
+        "",
+    ]
+    for v in verdicts:
+        lines.append(f"- **[{v['state']}]** {v['claim']}")
+        for issue in v["issues"]:
+            lines.append(f"    - refused: `{issue['code']}` — {issue['detail']}")
+    lines += [
+        "",
+        f"**{shipped} shipped, {refused} refused.** A refusal is an outcome, not an error.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def run(input_path: Path, output_dir: Path) -> dict:
+    """
+    Core skill logic: bind every claim in the case file to its retrieved evidence, and render
+    the coverage map plus per-claim verdicts.
+
+    Args:
+        input_path:  Path to a case JSON file (subject, rows, outcomes, claims).
+        output_dir:  Directory where report.md and result.json will be written.
+
+    Returns:
+        dict: Machine-readable results (also written to result.json).
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    case = load_case(input_path)
+    rows = build_rows(case["rows"])
+    outcomes = build_outcomes(case["outcomes"])
+    coverage = CoverageReport(case["subject"], outcomes)
+    verdicts = evaluate_claims(case["claims"], rows)
+
+    report_md = render_report(case["subject"], coverage, verdicts)
+    (output_dir / "report.md").write_text(report_md, encoding="utf-8")
+
+    results: dict = {
+        "skill": "claim-provenance-check",
+        "input": str(input_path),
+        "generated_at": datetime.now().isoformat(),
+        "coverage": coverage.as_dict(),
+        "claims": verdicts,
+    }
+    (output_dir / "result.json").write_text(
+        json.dumps(results, indent=2, default=str), encoding="utf-8"
+    )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Demo mode
+# ---------------------------------------------------------------------------
+
+def run_demo(output_dir: Path) -> dict:
+    """Run on the bundled synthetic demo_input.txt to verify the skill works end-to-end."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    demo_input = Path(__file__).with_name("demo_input.txt")
+    results = run(demo_input, output_dir)
+
+    print(f"  Demo complete. Output: {output_dir}")
+    print(f"  Files: {', '.join(sorted(f.name for f in output_dir.rglob('*') if f.is_file()))}")
+    return results
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Bind every citation in a claim to a retrieved evidence row and report which "
+            "evidence classes were reached, refusing invented citations with no partial credit."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--input", dest="input_path", help="Path to a case JSON file")
+    parser.add_argument(
+        "--output",
+        dest="output_dir",
+        default="/tmp/claim-provenance-check_output",
+        help="Output directory (default: /tmp/claim-provenance-check_output)",
+    )
+    parser.add_argument("--demo", action="store_true", help="Run on the bundled synthetic demo_input.txt")
+    args = parser.parse_args()
+
+    out = Path(args.output_dir)
+
+    if args.demo:
+        run_demo(out)
+    elif args.input_path:
+        run(Path(args.input_path), out)
+        print(f"  Done. Output: {out}")
+        report = out / "report.md"
+        if report.exists():
+            print(f"  Report: {report}")
+    else:
+        parser.error("Provide --input <file> or --demo")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/claim-provenance-check/demo_input.txt
+++ b/skills/claim-provenance-check/demo_input.txt
@@ -1,0 +1,48 @@
+{
+  "_comment": "SYNTHETIC demo case. No real patient, trial, or literature data — all rows and outcomes below are invented placeholders, structured the same way a real retrieval layer would return them (see provenance_core.EvidenceRow / SourceOutcome). This is a JSON file with a .txt extension per the ClawBio demo_input.txt naming convention.",
+  "subject": "SYNTH-TARGET-01 (synthetic demo subject, not a real gene or drug target)",
+  "rows": [
+    {
+      "tag": "expression:0",
+      "source_class": "expression",
+      "text": "Transcript is elevated in tumour relative to adjacent normal tissue in the synthetic cohort.",
+      "cohort": "SYNTH-COHORT-01",
+      "n": 120
+    },
+    {
+      "tag": "literature:0",
+      "source_class": "literature",
+      "text": "Independent groups report the same directional effect in unrelated synthetic cohorts.",
+      "n": 14
+    },
+    {
+      "tag": "trials:0",
+      "source_class": "trials",
+      "text": "A synthetic interventional study against this target closed early without meeting its endpoint.",
+      "n": 88
+    }
+  ],
+  "outcomes": [
+    {"source_class": "expression", "ok": true, "rows": 1},
+    {"source_class": "literature", "ok": true, "rows": 1, "cost_usd": 0.005},
+    {"source_class": "trials", "ok": true, "rows": 1, "cost_usd": 0.0012},
+    {
+      "source_class": "population",
+      "ok": false,
+      "reason": "cohort ancestry does not cover the question asked",
+      "route": "a cohort matched to the population in question"
+    },
+    {
+      "source_class": "ip",
+      "ok": false,
+      "reason": "supplier unreachable",
+      "route": "patent prior-art search (synthetic route, no real supplier)"
+    }
+  ],
+  "claims": [
+    "Expression is raised against matched normal tissue [expression:0], and the direction replicates independently [literature:0].",
+    "An earlier interventional study against this target closed without meeting its endpoint [trials:0].",
+    "This is the strongest available target for this indication.",
+    "Population-matched evidence supports the same conclusion [population:4]."
+  ]
+}

--- a/skills/claim-provenance-check/provenance_core.py
+++ b/skills/claim-provenance-check/provenance_core.py
@@ -1,0 +1,247 @@
+"""
+Provenance core: evidence rows, the citation binder, and the coverage report.
+
+Standard library only, no network, no model. That is deliberate: this is the half of a
+report-generation pipeline that must still be trustworthy when the LLM half hallucinates.
+Everything here is deterministic and unit tested (see tests/test_claim_provenance_check.py).
+
+TWO IDEAS, IN THE ORDER THEY RUN.
+
+1. THE CITATION BINDER. Every claim carries tags like [trials:2] that must resolve to a real
+   row that was actually retrieved. A tag pointing at nothing is an invented citation, which
+   is a leading failure mode of LLM-written scientific claims. This check is mechanical, free,
+   and runs before any model call, because a model judge costs money and time and cannot be
+   trusted to catch a thing that plain arithmetic catches perfectly.
+
+2. THE COVERAGE REPORT. A caller declares which evidence classes it tried to reach for a
+   subject. For each class we record whether it was actually reached. A class that could not
+   be reached is never silently dropped: it becomes a gap row carrying the named source that
+   would close it. Publishing the map including its holes is the whole trust mechanism.
+
+Ported from Sippar's production `reportQuality.ts` and the ClawBio + Nebius Berlin hackathon
+demo (`hackathon/clawbio-berlin/provenance/core.py` in Nuru-AI/sippar), trimmed to the citation
+binder and coverage report so this skill does one job. The upstream module also carries a
+"validity envelope" (bounding a model/simulation's trained region) that is a natural follow-on
+skill, not part of this one.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable, Sequence
+
+
+# ---------------------------------------------------------------------------
+# States
+# ---------------------------------------------------------------------------
+
+class ClaimState(str, Enum):
+    """Evidence-strength language, deliberately not verdict language.
+
+    This skill does not rank, score, or decide whether a claim is TRUE. SUPPORTED and
+    CONTESTED describe what the cited evidence does; NO_COVERAGE describes what could not be
+    bound to evidence at all, and always ships with the refusal reason attached.
+    """
+
+    SUPPORTED = "SUPPORTED"
+    CONTESTED = "CONTESTED"
+    NO_COVERAGE = "NO COVERAGE"
+
+
+# ---------------------------------------------------------------------------
+# Evidence
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class EvidenceRow:
+    """One retrieved fact, from one source, that a claim may cite.
+
+    `tag` is what appears inside a claim, e.g. "trials:2". It must be assigned by the
+    retrieval layer, never by the model: a model that can mint its own tags can mint its own
+    evidence.
+    """
+
+    tag: str
+    source_class: str
+    text: str
+    url: str | None = None
+    cohort: str | None = None
+    n: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.tag or ":" not in self.tag:
+            raise ValueError(f"tag must look like 'class:index', got {self.tag!r}")
+
+
+@dataclass(frozen=True)
+class SourceOutcome:
+    """What happened when the caller tried to reach one evidence class.
+
+    A class that returned nothing is recorded with ok=False and a reason, never omitted. When
+    ok is False, `route` names what WOULD answer it, because a gap gets a route rather than a
+    shrug.
+    """
+
+    source_class: str
+    ok: bool
+    rows: int = 0
+    reason: str | None = None
+    route: str | None = None
+    cost_usd: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# The citation binder
+# ---------------------------------------------------------------------------
+
+TAG_RE = re.compile(r"\[([a-z0-9_-]+:\d+)\]", re.IGNORECASE)
+
+#: Shortest run of shared words that counts as copying rather than coincidence. 8 was chosen
+#: empirically upstream: shorter fires constantly on ordinary English, longer lets a whole
+#: lifted clause through.
+VERBATIM_RUN_WORDS = 8
+
+
+def extract_tags(text: str) -> list[str]:
+    """Every citation tag in a claim, in order, lowercased. Duplicates preserved."""
+    return [m.group(1).lower() for m in TAG_RE.finditer(text)]
+
+
+@dataclass
+class BinderIssue:
+    code: str
+    detail: str
+
+
+def _words(text: str) -> list[str]:
+    return re.findall(r"[a-z0-9']+", text.lower())
+
+
+def check_no_verbatim(claim: str, rows: Sequence[EvidenceRow], run: int = VERBATIM_RUN_WORDS) -> list[BinderIssue]:
+    """Flag any run of `run` consecutive words shared between the claim and any source row.
+
+    The claim must be prose ABOUT the source, never a copy of it.
+    """
+    claim_words = _words(claim)
+    if len(claim_words) < run:
+        return []
+    claim_runs = {
+        " ".join(claim_words[i : i + run]) for i in range(len(claim_words) - run + 1)
+    }
+    issues: list[BinderIssue] = []
+    for row in rows:
+        row_words = _words(row.text)
+        if len(row_words) < run:
+            continue
+        for i in range(len(row_words) - run + 1):
+            candidate = " ".join(row_words[i : i + run])
+            if candidate in claim_runs:
+                issues.append(
+                    BinderIssue("verbatim-run", f"{run}+ words copied from [{row.tag}]: {candidate!r}")
+                )
+                break
+    return issues
+
+
+def bind_claim(
+    claim: str,
+    rows: Sequence[EvidenceRow],
+    *,
+    require_citation: bool = True,
+    check_verbatim: bool = True,
+) -> list[BinderIssue]:
+    """Check one claim against the rows that were actually retrieved.
+
+    Returns an empty list when the claim is bindable. Any issue means the claim does not ship:
+    there is no partial credit, because a claim with one invented citation is an invented claim.
+    """
+    issues: list[BinderIssue] = []
+    valid = {r.tag.lower() for r in rows}
+    tags = extract_tags(claim)
+
+    if require_citation and not tags:
+        issues.append(BinderIssue("citation-floor", "claim carries no citation"))
+
+    for tag in tags:
+        if tag not in valid:
+            issues.append(BinderIssue("citation-invalid", f"[{tag}] does not match any retrieved row"))
+
+    if check_verbatim:
+        cited = [r for r in rows if r.tag.lower() in set(tags)] or list(rows)
+        issues.extend(check_no_verbatim(claim, cited))
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# The coverage report
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CoverageReport:
+    subject: str
+    outcomes: list[SourceOutcome]
+
+    @property
+    def reached(self) -> list[str]:
+        return [o.source_class for o in self.outcomes if o.ok]
+
+    @property
+    def gaps(self) -> list[SourceOutcome]:
+        return [o for o in self.outcomes if not o.ok]
+
+    @property
+    def total_cost_usd(self) -> float:
+        return round(sum(o.cost_usd or 0.0 for o in self.outcomes), 6)
+
+    def as_dict(self) -> dict:
+        return {
+            "subject": self.subject,
+            "reached": self.reached,
+            "gaps": [
+                {"class": g.source_class, "reason": g.reason, "route": g.route} for g in self.gaps
+            ],
+            "coverage": f"{len(self.reached)}/{len(self.outcomes)}",
+            "costUsd": self.total_cost_usd,
+        }
+
+    def render(self) -> str:
+        """Plain-text coverage map. This is the headline artifact, holes included."""
+        lines = [f"COVERAGE  {self.subject}  ({len(self.reached)}/{len(self.outcomes)} classes)"]
+        for o in self.outcomes:
+            if o.ok:
+                lines.append(f"  [reached] {o.source_class}  ({o.rows} rows)")
+            else:
+                route = f"  route: {o.route}" if o.route else ""
+                lines.append(f"  [NO COVERAGE] {o.source_class}  {o.reason or ''}{route}")
+        if self.total_cost_usd:
+            lines.append(f"  cost: ${self.total_cost_usd:.4f}")
+        return "\n".join(lines)
+
+
+def state_for_claim(
+    claim: str,
+    rows: Sequence[EvidenceRow],
+    *,
+    disagreeing_tags: Iterable[str] = (),
+) -> tuple[ClaimState, list[BinderIssue]]:
+    """Bind a claim, then state how strong it is.
+
+    A claim that fails the binder is NO_COVERAGE, not a weaker SUPPORTED: an unbindable claim
+    has no evidence behind it, which is a coverage fact rather than a confidence one.
+    """
+    issues = bind_claim(claim, rows)
+    if issues:
+        return ClaimState.NO_COVERAGE, issues
+
+    tags = set(extract_tags(claim))
+    if tags & {t.lower() for t in disagreeing_tags}:
+        return ClaimState.CONTESTED, []
+
+    cited_classes = {t.split(":", 1)[0] for t in tags}
+    if len(cited_classes) >= 2:
+        return ClaimState.SUPPORTED, []
+    # One class is not independent corroboration. Say so rather than implying it is.
+    return ClaimState.CONTESTED, []

--- a/skills/claim-provenance-check/tests/test_claim_provenance_check.py
+++ b/skills/claim-provenance-check/tests/test_claim_provenance_check.py
@@ -1,0 +1,208 @@
+"""
+Tests for the Claim Provenance Check skill.
+
+These pin the REFUSAL behaviour, which is the part that matters: the claim this skill makes is
+not "it produces a report", it is "it declines correctly" on an invented citation, a missing
+citation, or copied text — and that no partial credit is given for a claim that fails any one
+of those checks.
+
+Run:
+    pytest skills/claim-provenance-check/tests/ -v
+or via ClawBio runner:
+    python -m pytest skills/claim-provenance-check/tests/ -v
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the skill importable regardless of working directory.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from claim_provenance_check import run, run_demo  # noqa: E402
+from provenance_core import (  # noqa: E402
+    ClaimState,
+    CoverageReport,
+    EvidenceRow,
+    SourceOutcome,
+    bind_claim,
+    check_no_verbatim,
+    extract_tags,
+    state_for_claim,
+)
+
+ROWS = [
+    EvidenceRow("trials:0", "trials", "A phase II study of the agent was terminated for futility.", n=212),
+    EvidenceRow("literature:0", "literature", "Elevated wall shear stress correlates with remodelling.", n=48),
+    EvidenceRow("ip:0", "ip", "Composition of matter claim granted to a third party in 2019."),
+]
+
+
+@pytest.fixture
+def tmp_output(tmp_path: Path) -> Path:
+    return tmp_path / "output"
+
+
+# ---------------------------------------------------------------------------
+# Tags
+# ---------------------------------------------------------------------------
+
+def test_extract_tags_reads_all_and_lowercases():
+    assert extract_tags("a [Trials:0] b [ip:0]") == ["trials:0", "ip:0"]
+
+
+def test_extract_tags_ignores_non_tags():
+    assert extract_tags("see figure [3] and table [x]") == []
+
+
+# ---------------------------------------------------------------------------
+# The binder
+# ---------------------------------------------------------------------------
+
+def test_valid_claim_binds_clean():
+    assert bind_claim("The trial stopped early [trials:0], and the IP is held elsewhere [ip:0].", ROWS) == []
+
+
+def test_invented_citation_is_caught():
+    issues = bind_claim("Strong signal in cohort [trials:9].", ROWS)
+    assert [i.code for i in issues] == ["citation-invalid"]
+
+
+def test_uncited_claim_is_caught():
+    issues = bind_claim("This target is clearly the best option available.", ROWS)
+    assert any(i.code == "citation-floor" for i in issues)
+
+
+def test_verbatim_copying_is_caught():
+    # Lifts an 8+ word run straight out of trials:0.
+    claim = "Note that a phase II study of the agent was terminated for futility [trials:0]."
+    issues = bind_claim(claim, ROWS)
+    assert any(i.code == "verbatim-run" for i in issues)
+
+
+def test_short_claims_do_not_trip_verbatim():
+    assert check_no_verbatim("Terminated early.", ROWS) == []
+
+
+def test_paraphrase_passes():
+    claim = "Enrolment halted before completion because the endpoint was not being met [trials:0]."
+    assert not any(i.code == "verbatim-run" for i in bind_claim(claim, ROWS))
+
+
+def test_invented_citation_gets_no_partial_credit_alongside_a_valid_one():
+    # One good tag and one bad tag: the whole claim is refused, not half-credited.
+    issues = bind_claim("Confirmed in one study [trials:0] and another [trials:9].", ROWS)
+    assert any(i.code == "citation-invalid" for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# Claim states
+# ---------------------------------------------------------------------------
+
+def test_two_independent_classes_is_supported():
+    state, issues = state_for_claim("Halted early [trials:0], and reported elsewhere [literature:0].", ROWS)
+    assert state is ClaimState.SUPPORTED and issues == []
+
+
+def test_single_class_is_contested_not_supported():
+    # One source is not corroboration, and pretending otherwise is the quiet failure.
+    state, _ = state_for_claim("Halted early [trials:0].", ROWS)
+    assert state is ClaimState.CONTESTED
+
+
+def test_disagreement_is_contested():
+    state, _ = state_for_claim(
+        "Halted early [trials:0], though the literature reports benefit [literature:0].",
+        ROWS,
+        disagreeing_tags=["literature:0"],
+    )
+    assert state is ClaimState.CONTESTED
+
+
+def test_unbindable_claim_is_no_coverage_not_weak_support():
+    state, issues = state_for_claim("A compelling result [trials:9].", ROWS)
+    assert state is ClaimState.NO_COVERAGE and issues
+
+
+# ---------------------------------------------------------------------------
+# Coverage report
+# ---------------------------------------------------------------------------
+
+def test_coverage_keeps_gaps_visible_with_routes():
+    report = CoverageReport(
+        "VOL04 synthetic subject",
+        [
+            SourceOutcome("hemodynamics", True, rows=1),
+            SourceOutcome("trials", True, rows=6, cost_usd=0.0012),
+            SourceOutcome(
+                "device_recalls", False,
+                reason="supplier unreachable",
+                route="openFDA device recalls, $0.09",
+            ),
+        ],
+    )
+    assert report.reached == ["hemodynamics", "trials"]
+    assert len(report.gaps) == 1
+    rendered = report.render()
+    assert "NO COVERAGE" in rendered and "openFDA device recalls" in rendered
+    assert report.as_dict()["coverage"] == "2/3"
+
+
+def test_cost_is_summed_across_reached_classes():
+    report = CoverageReport("x", [
+        SourceOutcome("a", True, cost_usd=0.005),
+        SourceOutcome("b", True, cost_usd=0.0012),
+    ])
+    assert report.total_cost_usd == 0.0062
+
+
+# ---------------------------------------------------------------------------
+# CLI / end-to-end
+# ---------------------------------------------------------------------------
+
+def test_demo_runs(tmp_output: Path) -> None:
+    run_demo(tmp_output)
+
+
+def test_demo_report_generated(tmp_output: Path) -> None:
+    run_demo(tmp_output)
+    report = tmp_output / "report.md"
+    assert report.exists(), "report.md was not created"
+    assert report.stat().st_size > 0, "report.md is empty"
+    text = report.read_text()
+    assert "ClawBio is a research and educational tool" in text
+    assert "NO COVERAGE" in text  # the bundled demo case includes a NO COVERAGE claim
+
+
+def test_demo_result_json_valid(tmp_output: Path) -> None:
+    run_demo(tmp_output)
+    result_file = tmp_output / "result.json"
+    assert result_file.exists(), "result.json was not created"
+    data = json.loads(result_file.read_text())
+    assert data.get("skill") == "claim-provenance-check"
+    assert "coverage" in data and "claims" in data
+
+
+def test_demo_invented_citation_claim_is_refused(tmp_output: Path) -> None:
+    results = run_demo(tmp_output)
+    invented = next(c for c in results["claims"] if "population:4" in c["claim"])
+    assert invented["state"] == "NO COVERAGE"
+    assert any(i["code"] == "citation-invalid" for i in invented["issues"])
+
+
+def test_demo_uncited_claim_is_refused(tmp_output: Path) -> None:
+    results = run_demo(tmp_output)
+    uncited = next(c for c in results["claims"] if c["claim"].startswith("This is the strongest"))
+    assert uncited["state"] == "NO COVERAGE"
+    assert any(i["code"] == "citation-floor" for i in uncited["issues"])
+
+
+def test_run_rejects_case_missing_required_keys(tmp_path: Path, tmp_output: Path) -> None:
+    bad_case = tmp_path / "bad_case.json"
+    bad_case.write_text(json.dumps({"subject": "x", "rows": [], "outcomes": []}))
+    with pytest.raises(ValueError, match="claims"):
+        run(bad_case, tmp_output)


### PR DESCRIPTION
## What

A citation-binder + coverage-report skill: given a case file of retrieved evidence rows, per-class
source outcomes, and drafted claims, it binds every `[class:index]` citation tag in a claim to a
retrieved row and reports which evidence classes a subject actually reached vs `NO COVERAGE`.

No partial credit — a claim with an invented citation, a missing citation, or an 8+ word verbatim
run copied from a cited row is refused in full, not scored down.

Standard-library-only Python (`re`, `dataclasses`, `enum`, `typing`), zero network calls, zero
model calls.

## Why

An LLM-drafted claim carrying a plausible-looking citation like `[trials:2]` reads as evidence to
anyone who doesn't re-run the retrieval themselves. This is a mechanical, free, deterministic gate
that runs before any model judge and catches exactly that failure mode — an invented citation —
which arithmetic catches perfectly and a paid judge cannot be trusted to catch reliably.

## Provenance

Ported from a citation-binder/coverage-report engine built for the ClawBio + Nebius Berlin
hackathon (2026-08-18), itself adapted from Sippar's production `reportQuality.ts`
(sippar.network). The core logic (`provenance_core.py`) is unchanged in behaviour from the
hackathon source; this PR is the from-scratch ClawBio-shaped packaging of it (`SKILL.md`, CLI
wrapper, synthetic demo data, tests).

## Checklist (CONTRIBUTING.md / CLAUDE.md 17-check conformance)

- [x] `SKILL.md` follows `templates/SKILL-TEMPLATE.md`: Trigger (fire / do-not-fire), Scope,
      Workflow (numbered steps), Example Output (real rendered sample), Gotchas (5 entries),
      Safety (references the ClawBio disclaimer), Agent Boundary, plus Domain Decisions grounded
      in what the code actually hardcodes (the 8-word verbatim threshold, the 2-class SUPPORTED
      floor, no-partial-credit).
- [x] `uv run agentskills validate skills/claim-provenance-check/` → `Valid skill`
- [x] Synthetic demo data only (`demo_input.txt`) — no real patient/trial data, clearly labelled
      synthetic in the file itself.
- [x] `python skills/claim-provenance-check/claim_provenance_check.py --demo --output <dir>` runs
      clean and writes `report.md` (with the safety disclaimer) + `result.json`.
- [x] 21 tests in `tests/test_claim_provenance_check.py`, all passing — pins the refusal behaviour
      (invented citation, missing citation, verbatim copying, no-partial-credit, NO COVERAGE vs
      CONTESTED vs SUPPORTED) plus CLI/end-to-end checks. `pytest skills/claim-provenance-check/tests/ -v`
- [x] Registered as `provcheck` in `clawbio.py` / `skills/catalog.json` via
      `python scripts/generate_catalog.py` (clean diff, no unrelated churn); confirmed with
      `python clawbio.py list` and `python clawbio.py run provcheck --demo`.

## Test plan

```bash
uv run agentskills validate skills/claim-provenance-check/
uv run pytest skills/claim-provenance-check/tests/ -v
python skills/claim-provenance-check/claim_provenance_check.py --demo --output /tmp/demo
python clawbio.py run provcheck --demo
```