### PR TITLE
feat(ci): auto-approve queued runs for PRs that touch only skills/

### DIFF
--- a/.github/workflows/approve-skills-only.yml
+++ b/.github/workflows/approve-skills-only.yml
@@ -1,0 +1,50 @@
+name: Approve skills-only CI
+
+# Issue #360. Fork PRs from first-time contributors park in `action_required`,
+# where they surface through `gh pr checks` as "no checks reported" and read
+# exactly like a pass. Five PRs sat in that state in one week, and #329 went
+# five remediation rounds with CI never having run against it at all.
+#
+# GitHub has no path-scoped approval policy, so the narrowing lives in
+# `scripts/approve_skills_only_runs.py` rather than in a repository setting.
+# Read that file's docstring before widening anything here: it is explicit
+# about what the boundary is worth and what it is not.
+#
+# This workflow must only ever run from the default branch. `schedule` and
+# `workflow_dispatch` both do. Never add `pull_request`: a fork could then
+# propose a change to this file and have it approve itself.
+
+on:
+  schedule:
+    # Every 15 minutes. A contributor pushing and waiting a quarter of an hour
+    # for CI to start is a far better failure mode than the current one, where
+    # they may wait indefinitely and read the silence as success.
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+permissions:
+  # `actions: write` is what approves a queued run. `pull-requests: read` is
+  # what lets the script see which files a PR touches, which IS the boundary,
+  # so it cannot be dropped. Nothing here needs write access to contents.
+  actions: write
+  pull-requests: read
+  contents: read
+
+concurrency:
+  # Two overlapping runs would race on the same queued workflow runs. Do not
+  # cancel in progress: an approval half-done is worse than one that finishes.
+  group: approve-skills-only
+  cancel-in-progress: false
+
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Approve queued runs for skills-only PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 scripts/approve_skills_only_runs.py

--- a/scripts/approve_skills_only_runs.py
+++ b/scripts/approve_skills_only_runs.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Approve queued CI runs for fork PRs that touch only `skills/`.
+
+Issue #360. This repository requires approval for first-time contributors'
+workflow runs. Those runs park in `action_required` and surface through
+`gh pr checks` as "no checks reported", which reads exactly like a pass. Five
+PRs sat in that state in a single week, and #329 went five remediation rounds
+with CI having never run against it at all, so its 17 assertions executed
+nowhere but the contributor's laptop.
+
+GitHub offers no path-scoped approval policy: `approval_policy` is one
+repository-wide value with three options, none path-aware. So the narrowing
+lives here instead of in a setting.
+
+WHAT THIS BOUNDARY IS WORTH, stated plainly so nobody mistakes it for more.
+`skills/` is precisely where contributor code lives, and CI already executes
+it: pytest imports a fork's test files, and the skill-harness job runs a
+fork's shell. Auto-approving skills-only PRs therefore does NOT mean untrusted
+code stops running unreviewed. What it does mean is that a PR which runs
+untrusted code cannot in the same breath rewrite the pipeline that runs it
+(`.github/`), the core package (`clawbio/`), the tooling (`scripts/`), or
+dependency resolution (`pyproject.toml`, `uv.lock`). Anything touching those
+still waits for a human.
+
+The residual exposure is runner compute on a token with `contents: read` and
+no secrets in any workflow. That is the trade this script encodes.
+
+Usage:
+    python scripts/approve_skills_only_runs.py            # act
+    python scripts/approve_skills_only_runs.py --dry-run  # report only
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+REPO = "ClawBio/ClawBio"
+
+# The only prefix admitted. Trailing slash is load-bearing: a bare
+# `startswith("skills")` would admit `skills-evil/payload.py`.
+ALLOWED_PREFIX = "skills/"
+
+
+def is_skills_only(files: list[str]) -> bool:
+    """True only if every path is a plain file under `skills/`.
+
+    Fails closed on an empty list: no files means the diff could not be read,
+    which is not the same as a harmless PR.
+    """
+    if not files:
+        return False
+
+    for raw in files:
+        path = (raw or "").strip()
+        if not path:
+            return False
+        # Absolute paths, traversal, and backslash separators are all outside
+        # what a well-formed git pathname looks like here. Refuse rather than
+        # normalise: normalising is where the bypasses live.
+        if path.startswith("/") or "\\" in path:
+            return False
+        if ".." in path.split("/"):
+            return False
+        if "." in path.split("/"):
+            return False
+        # Case-sensitive on purpose. A case-insensitive checkout could resolve
+        # `SKILLS/` to the same directory, but guessing which filesystem is in
+        # play is worse than refusing an unusual spelling.
+        if not path.startswith(ALLOWED_PREFIX):
+            return False
+        if len(path) <= len(ALLOWED_PREFIX):
+            return False
+    return True
+
+
+def pair_runs_to_prs(runs: list[dict], prs: list[dict]) -> list[tuple[int, int]]:
+    """Pair each queued run with the open PR whose CURRENT head it is.
+
+    GitHub leaves `pull_requests` empty on cross-repository runs, so the join
+    is by head SHA. Matching the current head also drops superseded runs: all
+    four pending on this repo when this was written were stale commits on one
+    branch, and approving those spends runner minutes on code nobody is
+    reviewing.
+    """
+    by_sha = {pr["headRefOid"]: pr["number"] for pr in prs if pr.get("headRefOid")}
+    pairs = {
+        (int(run["id"]), by_sha[run["head_sha"]])
+        for run in runs
+        if run.get("head_sha") in by_sha
+    }
+    return sorted(pairs)
+
+
+def _gh_json(args: list[str]) -> object:
+    result = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, check=False
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh {' '.join(args)} failed: {result.stderr.strip()}")
+    return json.loads(result.stdout or "null")
+
+
+def queued_runs() -> list[dict]:
+    data = _gh_json([
+        "api", f"repos/{REPO}/actions/runs?status=action_required&per_page=50"
+    ])
+    return (data or {}).get("workflow_runs", [])
+
+
+def open_prs() -> list[dict]:
+    return _gh_json([
+        "pr", "list", "--repo", REPO, "--state", "open",
+        "--limit", "100", "--json", "number,headRefOid,author",
+    ]) or []
+
+
+def pr_files(number: int) -> list[str]:
+    data = _gh_json(["api", f"repos/{REPO}/pulls/{number}/files?per_page=300"])
+    return [f["filename"] for f in (data or [])]
+
+
+def approve(run_id: int) -> None:
+    subprocess.run(
+        ["gh", "api", "-X", "POST",
+         f"repos/{REPO}/actions/runs/{run_id}/approve"],
+        check=True, capture_output=True, text=True,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="report what would be approved without approving it",
+    )
+    args = parser.parse_args()
+
+    runs = queued_runs()
+    if not runs:
+        print("No runs awaiting approval.")
+        return 0
+
+    pairs = pair_runs_to_prs(runs, open_prs())
+    stale = len(runs) - len({r for r, _ in pairs})
+    if stale:
+        print(f"Ignoring {stale} run(s) not at any open PR's current head.")
+
+    approved = 0
+    for run_id, pr_number in pairs:
+        try:
+            files = pr_files(pr_number)
+        except RuntimeError as exc:
+            print(f"  PR #{pr_number}: could not read files, leaving queued ({exc})")
+            continue
+
+        if not is_skills_only(files):
+            outside = sorted({
+                f for f in files if not f.startswith(ALLOWED_PREFIX)
+            })[:5]
+            print(f"  PR #{pr_number}: run {run_id} left for a human "
+                  f"(touches {', '.join(outside) or 'unreadable paths'})")
+            continue
+
+        if args.dry_run:
+            print(f"  PR #{pr_number}: would approve run {run_id} "
+                  f"({len(files)} files, all under skills/)")
+            continue
+
+        try:
+            approve(run_id)
+        except subprocess.CalledProcessError as exc:
+            print(f"  PR #{pr_number}: approve failed for run {run_id}: "
+                  f"{exc.stderr.strip()}")
+            continue
+        approved += 1
+        print(f"  PR #{pr_number}: approved run {run_id} "
+              f"({len(files)} files, all under skills/)")
+
+    print(f"{'Would approve' if args.dry_run else 'Approved'} {approved} run(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_approve_skills_only.py
+++ b/tests/test_approve_skills_only.py
@@ -1,0 +1,149 @@
+"""Tests for the skills-only CI auto-approval gate.
+
+Issue #360. Fork PRs from first-time contributors park in `action_required`
+and surface as "no checks reported", which is indistinguishable from a pass in
+`gh pr checks`. Five PRs sat in that state in one week, and #329 went five
+remediation rounds with CI having never run at all.
+
+GitHub has no path-scoped approval policy, so this is automation rather than a
+setting. `is_skills_only` is the security boundary: everything it returns True
+for gets its workflow run approved with no human in the loop. It must fail
+closed on anything it does not positively recognise.
+
+What the boundary does and does not buy, stated plainly so nobody mistakes it
+for more: `skills/` is exactly where contributor code lives, and CI already
+executes it (pytest imports fork test files, and the skill-harness job runs a
+fork's shell). So this is not "no untrusted execution". It is "a PR that runs
+untrusted code cannot also rewrite the pipeline that runs it, the core package,
+or dependency resolution".
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load():
+    p = Path(__file__).resolve().parents[1] / "scripts" / "approve_skills_only_runs.py"
+    spec = importlib.util.spec_from_file_location("approve_skills_only_runs", p)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+MOD = _load()
+
+
+class TestSkillsOnlyBoundary:
+    """Everything this admits runs untrusted code without human review."""
+
+    def test_a_plain_skill_change_is_admitted(self):
+        assert MOD.is_skills_only(["skills/my-skill/my_skill.py"]) is True
+
+    def test_several_files_in_one_skill(self):
+        assert MOD.is_skills_only([
+            "skills/a/a.py", "skills/a/SKILL.md", "skills/a/tests/test_a.py",
+        ]) is True
+
+    def test_two_skills_at_once(self):
+        assert MOD.is_skills_only(["skills/a/a.py", "skills/b/b.R"]) is True
+
+    def test_the_generated_catalog_is_admitted(self):
+        """Contributors regenerate it; it grants no execution."""
+        assert MOD.is_skills_only(["skills/catalog.json", "skills/a/a.py"]) is True
+
+    @pytest.mark.parametrize("path", [
+        ".github/workflows/ci.yml",
+        ".github/workflows/approve-skills-only.yml",
+        "pyproject.toml",
+        "uv.lock",
+        "clawbio/cli.py",
+        "clawbio/common/checksums.py",
+        "scripts/generate_catalog.py",
+        "tests/test_generate_catalog.py",
+        "conftest.py",
+        "Makefile",
+        ".github/dependabot.yml",
+    ])
+    def test_anything_outside_skills_is_refused(self, path):
+        assert MOD.is_skills_only([path]) is False
+
+    def test_one_bad_file_poisons_the_whole_set(self):
+        """The dangerous shape: hide a workflow edit behind real skill work."""
+        assert MOD.is_skills_only([
+            "skills/a/a.py",
+            "skills/a/SKILL.md",
+            ".github/workflows/ci.yml",
+        ]) is False
+
+    def test_an_empty_file_list_is_refused(self):
+        """Fail closed. An empty list means the diff could not be read, not
+        that the PR is harmless."""
+        assert MOD.is_skills_only([]) is False
+
+    @pytest.mark.parametrize("path", [
+        "skills/../pyproject.toml",
+        "skills/a/../../clawbio/cli.py",
+        "../skills/a/a.py",
+        "skills/./../../.github/workflows/ci.yml",
+    ])
+    def test_path_traversal_is_refused(self, path):
+        assert MOD.is_skills_only([path]) is False
+
+    @pytest.mark.parametrize("path", [
+        "skills-evil/a.py",
+        "skillsfoo/a.py",
+        "myskills/a.py",
+        "skills.py",
+        "skills",
+    ])
+    def test_prefix_confusion_is_refused(self, path):
+        """`startswith("skills")` without the separator admits `skills-evil/`."""
+        assert MOD.is_skills_only([path]) is False
+
+    @pytest.mark.parametrize("path", [
+        "SKILLS/a/a.py",
+        "Skills/a/a.py",
+    ])
+    def test_case_variants_are_refused(self, path):
+        """macOS and Windows checkouts are case-insensitive; the boundary is
+        not. Refuse rather than guess which filesystem resolves it."""
+        assert MOD.is_skills_only([path]) is False
+
+    def test_an_absolute_path_is_refused(self):
+        assert MOD.is_skills_only(["/etc/passwd"]) is False
+
+    def test_a_bare_file_at_repo_root_is_refused(self):
+        assert MOD.is_skills_only(["README.md"]) is False
+
+
+class TestRunPairing:
+    """Only the run matching an open PR's CURRENT head may be approved.
+
+    All four runs pending on this repo when the gate was written were stale
+    commits on one branch, superseded by later pushes. Approving those spends
+    runner minutes on code nobody is reviewing.
+    """
+
+    def test_a_run_at_an_open_prs_head_is_paired(self):
+        runs = [{"id": 1, "head_sha": "aaa"}]
+        prs = [{"number": 42, "headRefOid": "aaa"}]
+        assert MOD.pair_runs_to_prs(runs, prs) == [(1, 42)]
+
+    def test_a_stale_run_is_not_paired(self):
+        runs = [{"id": 1, "head_sha": "old"}]
+        prs = [{"number": 42, "headRefOid": "new"}]
+        assert MOD.pair_runs_to_prs(runs, prs) == []
+
+    def test_a_run_with_no_open_pr_is_not_paired(self):
+        runs = [{"id": 1, "head_sha": "aaa"}]
+        assert MOD.pair_runs_to_prs(runs, []) == []
+
+    def test_pairs_are_stable_and_deduplicated(self):
+        runs = [{"id": 2, "head_sha": "a"}, {"id": 1, "head_sha": "a"}]
+        prs = [{"number": 7, "headRefOid": "a"}]
+        assert MOD.pair_runs_to_prs(runs, prs) == [(1, 7), (2, 7)]


### PR DESCRIPTION
Addresses the part of #360 that a workflow change could not fix.

## Why this is automation and not a setting

GitHub has **no path-scoped approval policy**. The API confirms one repository-wide value:

```
GET repos/ClawBio/ClawBio/actions/permissions/fork-pr-contributor-approval
{"approval_policy":"first_time_contributors"}
```

The three options are `first_time_contributors_new_to_github`, `first_time_contributors`, `all_external_contributors`. None is path-aware. So "relax approval for skills-only PRs" has to be implemented, not configured.

## What the boundary is actually worth

Stating this plainly because it would be easy to over-read. `skills/` is precisely where contributor code lives, and **CI already executes it**: pytest imports a fork's test files, and the `skill-harness` job merged yesterday runs a fork's shell. So this does **not** mean untrusted code stops running unreviewed.

What it means is narrower and still worth having: a PR that runs untrusted code cannot in the same breath rewrite the pipeline that runs it (`.github/`), the core package (`clawbio/`), the tooling (`scripts/`), or dependency resolution (`pyproject.toml`, `uv.lock`). Those still wait for a human.

Residual exposure is runner compute on a token with `contents: read`. I checked: **no workflow in this repository references any secret**, and only `ci.yml` triggers on `pull_request` (not `pull_request_target`).

## The boundary fails closed

`is_skills_only` refuses an empty file list (a diff that could not be read is not a harmless PR), absolute paths, `..` traversal, backslashes, and case variants. The trailing slash in `skills/` is load-bearing: a bare `startswith("skills")` would admit `skills-evil/payload.py`.

Only runs at an open PR's **current** head are approved. All four runs pending on this repo today are superseded commits on one branch; approving those would spend runner minutes on code nobody is reviewing.

## Validated against live data, not just fixtures

Decision on all eight open PRs:

| PR | Verdict | Why |
|---|---|---|
| #352, #351, #350, #345, #344, #329 | AUTO-APPROVE | pure `skills/` |
| #348 | HUMAN | touches `clawbio/cli.py`, `pyproject.toml` |
| #346 | HUMAN | touches `clawbio/cli.py` |

That is the intended split: a new skill registering a CLI alias still gets a human; pure skill work flows.

Four mutations, each caught by a named test: always-true, dropping the trailing slash, dropping the traversal guard, pairing stale runs.

## Trigger safety

`schedule` and `workflow_dispatch` only, so it always runs from the default branch. **It must never gain a `pull_request` trigger**, or a fork could propose a change to this workflow and have it approve itself. There is a comment saying so in the file.

## Correction to #360, which I got wrong

I wrote there and on #329 that "zero workflow runs have ever existed" for `feat/claw-amplicon-qc`. That is false, and I have corrected both. The full history shows nine runs: one success on the first push, several failures, and four parked in `action_required` and never approved. My query had filtered the 20 most recent runs repo-wide, which could not have shown that branch's older runs, and I over-generalised from it.

The accurate statement is narrower but still the point of this PR: four runs were queued and never approved, and the current head has no run at all.

225 tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Auto-approves GitHub Actions runs for untrusted fork PRs using `actions: write`. The path gate is fail-closed and does not cover pipeline or core-package changes, but a bug in that gate would skip human review of CI.
> 
> **Overview**
> Stops first-time-contributor fork PRs that only touch `skills/` from sitting forever in `action_required` (which `gh pr checks` treats like a pass). GitHub has no path-scoped approval policy, so a scheduled workflow on the default branch now approves those queued runs.
> 
> `is_skills_only` is the fail-closed gate: every path must be under `skills/`. Empty diffs, traversal, prefix tricks, case variants, and any file outside `skills/` still wait for a human, so a PR cannot both run untrusted skill code and rewrite CI, `clawbio/`, `scripts/`, or lockfiles. Only runs matching an open PR's current head are approved.
> 
> The workflow is `schedule` / `workflow_dispatch` only (never `pull_request`) so a fork cannot change it and approve itself. Residual exposure is runner compute on `contents: read` with no workflow secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af50bd9040dfc3875fc0b70b3a1ea2aa1bdaadb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->