### PR TITLE
ci: run vcf-annotator tests on the main allowlist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,9 @@ jobs:
       - name: Run Skill Builder tests
         run: uv run pytest skills/skill-builder/tests/test_skill_builder.py -v
 
+      - name: Run VCF Annotator tests
+        run: uv run pytest skills/vcf-annotator/tests/test_vcf_annotator.py -v
+
       - name: Run bot security tests
         run: uv run pytest bot/tests/test_security.py -v
 

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -4297,14 +4297,14 @@
       "description": "Annotate VCF variants with Ensembl VEP, ClinVar, and gnomAD. Ranks variants by impact (HIGH/MODERATE/LOW/MODIFIER) and generates a reproducible report.",
       "version": "0.1.0",
       "status": "planned",
-      "maturity_tier": "tested",
+      "maturity_tier": "ci-validated",
       "maturity_evidence": {
         "has_skill_md": true,
         "has_script": true,
         "has_tests": true,
         "has_demo": true,
         "cli_registered": false,
-        "ci_tested": false,
+        "ci_tested": true,
         "benchmark_validated": false
       },
       "has_script": true,

--- a/skills/vcf-annotator/SKILL.md
+++ b/skills/vcf-annotator/SKILL.md
@@ -188,16 +188,16 @@ CFTR, APOE, MTHFR) with ClinVar classifications and gnomAD frequencies.
 **Input**: demo_variants.vcf
 **Date**: 2026-04-19 10:00 UTC
 **Total variants**: 5
-**HIGH impact**: 3 | **MODERATE**: 2 | **LOW**: 0
+**HIGH impact**: 2 | **MODERATE**: 3 | **LOW**: 0
 **ClinVar Pathogenic/Likely Pathogenic**: 3
 
 ## Variant Table
 
 | # | Gene  | Variant             | Consequence       | Impact   | ClinVar    | gnomAD AF |
 |---|-------|---------------------|-------------------|----------|------------|-----------|
-| 1 | BRCA1 | 17:43044295 G>A     | missense_variant  | HIGH     | Pathogenic | 0.000008  |
-| 2 | BRCA2 | 13:32316461 C>T     | stop_gained       | HIGH     | Pathogenic | 0.000004  |
-| 3 | CFTR  | 7:117548628 CTTT>C  | frameshift_variant| HIGH     | Pathogenic | 0.021000  |
+| 1 | BRCA2 | 13:32316461 C>T     | stop_gained       | HIGH     | Pathogenic | 0.000004  |
+| 2 | CFTR  | 7:117548628 CTTT>C  | frameshift_variant| HIGH     | Pathogenic | 0.021000  |
+| 3 | BRCA1 | 17:43063931 G>A     | missense_variant  | MODERATE | Pathogenic | 0.000024  |
 ```
 
 ## Output Structure

--- a/skills/vcf-annotator/examples/demo_output/report.md
+++ b/skills/vcf-annotator/examples/demo_output/report.md
@@ -3,14 +3,14 @@
 **Input**: demo_variants.vcf  
 **Date**: 2026-04-18 19:07 UTC  
 **Total variants**: 5  
-**HIGH impact**: 3 | **MODERATE**: 2 | **LOW**: 0  
+**HIGH impact**: 2 | **MODERATE**: 3 | **LOW**: 0<br>
 **ClinVar Pathogenic/Likely Pathogenic**: 3
 
 ---
 
 ## Summary
 
-Annotated 5 variants against Ensembl VEP, ClinVar, and gnomAD. 3 variant(s) carry HIGH impact consequences. 3 variant(s) are classified as Pathogenic or Likely Pathogenic in ClinVar. Variants are ranked by predicted functional impact below.
+Annotated 5 variants against Ensembl VEP, ClinVar, and gnomAD. 2 variant(s) carry HIGH impact consequences. 3 variant(s) are classified as Pathogenic or Likely Pathogenic in ClinVar. Variants are ranked by predicted functional impact below.
 
 ---
 
@@ -18,33 +18,17 @@ Annotated 5 variants against Ensembl VEP, ClinVar, and gnomAD. 3 variant(s) carr
 
 | # | Gene | Variant | Consequence | Impact | ClinVar | gnomAD AF |
 |---|------|---------|-------------|--------|---------|-----------|
-| 1 | BRCA1 | 17:43044295 G>A | missense_variant | **HIGH** | Pathogenic | 0.000008 |
-| 2 | BRCA2 | 13:32316461 C>T | stop_gained | **HIGH** | Pathogenic | 0.000004 |
-| 3 | CFTR | 7:117548628 CTTT>C | frameshift_variant | **HIGH** | Pathogenic | 0.021000 |
-| 4 | APOE | 19:11089199 T>C | missense_variant | **MODERATE** | Risk factor | 0.147000 |
-| 5 | MTHFR | 1:69515 G>A | missense_variant | **MODERATE** | Benign/Likely benign | 0.312000 |
+| 1 | BRCA2 | 13:32316461 C>T | stop_gained | **HIGH** | Pathogenic | 0.000004 |
+| 2 | CFTR | 7:117548628 CTTT>C | frameshift_variant | **HIGH** | Pathogenic | 0.021000 |
+| 3 | BRCA1 | 17:43063931 G>A | missense_variant | **MODERATE** | Pathogenic | 0.000024 |
+| 4 | APOE | 19:44908684 T>C | missense_variant | **MODERATE** | Risk factor | 0.147000 |
+| 5 | MTHFR | 1:11796321 G>A | missense_variant | **MODERATE** | Benign/Likely benign | 0.312000 |
 
 ---
 
 ## Detailed Annotations
 
-### 1. BRCA1 — 17:43044295 G>A
-
-| Field | Value |
-|-------|-------|
-| **rsID** | rs80357382 |
-| **HGVS** | NM_007294.4:c.5266dupC |
-| **Consequence** | missense_variant |
-| **Impact** | HIGH |
-| **SIFT** | deleterious |
-| **PolyPhen** | probably_damaging |
-| **ClinVar** | Pathogenic |
-| **ClinVar Condition** | Hereditary breast and ovarian cancer syndrome |
-| **gnomAD AF (global)** | 0.000008 |
-| **gnomAD AF (AFR)** | 0.000000 |
-| **gnomAD AF (EUR)** | 0.000012 |
-
-### 2. BRCA2 — 13:32316461 C>T
+### 1. BRCA2 — 13:32316461 C>T
 
 | Field | Value |
 |-------|-------|
@@ -60,7 +44,7 @@ Annotated 5 variants against Ensembl VEP, ClinVar, and gnomAD. 3 variant(s) carr
 | **gnomAD AF (AFR)** | 0.000000 |
 | **gnomAD AF (EUR)** | 0.000006 |
 
-### 3. CFTR — 7:117548628 CTTT>C
+### 2. CFTR — 7:117548628 CTTT>C
 
 | Field | Value |
 |-------|-------|
@@ -76,7 +60,23 @@ Annotated 5 variants against Ensembl VEP, ClinVar, and gnomAD. 3 variant(s) carr
 | **gnomAD AF (AFR)** | 0.000300 |
 | **gnomAD AF (EUR)** | 0.033000 |
 
-### 4. APOE — 19:11089199 T>C
+### 3. BRCA1 — 17:43063931 G>A
+
+| Field | Value |
+|-------|-------|
+| **rsID** | rs55770810 |
+| **HGVS** | NM_007294.4:c.5095C>T (p.Arg1699Trp) |
+| **Consequence** | missense_variant |
+| **Impact** | MODERATE |
+| **SIFT** | deleterious |
+| **PolyPhen** | probably_damaging |
+| **ClinVar** | Pathogenic |
+| **ClinVar Condition** | Hereditary breast and ovarian cancer syndrome |
+| **gnomAD AF (global)** | 0.000024 |
+| **gnomAD AF (AFR)** | N/A |
+| **gnomAD AF (EUR)** | N/A |
+
+### 4. APOE — 19:44908684 T>C
 
 | Field | Value |
 |-------|-------|
@@ -92,7 +92,7 @@ Annotated 5 variants against Ensembl VEP, ClinVar, and gnomAD. 3 variant(s) carr
 | **gnomAD AF (AFR)** | 0.232000 |
 | **gnomAD AF (EUR)** | 0.143000 |
 
-### 5. MTHFR — 1:69515 G>A
+### 5. MTHFR — 1:11796321 G>A
 
 | Field | Value |
 |-------|-------|

--- a/skills/vcf-annotator/tests/test_vcf_annotator.py
+++ b/skills/vcf-annotator/tests/test_vcf_annotator.py
@@ -15,6 +15,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 from vcf_annotator import (
     DEMO_ANNOTATIONS,
+    DEMO_VCF_CONTENT,
     IMPACT_RANK,
     generate_report,
     parse_vcf,
@@ -216,6 +217,27 @@ class TestDemoData:
         impacts = [v["impact"] for v in DEMO_ANNOTATIONS]
         ranks   = [IMPACT_RANK.get(i, 5) for i in impacts]
         assert ranks == sorted(ranks)
+
+    def test_demo_grch38_coordinates(self):
+        expected = {
+            "rs80357382": ("17", "43106457"),
+            "rs429358": ("19", "44908684"),
+            "rs1801133": ("1", "11796321"),
+        }
+        by_id = {v["id"]: v for v in DEMO_ANNOTATIONS}
+        for rsid, (chrom, pos) in expected.items():
+            assert by_id[rsid]["chrom"] == chrom
+            assert by_id[rsid]["pos"] == pos
+        vcf = DEMO_VCF_CONTENT
+        assert "19\t44908684\trs429358" in vcf
+        assert "1\t11796321\trs1801133" in vcf
+        assert "17\t43106457\trs80357382" in vcf
+
+    def test_demo_brca1_is_missense_not_duplication(self):
+        brca1 = next(v for v in DEMO_ANNOTATIONS if v["id"] == "rs80357382")
+        assert brca1["consequence"] == "missense_variant"
+        assert brca1["impact"] == "MODERATE"
+        assert "dup" not in brca1["hgvs"].lower()
 
 
 # ── CLI entry point ────────────────────────────────────────────────────────────

--- a/skills/vcf-annotator/tests/test_vcf_annotator.py
+++ b/skills/vcf-annotator/tests/test_vcf_annotator.py
@@ -26,7 +26,7 @@ from vcf_annotator import (
 SAMPLE_VCF = """##fileformat=VCFv4.2
 ##reference=GRCh38
 #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
-17\t43044295\trs80357382\tG\tA\t.\tPASS\t.
+17\t43063931\trs55770810\tG\tA\t.\tPASS\t.
 13\t32316461\trs80359550\tC\tT\t.\tPASS\t.
 chr7\t117548628\t.\tCTTT\tC\t.\tPASS\t.
 """
@@ -70,7 +70,7 @@ class TestParseVCF:
 
     def test_rsid_preserved(self, sample_vcf):
         variants = parse_vcf(sample_vcf)
-        assert variants[0]["id"] == "rs80357382"
+        assert variants[0]["id"] == "rs55770810"
 
     def test_skips_header_lines(self, sample_vcf):
         variants = parse_vcf(sample_vcf)
@@ -220,7 +220,7 @@ class TestDemoData:
 
     def test_demo_grch38_coordinates(self):
         expected = {
-            "rs80357382": ("17", "43106457"),
+            "rs55770810": ("17", "43063931"),
             "rs429358": ("19", "44908684"),
             "rs1801133": ("1", "11796321"),
         }
@@ -231,13 +231,15 @@ class TestDemoData:
         vcf = DEMO_VCF_CONTENT
         assert "19\t44908684\trs429358" in vcf
         assert "1\t11796321\trs1801133" in vcf
-        assert "17\t43106457\trs80357382" in vcf
+        assert "17\t43063931\trs55770810\tG\tA" in vcf
 
     def test_demo_brca1_is_missense_not_duplication(self):
-        brca1 = next(v for v in DEMO_ANNOTATIONS if v["id"] == "rs80357382")
+        brca1 = next(v for v in DEMO_ANNOTATIONS if v["id"] == "rs55770810")
+        assert (brca1["chrom"], brca1["pos"]) == ("17", "43063931")
+        assert (brca1["ref"], brca1["alt"]) == ("G", "A")
         assert brca1["consequence"] == "missense_variant"
         assert brca1["impact"] == "MODERATE"
-        assert "dup" not in brca1["hgvs"].lower()
+        assert brca1["hgvs"] == "NM_007294.4:c.5095C>T (p.Arg1699Trp)"
 
 
 # ── CLI entry point ────────────────────────────────────────────────────────────

--- a/skills/vcf-annotator/tests/test_vcf_annotator.py
+++ b/skills/vcf-annotator/tests/test_vcf_annotator.py
@@ -241,6 +241,63 @@ class TestDemoData:
         assert brca1["impact"] == "MODERATE"
         assert brca1["hgvs"] == "NM_007294.4:c.5095C>T (p.Arg1699Trp)"
 
+    def test_demo_vcf_rows_match_annotations(self):
+        """Every DEMO_ANNOTATIONS record must agree with its DEMO_VCF_CONTENT
+        row. Cross-artifact consistency: the VCF and the annotation table are
+        maintained separately, so echoing either one cannot catch drift.
+        """
+        rows = {}
+        for line in DEMO_VCF_CONTENT.splitlines():
+            if line.startswith("#") or not line.strip():
+                continue
+            chrom, pos, rsid, ref, alt = line.split("\t")[:5]
+            rows[rsid] = (chrom, pos, ref, alt)
+        for v in DEMO_ANNOTATIONS:
+            assert v["id"] in rows, f"{v['id']} missing from demo VCF"
+            assert rows[v["id"]] == (v["chrom"], v["pos"], v["ref"], v["alt"]), (
+                f"{v['id']}: VCF row {rows[v['id']]} disagrees with annotation "
+                f"{(v['chrom'], v['pos'], v['ref'], v['alt'])}"
+            )
+
+    def test_demo_brca1_hgvs_matches_genomic_alleles(self):
+        """Derive, do not echo: for a minus-strand gene the genomic REF/ALT
+        must be the complement of the cDNA substitution, and the cDNA position
+        must be the first base of the codon named by the protein change.
+
+        External anchors (verified 2026-08-30, live):
+          - ClinVar VCV000055396 = NM_007294.4:c.5095C>T (p.Arg1699Trp),
+            dbSNP rs55770810, GRCh38 chr17:43063931
+          - Ensembl VEP colocates rs55770810 (G/A) at 17:43063931,
+            codon Cgg/Tgg (Arg->Trp)
+        These checks would have failed on the audited inconsistent record
+        (17:43106457 T>A labelled p.Arg1699Trp): complement of c.5095C>T is
+        G>A, not T>A.
+        """
+        import re
+
+        complement = {"A": "T", "C": "G", "G": "C", "T": "A"}
+        brca1 = next(v for v in DEMO_ANNOTATIONS if v["gene"] == "BRCA1")
+        m = re.search(r"c\.(\d+)([ACGT])>([ACGT])", brca1["hgvs"])
+        assert m, f"HGVS lacks a cDNA substitution: {brca1['hgvs']}"
+        c_pos, c_ref, c_alt = int(m.group(1)), m.group(2), m.group(3)
+        p = re.search(r"p\.\w+?(\d+)\w+?", brca1["hgvs"])
+        assert p, f"HGVS lacks a protein residue number: {brca1['hgvs']}"
+        residue = int(p.group(1))
+
+        # BRCA1 is on the minus strand: genomic alleles complement the cDNA.
+        assert brca1["ref"] == complement[c_ref], (
+            f"minus-strand REF should complement c.{c_pos}{c_ref}>{c_alt}: "
+            f"expected {complement[c_ref]}, got {brca1['ref']}"
+        )
+        assert brca1["alt"] == complement[c_alt], (
+            f"minus-strand ALT should complement c.{c_pos}{c_ref}>{c_alt}: "
+            f"expected {complement[c_alt]}, got {brca1['alt']}"
+        )
+        # c.5095 is the first base of codon 1699: 3k - 2.
+        assert 3 * residue - 2 == c_pos, (
+            f"cDNA position {c_pos} is not the first base of codon {residue}"
+        )
+
 
 # ── CLI entry point ────────────────────────────────────────────────────────────
 #

--- a/skills/vcf-annotator/vcf_annotator.py
+++ b/skills/vcf-annotator/vcf_annotator.py
@@ -53,32 +53,14 @@ DEMO_VCF_CONTENT = """##fileformat=VCFv4.2
 ##reference=GRCh38
 ##FILTER=<ID=PASS,Description="All filters passed">
 #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
-17\t43044295\trs80357382\tG\tA\t.\tPASS\t.
+17\t43106457\trs80357382\tT\tA\t.\tPASS\t.
 13\t32316461\trs80359550\tC\tT\t.\tPASS\t.
 7\t117548628\trs113993960\tCTTT\tC\t.\tPASS\t.
-19\t11089199\trs429358\tT\tC\t.\tPASS\t.
-1\t69515\trs1801133\tG\tA\t.\tPASS\t.
+19\t44908684\trs429358\tT\tC\t.\tPASS\t.
+1\t11796321\trs1801133\tG\tA\t.\tPASS\t.
 """
 
 DEMO_ANNOTATIONS = [
-    {
-        "chrom": "17",
-        "pos": "43044295",
-        "id": "rs80357382",
-        "ref": "G",
-        "alt": "A",
-        "gene": "BRCA1",
-        "consequence": "missense_variant",
-        "impact": "HIGH",
-        "clinvar_significance": "Pathogenic",
-        "clinvar_condition": "Hereditary breast and ovarian cancer syndrome",
-        "gnomad_af": 0.000008,
-        "gnomad_af_afr": 0.0,
-        "gnomad_af_eur": 0.000012,
-        "hgvs": "NM_007294.4:c.5266dupC",
-        "sift": "deleterious",
-        "polyphen": "probably_damaging",
-    },
     {
         "chrom": "13",
         "pos": "32316461",
@@ -116,8 +98,26 @@ DEMO_ANNOTATIONS = [
         "polyphen": "N/A",
     },
     {
+        "chrom": "17",
+        "pos": "43106457",
+        "id": "rs80357382",
+        "ref": "T",
+        "alt": "A",
+        "gene": "BRCA1",
+        "consequence": "missense_variant",
+        "impact": "MODERATE",
+        "clinvar_significance": "Pathogenic",
+        "clinvar_condition": "Hereditary breast and ovarian cancer syndrome",
+        "gnomad_af": 0.000008,
+        "gnomad_af_afr": 0.0,
+        "gnomad_af_eur": 0.000012,
+        "hgvs": "NP_009225.1:p.Arg1699Trp",
+        "sift": "deleterious",
+        "polyphen": "probably_damaging",
+    },
+    {
         "chrom": "19",
-        "pos": "11089199",
+        "pos": "44908684",
         "id": "rs429358",
         "ref": "T",
         "alt": "C",
@@ -135,7 +135,7 @@ DEMO_ANNOTATIONS = [
     },
     {
         "chrom": "1",
-        "pos": "69515",
+        "pos": "11796321",
         "id": "rs1801133",
         "ref": "G",
         "alt": "A",

--- a/skills/vcf-annotator/vcf_annotator.py
+++ b/skills/vcf-annotator/vcf_annotator.py
@@ -53,7 +53,7 @@ DEMO_VCF_CONTENT = """##fileformat=VCFv4.2
 ##reference=GRCh38
 ##FILTER=<ID=PASS,Description="All filters passed">
 #CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
-17\t43106457\trs80357382\tT\tA\t.\tPASS\t.
+17\t43063931\trs55770810\tG\tA\t.\tPASS\t.
 13\t32316461\trs80359550\tC\tT\t.\tPASS\t.
 7\t117548628\trs113993960\tCTTT\tC\t.\tPASS\t.
 19\t44908684\trs429358\tT\tC\t.\tPASS\t.
@@ -99,19 +99,19 @@ DEMO_ANNOTATIONS = [
     },
     {
         "chrom": "17",
-        "pos": "43106457",
-        "id": "rs80357382",
-        "ref": "T",
+        "pos": "43063931",
+        "id": "rs55770810",
+        "ref": "G",
         "alt": "A",
         "gene": "BRCA1",
         "consequence": "missense_variant",
         "impact": "MODERATE",
         "clinvar_significance": "Pathogenic",
         "clinvar_condition": "Hereditary breast and ovarian cancer syndrome",
-        "gnomad_af": 0.000008,
-        "gnomad_af_afr": 0.0,
-        "gnomad_af_eur": 0.000012,
-        "hgvs": "NP_009225.1:p.Arg1699Trp",
+        "gnomad_af": 0.000024,
+        "gnomad_af_afr": None,
+        "gnomad_af_eur": None,
+        "hgvs": "NM_007294.4:c.5095C>T (p.Arg1699Trp)",
         "sift": "deleterious",
         "polyphen": "probably_damaging",
     },
@@ -363,7 +363,7 @@ def generate_report(
         f"**Input**: {input_label}  ",
         f"**Date**: {now}  ",
         f"**Total variants**: {total}  ",
-        f"**HIGH impact**: {high} | **MODERATE**: {mod} | **LOW**: {low}  ",
+        f"**HIGH impact**: {high} | **MODERATE**: {mod} | **LOW**: {low}<br>",
         f"**ClinVar Pathogenic/Likely Pathogenic**: {path_count}",
         "",
         "---",


### PR DESCRIPTION
Fixes #337.

## Summary

- Add `skills/vcf-annotator/tests/test_vcf_annotator.py` to the main CI allowlist.
- Exercise the documented CLI entrypoint and `--demo` path, not only helper functions.
- Correct stale GRCh38 demo coordinates and make the BRCA1 rsID, alleles, HGVS, consequence, and impact internally consistent.
- Synchronize the skill example and committed demo report with the corrected data.

## Scientific source

The BRCA1 demo row uses NCBI ClinVar Variation ID 55396 / rs55770810: GRCh38 `17:43063931 G>A`, `NM_007294.4:c.5095C>T (p.Arg1699Trp)`, a missense variant represented as MODERATE impact in the VEP-style consequence vocabulary.

https://www.ncbi.nlm.nih.gov/clinvar/variation/55396/

## Validation

- `python -m pytest skills/vcf-annotator/tests/test_vcf_annotator.py -q` — 34 passed
- `python skills/vcf-annotator/vcf_annotator.py --demo --output <temp-dir>` — passed
- `uvx --from 'skills-ref>=0.1.1,<1' agentskills validate skills/vcf-annotator` — valid
- `git diff --check` — clean
