### PR TITLE
docs(ci): correct a false claim about #329's environment.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,11 +305,24 @@ jobs:
             if ! micromamba create -y -n "env-$skill" -f "$env_file"; then
               # A declared environment that will not solve means nobody can run
               # this skill as documented, so it is a real failure rather than a
-              # skip. claw-amplicon-qc (#329) pins `r-base>=4.4` while the
-              # bioconda builds of dada2, ShortRead and Biostrings resolve only
-              # against r-base 4.1.3, so its environment.yml has never been
-              # buildable and five review rounds never noticed.
-              echo "::error::skills/$skill: environment.yml did not solve, so its documented environment cannot be built."
+              # skip.
+              #
+              # This comment previously cited claw-amplicon-qc (#329) as an
+              # example whose environment.yml "has never been buildable". That
+              # was WRONG and is corrected here. The solve that produced it ran
+              # `--platform linux-64` from macOS, where the `__glibc` virtual
+              # package is unset ("glibc version not found (virtual package
+              # skipped)"), which makes every glibc-linked build unsatisfiable
+              # and yields a conflict trace that reads exactly like a genuine
+              # pin conflict. With CONDA_OVERRIDE_GLIBC set, that same file
+              # solves. It was the third false finding this project has raised
+              # against that one contributor.
+              #
+              # This job runs on ubuntu-latest, where `__glibc` is set
+              # natively, so the artefact cannot occur here. Anyone reproducing
+              # a failure from this job on macOS must set CONDA_OVERRIDE_GLIBC
+              # before concluding the environment is broken.
+              echo "::error::skills/$skill: environment.yml did not solve on this Linux runner, so its documented environment cannot be built. If reproducing on macOS, set CONDA_OVERRIDE_GLIBC first: a cross-platform solve without it fails for an unrelated reason."
               status=1
               echo "::endgroup::"
               continue


### PR DESCRIPTION
The `skill-harness` job I merged yesterday carries a comment asserting that claw-amplicon-qc's `environment.yml` "has never been buildable". **That is wrong**, and this corrects it.

## What actually happened

The solve behind that claim ran `--platform linux-64` from macOS. In that configuration micromamba cannot determine the target's glibc:

```
warning  libmamba glibc version not found (virtual package skipped)
```

Skipping `__glibc` makes every glibc-linked build unsatisfiable, and the resulting trace reads exactly like a genuine pin conflict, right down to naming `r-base` versions. Same file, same platform flag, only difference being the override:

| | result |
|---|---|
| `micromamba create --platform linux-64 -f environment.yml` | `Could not solve for environment specs` |
| same, with `CONDA_OVERRIDE_GLIBC=2.28` | solves, exit 0 |

And the pre-fix file (`157dee30^`, the version I called unbuildable) resolves cleanly to r-base 4.5.3, Biostrings 2.78.0, dada2 1.38.0, ShortRead 1.68.0.

So the `r-base>=4.4` pin was never the problem, the environment was always buildable on Linux, and the pins the contributor pushed in response to my report were not needed.

## Why this one stings

It is the **third** false finding this project has raised against the same contributor, after two false shell-injection reports on the same PR. It is also the first that cost them work: they pushed a commit to fix a defect that did not exist.

The specific error I made is one I have flagged in others' code repeatedly this week: I ran a check in an environment that could not give a valid answer, and read its output as a finding instead of asking whether the check itself was sound. A cross-platform conda solve is exactly the kind of check that fails for reasons unrelated to what it appears to measure.

## The job is unaffected

`skill-harness` runs on `ubuntu-latest`, where `__glibc` is set natively, so this artefact cannot occur there. The change is the comment plus a more useful error message telling anyone reproducing a failure on macOS to set `CONDA_OVERRIDE_GLIBC` before concluding an environment is broken.

225 tests pass. No behavioural change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and error-message only in CI; harness behavior is unchanged.
> 
> **Overview**
> Retracts a false claim in the `skill-harness` job that `claw-amplicon-qc` (#329) `environment.yml` had never been solvable. The earlier conclusion came from a macOS `--platform linux-64` micromamba solve with `__glibc` unset, which looks like a pin conflict.
> 
> The job still fails unsolvable envs on Linux. The error now says the solve failed on this Linux runner and to set `CONDA_OVERRIDE_GLIBC` before treating a macOS cross-platform solve as proof the file is broken. No job logic change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 350671c952bb89f5a10ec2e26da137999d125e01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->