### PR TITLE
feat: equity-scorer writes reproducibility bundle via clawbio.common

### DIFF
--- a/skills/equity-scorer/SKILL.md
+++ b/skills/equity-scorer/SKILL.md
@@ -127,8 +127,15 @@ equity_report/
 └── reproducibility/
     ├── commands.sh          # Commands to re-run
     ├── environment.yml      # Conda export
-    └── checksums.sha256     # Input file checksums
+    └── checksums.sha256     # Output artefact checksums (tables/ + figures/)
 ```
+
+Verify with `cd <output_dir> && sha256sum -c reproducibility/checksums.sha256`.
+The manifest names the run's derived tables and figures only: `report.md` and
+`result.json` embed wall-clock timestamps and would never re-verify, so they
+are deliberately outside the envelope (every number in `result.json` is still
+covered via the byte-identical `tables/heim_score.json`). Input files are not
+listed — input provenance is recorded as `input_checksum` in `result.json`.
 
 ## Example Report Output
 

--- a/skills/equity-scorer/equity_scorer.py
+++ b/skills/equity-scorer/equity_scorer.py
@@ -39,9 +39,11 @@ from clawbio.common.parsers import parse_vcf_matrix
 from clawbio.common.checksums import sha256_file as _sha256_file
 from clawbio.common.report import write_result_json, DISCLAIMER as _DISCLAIMER
 from clawbio.common.reproducibility import (
+    ReproCommand,
+    ReproPath,
     write_checksums,
-    write_commands_sh,
     write_environment_yml,
+    write_portable_commands_sh,
 )
 
 # ---------------------------------------------------------------------------
@@ -78,6 +80,22 @@ POP_COLOURS = {
 # REPRODUCIBILITY BUNDLE (delegates to shared library)
 # ===================================================================
 
+def _repro_path(value: Path, *, output_dir: Path) -> ReproPath:
+    """Classify a path for portable reproducibility command rendering."""
+    value = value.resolve()
+    try:
+        value.relative_to(_PROJECT_ROOT)
+        return ReproPath(value, anchor="repo_root")
+    except ValueError:
+        pass
+
+    try:
+        value.relative_to(output_dir.resolve())
+        return ReproPath(value, anchor="output_dir")
+    except ValueError:
+        return ReproPath(value, anchor="auto")
+
+
 def _write_repro_bundle(
     output_dir: Path,
     input_path: Path,
@@ -86,27 +104,52 @@ def _write_repro_bundle(
 ) -> None:
     """Write commands.sh, environment.yml, and checksums.sha256 to
     <output_dir>/reproducibility/ via clawbio.common.reproducibility."""
-    cmd = "python skills/equity-scorer/equity_scorer.py --input %s" % input_path
+    args: list = ["--input", _repro_path(input_path, output_dir=output_dir)]
     if pop_map_path is not None:
-        cmd += " --pop-map %s" % pop_map_path
-    cmd += " --output %s --weights %s" % (
+        args += ["--pop-map", _repro_path(pop_map_path, output_dir=output_dir)]
+    args += [
+        "--output", ReproPath(output_dir, anchor="output_dir"),
+        # str() round-trips floats exactly; rounding here would record a
+        # different command than the one that ran.
+        "--weights", ",".join(str(w) for w in weights),
+    ]
+    write_portable_commands_sh(
         output_dir,
-        ",".join("%.2f" % w for w in weights),
+        ReproCommand(
+            script_path=Path("skills/equity-scorer/equity_scorer.py"),
+            args=args,
+            comment="Replay this ClawBio equity-scorer run",
+        ),
+        repo_root=_PROJECT_ROOT,
     )
-    write_commands_sh(output_dir, cmd)
 
+    # Version bounds mirror SKILL.md "Dependencies". pip_deps stays empty:
+    # the script imports clawbio.common via its own sys.path insert, so the
+    # environment needs no installed clawbio package.
     write_environment_yml(
         output_dir,
         env_name="clawbio-equity-scorer",
-        conda_deps=["numpy", "pandas", "matplotlib", "scikit-learn"],
+        conda_deps=[
+            "numpy>=1.24",
+            "pandas>=2.0",
+            "matplotlib>=3.7",
+            "scikit-learn>=1.3",
+        ],
         pip_deps=[],
+        python_version="3.11",
     )
 
-    checksum_targets = [input_path]
-    if pop_map_path is not None:
-        checksum_targets.append(pop_map_path)
-    checksum_targets += [output_dir / "report.md", output_dir / "result.json"]
-    write_checksums(checksum_targets, output_dir)
+    # Checksum the derived numerical/graphical artefacts only, labelled
+    # relative to output_dir so `cd <output_dir> && sha256sum -c` works.
+    # report.md and result.json embed wall-clock timestamps and would never
+    # re-verify; inputs live outside output_dir and are excluded (result.json
+    # already records the input digest as input_checksum).
+    checksum_targets: list = []
+    for sub in ("tables", "figures"):
+        subdir = output_dir / sub
+        if subdir.is_dir():
+            checksum_targets.extend(p for p in sorted(subdir.iterdir()) if p.is_file())
+    write_checksums(checksum_targets, output_dir, anchor=output_dir)
 
 
 # ===================================================================

--- a/skills/equity-scorer/equity_scorer.py
+++ b/skills/equity-scorer/equity_scorer.py
@@ -38,6 +38,11 @@ if str(_PROJECT_ROOT) not in sys.path:
 from clawbio.common.parsers import parse_vcf_matrix
 from clawbio.common.checksums import sha256_file as _sha256_file
 from clawbio.common.report import write_result_json, DISCLAIMER as _DISCLAIMER
+from clawbio.common.reproducibility import (
+    write_checksums,
+    write_commands_sh,
+    write_environment_yml,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -67,6 +72,41 @@ POP_COLOURS = {
     "MID": "#CC79A7",
     "UNKNOWN": "#999999",
 }
+
+
+# ===================================================================
+# REPRODUCIBILITY BUNDLE (delegates to shared library)
+# ===================================================================
+
+def _write_repro_bundle(
+    output_dir: Path,
+    input_path: Path,
+    pop_map_path: Optional[Path],
+    weights: Tuple[float, ...],
+) -> None:
+    """Write commands.sh, environment.yml, and checksums.sha256 to
+    <output_dir>/reproducibility/ via clawbio.common.reproducibility."""
+    cmd = "python skills/equity-scorer/equity_scorer.py --input %s" % input_path
+    if pop_map_path is not None:
+        cmd += " --pop-map %s" % pop_map_path
+    cmd += " --output %s --weights %s" % (
+        output_dir,
+        ",".join("%.2f" % w for w in weights),
+    )
+    write_commands_sh(output_dir, cmd)
+
+    write_environment_yml(
+        output_dir,
+        env_name="clawbio-equity-scorer",
+        conda_deps=["numpy", "pandas", "matplotlib", "scikit-learn"],
+        pip_deps=[],
+    )
+
+    checksum_targets = [input_path]
+    if pop_map_path is not None:
+        checksum_targets.append(pop_map_path)
+    checksum_targets += [output_dir / "report.md", output_dir / "result.json"]
+    write_checksums(checksum_targets, output_dir)
 
 
 # ===================================================================
@@ -1005,6 +1045,8 @@ def run_vcf_pipeline(
         input_checksum=sha256_file(str(vcf_path)) if vcf_path.exists() else "",
     )
 
+    _write_repro_bundle(output_dir, vcf_path, pop_map_path, weights)
+
     print("\nDone.")
     print("  HEIM Score: %s/100 (%s)" % (heim_result["heim_score"], heim_result["rating"]))
     print("  Report: %s" % report_path)
@@ -1086,6 +1128,8 @@ def run_csv_pipeline(
         data=heim_result,
         input_checksum=sha256_file(str(csv_path)) if csv_path.exists() else "",
     )
+
+    _write_repro_bundle(output_dir, csv_path, None, weights)
 
     print("HEIM Score: %s/100 (%s)" % (heim_result["heim_score"], heim_result["rating"]))
     print("Report: %s" % report_path)

--- a/skills/equity-scorer/equity_scorer.py
+++ b/skills/equity-scorer/equity_scorer.py
@@ -80,8 +80,20 @@ POP_COLOURS = {
 # REPRODUCIBILITY BUNDLE (delegates to shared library)
 # ===================================================================
 
-def _repro_path(value: Path, *, output_dir: Path) -> ReproPath:
-    """Classify a path for portable reproducibility command rendering."""
+def _repro_input_arg(
+    value: Path,
+    *,
+    output_dir: Path,
+    var_name: str,
+    preflight: list,
+):
+    """Classify an input path for portable reproducibility command rendering.
+
+    Inputs outside the repo must not be recorded as absolute paths: a
+    deposited bundle would disclose the local filesystem location of a
+    cohort file. They are rendered as "$<var_name>/<basename>" with a
+    preflight line requiring the variable at replay time.
+    """
     value = value.resolve()
     try:
         value.relative_to(_PROJECT_ROOT)
@@ -93,7 +105,11 @@ def _repro_path(value: Path, *, output_dir: Path) -> ReproPath:
         value.relative_to(output_dir.resolve())
         return ReproPath(value, anchor="output_dir")
     except ValueError:
-        return ReproPath(value, anchor="auto")
+        preflight.append(
+            ': "${%s:?Set %s to the directory containing %s}"'
+            % (var_name, var_name, value.name)
+        )
+        return '"$%s/%s"' % (var_name, value.name)
 
 
 def _write_repro_bundle(
@@ -101,12 +117,26 @@ def _write_repro_bundle(
     input_path: Path,
     pop_map_path: Optional[Path],
     weights: Tuple[float, ...],
+    checksum_paths: List[Path],
 ) -> None:
     """Write commands.sh, environment.yml, and checksums.sha256 to
     <output_dir>/reproducibility/ via clawbio.common.reproducibility."""
-    args: list = ["--input", _repro_path(input_path, output_dir=output_dir)]
+    preflight: list = []
+    args: list = [
+        "--input",
+        _repro_input_arg(
+            input_path, output_dir=output_dir, var_name="INPUT_DIR",
+            preflight=preflight,
+        ),
+    ]
     if pop_map_path is not None:
-        args += ["--pop-map", _repro_path(pop_map_path, output_dir=output_dir)]
+        args += [
+            "--pop-map",
+            _repro_input_arg(
+                pop_map_path, output_dir=output_dir, var_name="POP_MAP_DIR",
+                preflight=preflight,
+            ),
+        ]
     args += [
         "--output", ReproPath(output_dir, anchor="output_dir"),
         # str() round-trips floats exactly; rounding here would record a
@@ -119,6 +149,7 @@ def _write_repro_bundle(
             script_path=Path("skills/equity-scorer/equity_scorer.py"),
             args=args,
             comment="Replay this ClawBio equity-scorer run",
+            preflight=preflight,
         ),
         repo_root=_PROJECT_ROOT,
     )
@@ -130,6 +161,7 @@ def _write_repro_bundle(
         output_dir,
         env_name="clawbio-equity-scorer",
         conda_deps=[
+            "biopython>=1.82",
             "numpy>=1.24",
             "pandas>=2.0",
             "matplotlib>=3.7",
@@ -143,13 +175,12 @@ def _write_repro_bundle(
     # relative to output_dir so `cd <output_dir> && sha256sum -c` works.
     # report.md and result.json embed wall-clock timestamps and would never
     # re-verify; inputs live outside output_dir and are excluded (result.json
-    # already records the input digest as input_checksum).
-    checksum_targets: list = []
-    for sub in ("tables", "figures"):
-        subdir = output_dir / sub
-        if subdir.is_dir():
-            checksum_targets.extend(p for p in sorted(subdir.iterdir()) if p.is_file())
-    write_checksums(checksum_targets, output_dir, anchor=output_dir)
+    # already records the input digest as input_checksum). The caller names
+    # this run's outputs explicitly — globbing tables/ and figures/ would
+    # certify stale artefacts left behind by a previous run into the same
+    # directory. Figures skipped at runtime (no matplotlib) are skipped by
+    # write_checksums too.
+    write_checksums(checksum_paths, output_dir, anchor=output_dir)
 
 
 # ===================================================================
@@ -1088,7 +1119,20 @@ def run_vcf_pipeline(
         input_checksum=sha256_file(str(vcf_path)) if vcf_path.exists() else "",
     )
 
-    _write_repro_bundle(output_dir, vcf_path, pop_map_path, weights)
+    _write_repro_bundle(
+        output_dir, vcf_path, pop_map_path, weights,
+        checksum_paths=[
+            tables_dir / "population_summary.csv",
+            tables_dir / "fst_matrix.csv",
+            tables_dir / "heterozygosity.csv",
+            tables_dir / "heim_score.json",
+            figures_dir / "heim_gauge.png",
+            figures_dir / "ancestry_bar.png",
+            figures_dir / "heterozygosity.png",
+            figures_dir / "fst_heatmap.png",
+            figures_dir / "pca_plot.png",
+        ],
+    )
 
     print("\nDone.")
     print("  HEIM Score: %s/100 (%s)" % (heim_result["heim_score"], heim_result["rating"]))
@@ -1172,7 +1216,15 @@ def run_csv_pipeline(
         input_checksum=sha256_file(str(csv_path)) if csv_path.exists() else "",
     )
 
-    _write_repro_bundle(output_dir, csv_path, None, weights)
+    _write_repro_bundle(
+        output_dir, csv_path, None, weights,
+        checksum_paths=[
+            tables_dir / "population_summary.csv",
+            tables_dir / "heim_score.json",
+            figures_dir / "heim_gauge.png",
+            figures_dir / "ancestry_bar.png",
+        ],
+    )
 
     print("HEIM Score: %s/100 (%s)" % (heim_result["heim_score"], heim_result["rating"]))
     print("Report: %s" % report_path)

--- a/skills/equity-scorer/tests/test_repro_bundle.py
+++ b/skills/equity-scorer/tests/test_repro_bundle.py
@@ -4,6 +4,10 @@ test_repro_bundle.py — Reproducibility bundle tests for Equity Scorer.
 Both pipelines (VCF and ancestry CSV) must write a reproducibility bundle
 via the shared clawbio.common layer into <output_dir>/reproducibility/:
 commands.sh, environment.yml, and checksums.sha256.
+
+The bundle must honour the contract in docs/reproducibility.md:
+`cd <output_dir> && sha256sum -c reproducibility/checksums.sha256` passes,
+and a byte-identical replay produces an identical checksums.sha256.
 """
 
 import sys
@@ -23,10 +27,15 @@ DEMO_MAP = PROJ / "examples" / "demo_population_map.csv"
 DEMO_CSV = PROJ / "examples" / "sample_ancestry.csv"
 
 
-def run_vcf(tmp_path):
+def run_vcf(tmp_path, weights=DEFAULT_WEIGHTS):
     out = tmp_path / "out"
-    run_vcf_pipeline(DEMO_VCF, DEMO_MAP, out, DEFAULT_WEIGHTS)
+    run_vcf_pipeline(DEMO_VCF, DEMO_MAP, out, weights)
     return out
+
+
+def read_checksums(out):
+    lines = (out / "reproducibility" / "checksums.sha256").read_text().strip().splitlines()
+    return dict(reversed(line.split("  ", 1)) for line in lines)
 
 
 def test_vcf_pipeline_writes_bundle(tmp_path):
@@ -37,32 +46,79 @@ def test_vcf_pipeline_writes_bundle(tmp_path):
     assert (repro / "checksums.sha256").exists()
 
 
-def test_commands_sh_reproduces_invocation(tmp_path):
-    out = run_vcf(tmp_path)
+def test_commands_sh_is_portable_and_faithful(tmp_path):
+    out = run_vcf(tmp_path, weights=(0.001, 0.001, 0.001, 0.997))
     content = (out / "reproducibility" / "commands.sh").read_text()
     assert content.startswith("#!/usr/bin/env bash")
-    assert "equity_scorer.py" in content
-    assert str(DEMO_VCF) in content
-    assert str(DEMO_MAP) in content
+    # Script and repo-resident inputs are anchored to $CLAWBIO_ROOT, quoted.
+    assert '"$CLAWBIO_ROOT/skills/equity-scorer/equity_scorer.py"' in content
+    assert '"$CLAWBIO_ROOT/examples/demo_populations.vcf"' in content
+    assert '"$CLAWBIO_ROOT/examples/demo_population_map.csv"' in content
+    # Output is anchored to the bundle's own location, not a machine path.
+    assert '"$OUTPUT_DIR"' in content
+    assert str(out) not in content
+    # Weights are recorded at full precision, not rounded to 2 decimals.
     assert "--weights" in content
+    assert "0.001,0.001,0.001,0.997" in content
+    assert "0.00," not in content
 
 
-def test_environment_yml_names_skill_env(tmp_path):
+def test_environment_yml_pins_skill_versions(tmp_path):
     out = run_vcf(tmp_path)
     content = (out / "reproducibility" / "environment.yml").read_text()
     assert "name: clawbio-equity-scorer" in content
-    assert "numpy" in content
-    assert "scikit-learn" in content
+    # Version bounds from SKILL.md "Dependencies"
+    assert "pandas>=2.0" in content
+    assert "numpy>=1.24" in content
+    assert "scikit-learn>=1.3" in content
+    assert "matplotlib>=3.7" in content
+    assert "python=3.11" in content
 
 
-def test_checksums_match_common_sha256(tmp_path):
+def test_checksums_verify_from_output_dir(tmp_path):
+    """Every entry must resolve relative to output_dir and match the file's
+    digest — the docs/reproducibility.md `sha256sum -c` contract."""
     out = run_vcf(tmp_path)
-    lines = (out / "reproducibility" / "checksums.sha256").read_text().strip().splitlines()
-    entries = dict(reversed(line.split("  ", 1)) for line in lines)
-    assert entries[DEMO_VCF.name] == sha256_file(DEMO_VCF)
-    assert entries[DEMO_MAP.name] == sha256_file(DEMO_MAP)
-    assert entries["report.md"] == sha256_file(out / "report.md")
-    assert "result.json" in entries
+    entries = read_checksums(out)
+    assert entries, "checksums.sha256 is empty"
+    for label, digest in entries.items():
+        target = out / label
+        assert not Path(label).is_absolute(), "absolute path in manifest: %s" % label
+        assert target.is_file(), "manifest entry does not resolve from output_dir: %s" % label
+        assert digest == sha256_file(target), "digest mismatch for %s" % label
+
+
+def test_checksums_cover_derived_artefacts(tmp_path):
+    out = run_vcf(tmp_path)
+    entries = read_checksums(out)
+    for rel in (
+        "tables/population_summary.csv",
+        "tables/fst_matrix.csv",
+        "tables/heterozygosity.csv",
+        "tables/heim_score.json",
+        "figures/heim_gauge.png",
+        "figures/ancestry_bar.png",
+        "figures/heterozygosity.png",
+        "figures/fst_heatmap.png",
+        "figures/pca_plot.png",
+    ):
+        assert rel in entries, "missing from manifest: %s" % rel
+    # Out-of-tree inputs and wall-clock-stamped outputs must not be listed:
+    # they either never resolve from output_dir or never re-verify.
+    assert DEMO_VCF.name not in entries
+    assert DEMO_MAP.name not in entries
+    assert "report.md" not in entries
+    assert "result.json" not in entries
+
+
+def test_checksums_reproduce_on_replay(tmp_path):
+    """A byte-identical replay must produce a byte-identical manifest."""
+    first = run_vcf(tmp_path / "a")
+    second = run_vcf(tmp_path / "b")
+    assert (
+        (first / "reproducibility" / "checksums.sha256").read_text()
+        == (second / "reproducibility" / "checksums.sha256").read_text()
+    )
 
 
 def test_csv_pipeline_writes_bundle(tmp_path):
@@ -72,8 +128,10 @@ def test_csv_pipeline_writes_bundle(tmp_path):
     assert (repro / "commands.sh").exists()
     assert (repro / "environment.yml").exists()
     content = (repro / "commands.sh").read_text()
-    assert str(DEMO_CSV) in content
+    assert '"$CLAWBIO_ROOT/examples/sample_ancestry.csv"' in content
     assert "--pop-map" not in content
-    lines = (repro / "checksums.sha256").read_text().strip().splitlines()
-    entries = dict(reversed(line.split("  ", 1)) for line in lines)
-    assert entries[DEMO_CSV.name] == sha256_file(DEMO_CSV)
+    entries = read_checksums(out)
+    assert "tables/population_summary.csv" in entries
+    assert "tables/heim_score.json" in entries
+    for label, digest in entries.items():
+        assert digest == sha256_file(out / label)

--- a/skills/equity-scorer/tests/test_repro_bundle.py
+++ b/skills/equity-scorer/tests/test_repro_bundle.py
@@ -1,0 +1,79 @@
+"""
+test_repro_bundle.py — Reproducibility bundle tests for Equity Scorer.
+
+Both pipelines (VCF and ancestry CSV) must write a reproducibility bundle
+via the shared clawbio.common layer into <output_dir>/reproducibility/:
+commands.sh, environment.yml, and checksums.sha256.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from equity_scorer import DEFAULT_WEIGHTS, run_csv_pipeline, run_vcf_pipeline
+from clawbio.common.checksums import sha256_file
+
+PROJ = Path(__file__).resolve().parents[3]
+DEMO_VCF = PROJ / "examples" / "demo_populations.vcf"
+DEMO_MAP = PROJ / "examples" / "demo_population_map.csv"
+DEMO_CSV = PROJ / "examples" / "sample_ancestry.csv"
+
+
+def run_vcf(tmp_path):
+    out = tmp_path / "out"
+    run_vcf_pipeline(DEMO_VCF, DEMO_MAP, out, DEFAULT_WEIGHTS)
+    return out
+
+
+def test_vcf_pipeline_writes_bundle(tmp_path):
+    out = run_vcf(tmp_path)
+    repro = out / "reproducibility"
+    assert (repro / "commands.sh").exists()
+    assert (repro / "environment.yml").exists()
+    assert (repro / "checksums.sha256").exists()
+
+
+def test_commands_sh_reproduces_invocation(tmp_path):
+    out = run_vcf(tmp_path)
+    content = (out / "reproducibility" / "commands.sh").read_text()
+    assert content.startswith("#!/usr/bin/env bash")
+    assert "equity_scorer.py" in content
+    assert str(DEMO_VCF) in content
+    assert str(DEMO_MAP) in content
+    assert "--weights" in content
+
+
+def test_environment_yml_names_skill_env(tmp_path):
+    out = run_vcf(tmp_path)
+    content = (out / "reproducibility" / "environment.yml").read_text()
+    assert "name: clawbio-equity-scorer" in content
+    assert "numpy" in content
+    assert "scikit-learn" in content
+
+
+def test_checksums_match_common_sha256(tmp_path):
+    out = run_vcf(tmp_path)
+    lines = (out / "reproducibility" / "checksums.sha256").read_text().strip().splitlines()
+    entries = dict(reversed(line.split("  ", 1)) for line in lines)
+    assert entries[DEMO_VCF.name] == sha256_file(DEMO_VCF)
+    assert entries[DEMO_MAP.name] == sha256_file(DEMO_MAP)
+    assert entries["report.md"] == sha256_file(out / "report.md")
+    assert "result.json" in entries
+
+
+def test_csv_pipeline_writes_bundle(tmp_path):
+    out = tmp_path / "out"
+    run_csv_pipeline(DEMO_CSV, out, DEFAULT_WEIGHTS)
+    repro = out / "reproducibility"
+    assert (repro / "commands.sh").exists()
+    assert (repro / "environment.yml").exists()
+    content = (repro / "commands.sh").read_text()
+    assert str(DEMO_CSV) in content
+    assert "--pop-map" not in content
+    lines = (repro / "checksums.sha256").read_text().strip().splitlines()
+    entries = dict(reversed(line.split("  ", 1)) for line in lines)
+    assert entries[DEMO_CSV.name] == sha256_file(DEMO_CSV)

--- a/skills/equity-scorer/tests/test_repro_bundle.py
+++ b/skills/equity-scorer/tests/test_repro_bundle.py
@@ -68,6 +68,7 @@ def test_environment_yml_pins_skill_versions(tmp_path):
     content = (out / "reproducibility" / "environment.yml").read_text()
     assert "name: clawbio-equity-scorer" in content
     # Version bounds from SKILL.md "Dependencies"
+    assert "biopython>=1.82" in content
     assert "pandas>=2.0" in content
     assert "numpy>=1.24" in content
     assert "scikit-learn>=1.3" in content
@@ -88,27 +89,49 @@ def test_checksums_verify_from_output_dir(tmp_path):
         assert digest == sha256_file(target), "digest mismatch for %s" % label
 
 
+VCF_MANIFEST = {
+    "tables/population_summary.csv",
+    "tables/fst_matrix.csv",
+    "tables/heterozygosity.csv",
+    "tables/heim_score.json",
+    "figures/heim_gauge.png",
+    "figures/ancestry_bar.png",
+    "figures/heterozygosity.png",
+    "figures/fst_heatmap.png",
+    "figures/pca_plot.png",
+}
+
+CSV_MANIFEST = {
+    "tables/population_summary.csv",
+    "tables/heim_score.json",
+    "figures/heim_gauge.png",
+    "figures/ancestry_bar.png",
+}
+
+
 def test_checksums_cover_derived_artefacts(tmp_path):
     out = run_vcf(tmp_path)
+    # Exact set: a truncated manifest AND a manifest padded with stale or
+    # foreign entries must both go red. Out-of-tree inputs and the
+    # wall-clock-stamped report.md/result.json are deliberately outside
+    # the envelope (they either never resolve from output_dir or never
+    # re-verify), so set equality also pins their absence.
+    assert set(read_checksums(out)) == VCF_MANIFEST
+
+
+def test_manifest_ignores_artefacts_from_previous_runs(tmp_path):
+    """Re-running a different pipeline into the same output directory must
+    not certify leftovers: the manifest names this run's outputs instead of
+    globbing whatever tables/ and figures/ happen to contain."""
+    out = tmp_path / "out"
+    run_vcf_pipeline(DEMO_VCF, DEMO_MAP, out, DEFAULT_WEIGHTS)
+    run_csv_pipeline(DEMO_CSV, out, DEFAULT_WEIGHTS)
     entries = read_checksums(out)
-    for rel in (
-        "tables/population_summary.csv",
-        "tables/fst_matrix.csv",
-        "tables/heterozygosity.csv",
-        "tables/heim_score.json",
-        "figures/heim_gauge.png",
-        "figures/ancestry_bar.png",
-        "figures/heterozygosity.png",
-        "figures/fst_heatmap.png",
-        "figures/pca_plot.png",
-    ):
-        assert rel in entries, "missing from manifest: %s" % rel
-    # Out-of-tree inputs and wall-clock-stamped outputs must not be listed:
-    # they either never resolve from output_dir or never re-verify.
-    assert DEMO_VCF.name not in entries
-    assert DEMO_MAP.name not in entries
-    assert "report.md" not in entries
-    assert "result.json" not in entries
+    assert set(entries) == CSV_MANIFEST
+    # The stale VCF-run artefacts are still on disk — that is the trap.
+    assert (out / "tables" / "fst_matrix.csv").exists()
+    for label, digest in entries.items():
+        assert digest == sha256_file(out / label)
 
 
 def test_checksums_reproduce_on_replay(tmp_path):
@@ -131,7 +154,43 @@ def test_csv_pipeline_writes_bundle(tmp_path):
     assert '"$CLAWBIO_ROOT/examples/sample_ancestry.csv"' in content
     assert "--pop-map" not in content
     entries = read_checksums(out)
-    assert "tables/population_summary.csv" in entries
-    assert "tables/heim_score.json" in entries
+    assert set(entries) == CSV_MANIFEST
     for label, digest in entries.items():
         assert digest == sha256_file(out / label)
+
+
+def test_out_of_repo_inputs_do_not_leak_paths(tmp_path):
+    """A user-supplied input outside the repo must not be recorded as a bare
+    absolute path in commands.sh — that would disclose the local filesystem
+    location of a cohort file in a deposited bundle. It is rendered as
+    "$INPUT_DIR/<name>" with the variable required at replay time."""
+    import shutil
+
+    external = tmp_path / "cohort data"
+    external.mkdir()
+    vcf = external / "my cohort.vcf"
+    pop_map = external / "my map.csv"
+    shutil.copy(DEMO_VCF, vcf)
+    shutil.copy(DEMO_MAP, pop_map)
+
+    out = tmp_path / "out"
+    run_vcf_pipeline(vcf, pop_map, out, DEFAULT_WEIGHTS)
+    content = (out / "reproducibility" / "commands.sh").read_text()
+
+    assert str(external) not in content
+    assert '"$INPUT_DIR/my cohort.vcf"' in content
+    assert '"$POP_MAP_DIR/my map.csv"' in content
+    # Replay must fail loudly if the variables are unset, not guess a path.
+    assert "${INPUT_DIR:?" in content
+    assert "${POP_MAP_DIR:?" in content
+
+
+def test_sha256_file_matches_known_digest(tmp_path):
+    """Pin sha256_file byte semantics against a known-good constant so the
+    manifest digests are anchored to more than the helper's own output."""
+    fixture = tmp_path / "fixture.txt"
+    fixture.write_bytes(b"ClawBio reproducibility fixture\n")
+    assert (
+        sha256_file(fixture)
+        == "01acddcefb698fd0b67f17afaa30db2ad84d923f776a7625aa0ca56586d4b54c"
+    )


### PR DESCRIPTION
## Summary

- equity-scorer's SKILL.md has always documented a `reproducibility/` output directory (`commands.sh`, `environment.yml`, `checksums.sha256`) that the code never actually produced — this implements it
- Both pipelines (VCF and ancestry CSV) now write the bundle via the shared `clawbio.common.reproducibility` layer; no hand-rolled writers
- `commands.sh` is a portable replay script (`write_portable_commands_sh` with `$CLAWBIO_ROOT`/`$OUTPUT_DIR` anchors, quoted paths, full-precision weights); `checksums.sha256` covers the derived artefacts under `tables/` and `figures/`, labelled relative to the output directory so `cd <output_dir> && sha256sum -c reproducibility/checksums.sha256` passes, including after a replay. Timestamped outputs (`report.md`, `result.json`) and out-of-tree inputs are deliberately excluded from the manifest; `result.json` already records the input digest as `input_checksum`.
- Note on scope of the provenance claim: `run_csv_pipeline` scores against literature-based heterozygosity estimates (labelled `het_source = "literature_estimate"` in its outputs), not values computed from the input. The bundle wraps those runs too — replaying reproduces the scoring, not a genotype-derived measurement.

## Skill affected

equity-scorer

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology) — unchanged; the code now matches its existing Output Structure section
- [x] Tests included and passing (`pytest -v`)
- [x] Demo data included for reviewers to test — existing `examples/demo_populations.vcf` + `examples/demo_population_map.csv`
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

Red/green TDD both rounds: the original 5 bundle tests were written first and failed before implementation; the review-driven rewrite (verification-from-output-dir, replay determinism, full-precision weights, pinned environment) again went red (6 failures) before the fix.

```
$ python -m pytest skills/equity-scorer/tests -q
43 passed in 5.51s
```

End-to-end verified, including the documented verification command and a replay via the generated script:

```
$ python skills/equity-scorer/equity_scorer.py --input examples/demo_populations.vcf \
    --pop-map examples/demo_population_map.csv --output "$OUT"
$ (cd "$OUT" && shasum -a 256 -c reproducibility/checksums.sha256)
tables/fst_matrix.csv: OK
... (9 artefacts, all OK)
$ bash "$OUT/reproducibility/commands.sh" && (cd "$OUT" && shasum -a 256 -c reproducibility/checksums.sha256)
... all OK after replay
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)