### PR TITLE
refactor: delegate sha256 helpers to clawbio.common.checksums

### DIFF
--- a/skills/clinical-trial-finder/tests/test_sha256_delegation.py
+++ b/skills/clinical-trial-finder/tests/test_sha256_delegation.py
@@ -1,0 +1,17 @@
+"""Checksum helper must delegate to the shared clawbio.common layer."""
+
+import sys
+from pathlib import Path
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+PROJECT_ROOT = SKILL_DIR.parents[1]
+for p in (SKILL_DIR, PROJECT_ROOT):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import writers  # noqa: E402
+from clawbio.common.checksums import sha256_file  # noqa: E402
+
+
+def test_sha256_delegates_to_common_layer():
+    assert writers._sha256 is sha256_file

--- a/skills/clinical-trial-finder/writers.py
+++ b/skills/clinical-trial-finder/writers.py
@@ -7,14 +7,19 @@ an output directory, creates the file, and returns its Path.
 
 import argparse
 import csv
-import hashlib
 import html as _html
 import json
+import sys
 from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 
-from constants import (
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from clawbio.common.checksums import sha256_file as _sha256  # noqa: E402
+from constants import (  # noqa: E402
     CSV_COLUMNS,
     DEFAULT_PAGE_SIZE,
     DISCLAIMER,
@@ -37,16 +42,6 @@ from constants import (
 def count_recruiting(trials: list[dict]) -> int:
     """Count trials with RECRUITING status."""
     return sum(1 for t in trials if t["status"] == "RECRUITING")
-
-
-def _sha256(path: Path) -> str:
-    """Return hex SHA-256 digest of a file.  Reads in 8KB chunks to handle
-    large files without loading everything into memory."""
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(8192), b""):
-            h.update(chunk)
-    return h.hexdigest()
 
 
 # ---------------------------------------------------------------------------

--- a/skills/methylation-clock/methylation_clock.py
+++ b/skills/methylation-clock/methylation_clock.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import sys
 from datetime import datetime, timezone
@@ -18,6 +17,7 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
+from clawbio.common.checksums import sha256_file as _sha256  # noqa: E402
 from clawbio.common.reproducibility import (  # noqa: E402
     ReproCommand,
     ReproPath,
@@ -53,14 +53,6 @@ def parse_metadata_cols(metadata_cols: str | None) -> list[str]:
     if not metadata_cols:
         return ["gender", "tissue_type", "dataset"]
     return [item.strip() for item in metadata_cols.split(",") if item.strip()]
-
-
-def _sha256(path: Path) -> str:
-    h = hashlib.sha256()
-    with open(path, "rb") as f:
-        for chunk in iter(lambda: f.read(8192), b""):
-            h.update(chunk)
-    return h.hexdigest()
 
 
 def _load_dataframe(path: Path) -> pd.DataFrame:

--- a/skills/methylation-clock/tests/test_sha256_delegation.py
+++ b/skills/methylation-clock/tests/test_sha256_delegation.py
@@ -1,0 +1,25 @@
+"""Checksum helper must delegate to the shared clawbio.common layer.
+
+Kept separate from test_methylation_clock.py so it runs even where pyaging
+(a heavy optional dependency) cannot be imported: pyaging is stubbed out
+before importing the module, since checksum behaviour does not depend on it.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+PROJECT_ROOT = SKILL_DIR.parents[1]
+for p in (SKILL_DIR, PROJECT_ROOT):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+sys.modules.setdefault("pyaging", MagicMock())
+
+import methylation_clock  # noqa: E402
+from clawbio.common.checksums import sha256_file  # noqa: E402
+
+
+def test_sha256_delegates_to_common_layer():
+    assert methylation_clock._sha256 is sha256_file


### PR DESCRIPTION
## Summary

- Removes two private copies of the SHA-256 file-hashing loop that already lives in `clawbio.common.checksums.sha256_file`: `methylation_clock.py` and clinical-trial-finder's `writers.py` now import the shared function
- `writers.py` gains the standard project-root `sys.path` shim; `methylation_clock.py` already had one for its `common.reproducibility` imports and just adds the checksum import to it
- No behaviour change — identical digests, identical chunk size; bundle layouts untouched

## Skill affected

methylation-clock, clinical-trial-finder

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology) — unchanged, no methodology change
- [x] Tests included and passing (`pytest -v`)
- [x] Demo data included for reviewers to test — existing skill demo data unchanged
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

Red/green TDD: one delegation test per skill (asserting the module helper `is` the shared function), both watched failing against the old local helpers, then passing after the swap. The methylation-clock test stubs `pyaging` so it runs even where that optional heavy dependency cannot be imported.

```
$ python -m pytest skills/methylation-clock/tests skills/clinical-trial-finder/tests -q
165 passed, 1 skipped, 1 warning in 8.04s
```

(The 1 skip is `test_methylation_clock.py`'s pre-existing module-level `pytest.importorskip("pyaging")` on machines where pyaging is unavailable.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)