### PR TITLE
fix(claw-semantic-sim): drop the false "works out of the box" demo claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,9 +381,8 @@ Computes a Semantic Isolation Index for diseases using 13.1M PubMed abstracts an
 - **Temporal Drift**: how research focus evolves over time
 - Publication-quality **4-panel figure**
 
-```bash
-python semantic_sim.py --demo --output sem_report
-```
+**Status: not yet implemented.** `semantic_sim.py` and the pipeline scripts behind it are not
+in this repository yet (see `skills/claw-semantic-sim/SKILL.md`); there is no runnable demo.
 
 **Key finding**: Neglected tropical diseases are **+38% more semantically isolated** (P < 0.0001, Cohen's d = 0.84). 14 of the 25 most isolated diseases are Global South priority conditions. Knowledge silos kill innovation — a malaria immunology breakthrough could help leishmaniasis, but the literatures don't talk to each other.
 

--- a/skills/claw-semantic-sim/SKILL.md
+++ b/skills/claw-semantic-sim/SKILL.md
@@ -98,13 +98,10 @@ Neglected tropical diseases (NTDs) are significantly more semantically isolated 
 05-05-heim-sem-integrate.py # Merge with biobank + clinical trial dimensions
 ```
 
-### Demo (works out of the box)
+## Status
 
-```bash
-python semantic_sim.py --demo --output demo_report
-```
-
-The demo uses pre-computed embeddings and metrics for 175 GBD diseases and generates the full 4-panel figure instantly.
+**Not yet implemented.** `semantic_sim.py` and the `05-00..05-05` pipeline scripts described
+above are not present in this repository yet; there is no runnable demo.
 
 ## Example Output
 


### PR DESCRIPTION
## Summary

- `skills/claw-semantic-sim/SKILL.md` and `README.md` both instruct readers to run
  `python semantic_sim.py --demo`, but that script and the `05-00..05-05` pipeline
  behind it have never existed in this repository.
- Replaces the runnable demo command in both docs with a plain "not yet implemented"
  status note.

## Skill affected

claw-semantic-sim (docs only, no code change)

## Root cause

`git log --all --diff-filter=A` over `semantic_sim.py` and `heim-sem` returns zero
hits on any branch, so the script was never committed alongside the docs that
describe it, not recently deleted. `skills/catalog.json` already records this
correctly (`maturity_tier: spec-only`, `has_script: false`, `has_demo: false`,
`demo_command: null`); only the prose in `SKILL.md` and `README.md` claimed the
demo runs "out of the box".

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology) - unchanged,
      only the Status section and demo block were touched
- [ ] Tests included and passing (`pytest -v`) - no code changed, nothing to test
- [ ] Demo data included for reviewers to test - not applicable, no demo exists yet
- [x] No patient/sensitive data committed
- [x] Follows CONTRIBUTING.md conventions

## Test output

Docs-only change. Verified in a clean `python:3.11-slim` container with
`uv sync --locked --all-extras`:
- `uv run python clawbio.py list` - exits clean, lists claw-semantic-sim unchanged
- `uv run pytest tests/ -v` - 171 passed, including `test_checked_in_catalog_is_current`
  (confirms `skills/catalog.json` needed no regeneration, since only prose changed)
- Competing-PR sweep on both touched files: 0/8 open PRs touch them

Not verified: I did not implement the missing pipeline itself, only corrected the
docs. Whether and when `semantic_sim.py` gets built is a separate, larger decision.

Fixes #353
