### PR TITLE
docs: point audit.py at relocated GenAI semconv repo

### DIFF
--- a/clawbio/common/audit.py
+++ b/clawbio/common/audit.py
@@ -1,8 +1,8 @@
 """Central audit log for ClawBio.
 
-Aligns with OpenTelemetry GenAI semantic conventions:
-  https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/
-  opentelemetry-semantic-conventions 0.62b1
+Aligns with OpenTelemetry GenAI semantic conventions (pre-stable):
+  https://github.com/open-telemetry/semantic-conventions-genai
+Re-verify the gen_ai.* attribute names once that repo tags a release.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- Updates the `clawbio/common/audit.py` module docstring to reference the new canonical home of the OpenTelemetry GenAI semantic conventions (`open-telemetry/semantic-conventions-genai`), which they moved to from the main semantic-conventions repo in v1.42.0 (June 2026)
- Notes the conventions are pre-stable and that the hardcoded `gen_ai.*` attribute names should be re-verified once the new repo tags its first release
- No code or behaviour changes — attribute names emitted are unchanged (verified identical between opentelemetry-semantic-conventions 0.62b1 and 0.65b0)

## Skill affected

None — shared infrastructure (`clawbio/common/audit.py`), used by all skills for audit logging.

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology) — N/A, no skill touched
- [x] Tests included and passing (`pytest -v`)
- [x] Demo data included for reviewers to test — N/A, docstring-only change
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

```
$ python -m pytest clawbio/common/tests/test_audit.py -q
14 passed in 0.25s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)