### PR TITLE
fix(rnaseq-de): keep gene IDs on nf-core count handoff

### DIFF
--- a/skills/rnaseq-de/rnaseq_de.py
+++ b/skills/rnaseq-de/rnaseq_de.py
@@ -54,13 +54,28 @@ def parse_contrast(contrast: str) -> tuple[str, str, str]:
     return parts[0], parts[1], parts[2]
 
 
+_GENE_ID_COLUMNS = ("gene_id", "Geneid", "gene", "GENEID", "GeneID")
+_GENE_NAME_COLUMNS = ("gene_name", "gene_symbol", "GeneName", "symbol")
+
+
+def _select_gene_id_column(columns: pd.Index) -> str:
+    for name in _GENE_ID_COLUMNS:
+        if name in columns:
+            return name
+    if len(columns) == 0:
+        raise ValueError("Count matrix is missing a gene identifier column")
+    return str(columns[0])
+
+
 def load_counts(path: Path) -> pd.DataFrame:
     sep = _sep_for(path)
     df = pd.read_csv(path, sep=sep)
     if df.shape[1] < 3:
         raise ValueError("Count matrix must have one gene column and at least two samples")
-    gene_col = df.columns[0]
-    counts = df.set_index(gene_col)
+    gene_col = _select_gene_id_column(df.columns)
+    drop = [col for col in _GENE_NAME_COLUMNS if col in df.columns and col != gene_col]
+    counts = df.drop(columns=drop).set_index(gene_col)
+    counts.index.name = gene_col
     counts = counts.apply(pd.to_numeric, errors="coerce")
     if counts.isna().any().any():
         raise ValueError("Count matrix contains non-numeric entries")
@@ -285,13 +300,31 @@ def _try_de_pydeseq2(
             shrinkage["lfc_shrinkage_note"] = f"Attempted LFC shrinkage with '{coeff}' but failed: {exc}"
     else:
         shrinkage["lfc_shrinkage_note"] = "Could not identify a PyDESeq2 coefficient for LFC shrinkage."
-    res = stats.results_df.reset_index().rename(columns={"index": "gene"})
+    res = _require_gene_column(stats.results_df.reset_index())
     if "baseMean" not in res.columns:
         base_mean = (counts.div(counts.sum(axis=0), axis=1) * 1_000_000.0).mean(axis=1)
         res = res.merge(base_mean.rename("baseMean"), left_on="gene", right_index=True, how="left")
     cols = ["gene", "baseMean", "log2FoldChange", "pvalue", "padj"]
     keep = [col for col in cols if col in res.columns]
     return res[keep].sort_values("padj", ascending=True), shrinkage
+
+
+def _require_gene_column(results: pd.DataFrame) -> pd.DataFrame:
+    """Return DE results with a non-empty `gene` column, or fail closed."""
+    res = results.copy()
+    if "gene" not in res.columns:
+        for name in (*_GENE_ID_COLUMNS, "index"):
+            if name in res.columns:
+                res = res.rename(columns={name: "gene"})
+                break
+    if "gene" not in res.columns:
+        raise ValueError("Differential expression results are missing gene identifiers")
+    if res["gene"].isna().any():
+        raise ValueError("Differential expression results are missing gene identifiers")
+    genes = res["gene"].astype(str).str.strip()
+    if (genes == "").any() or (genes.str.lower() == "nan").any():
+        raise ValueError("Differential expression results are missing gene identifiers")
+    return res
 
 
 def _resolve_shrinkage_coeff(dds: object, factor: str, numerator: str) -> str:

--- a/skills/rnaseq-de/tests/test_rnaseq_de.py
+++ b/skills/rnaseq-de/tests/test_rnaseq_de.py
@@ -8,6 +8,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from rnaseq_de import (
+    _require_gene_column,
     align_and_validate,
     compute_qc,
     de_simple,
@@ -147,3 +148,60 @@ def test_pydeseq2_reports_lfc_shrinkage(tmp_path):
     assert result_data["summary"]["backend_used"] == "pydeseq2"
     assert result_data["summary"]["lfc_shrinkage_applied"] is True
     assert result_data["summary"]["lfc_shrinkage_coeff"].startswith("condition[")
+
+
+def test_load_counts_accepts_nfcore_gene_name_column(tmp_path):
+    path = tmp_path / "salmon.merged.gene_counts.tsv"
+    path.write_text(
+        "gene_id\tgene_name\tctrl_1\tctrl_2\ttrt_1\ttrt_2\n"
+        "ENSG0001\tGeneA\t48\t52\t310\t295\n"
+        "ENSG0002\tGeneB\t250\t240\t42\t38\n",
+        encoding="utf-8",
+    )
+    counts = load_counts(path)
+    assert list(counts.index) == ["ENSG0001", "ENSG0002"]
+    assert list(counts.columns) == ["ctrl_1", "ctrl_2", "trt_1", "trt_2"]
+    assert counts.loc["ENSG0001", "trt_1"] == 310
+
+
+def test_require_gene_column_keeps_named_index():
+    results = pd.DataFrame(
+        {"log2FoldChange": [1.2]},
+        index=pd.Index(["ENSG0001"], name="gene_id"),
+    )
+    out = _require_gene_column(results.reset_index())
+    assert list(out["gene"]) == ["ENSG0001"]
+
+
+def test_require_gene_column_fails_when_identifier_missing():
+    results = pd.DataFrame({"log2FoldChange": [1.2], "padj": [0.01]})
+    with pytest.raises(ValueError, match="missing gene identifiers"):
+        _require_gene_column(results)
+
+
+def test_run_analysis_nfcore_counts_keep_gene_ids(tmp_path):
+    counts_path = tmp_path / "counts.tsv"
+    meta_path = tmp_path / "metadata.csv"
+    counts_path.write_text(
+        "gene_id\tgene_name\tctrl_1\tctrl_2\ttrt_1\ttrt_2\n"
+        "ENSG0001\tGeneA\t48\t52\t310\t295\n"
+        "ENSG0002\tGeneB\t250\t240\t42\t38\n"
+        "ENSG0003\tGeneC\t90\t86\t92\t88\n",
+        encoding="utf-8",
+    )
+    meta_path.write_text(
+        "sample_id,condition\nctrl_1,control\nctrl_2,control\ntrt_1,treated\ntrt_2,treated\n",
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / "nfcore_handoff"
+    run_analysis(
+        counts_path=counts_path,
+        metadata_path=meta_path,
+        formula="~ condition",
+        contrast="condition,treated,control",
+        output_dir=out_dir,
+        backend="simple",
+    )
+    de_df = pd.read_csv(out_dir / "tables" / "de_results.csv")
+    assert set(de_df["gene"]) == {"ENSG0001", "ENSG0002", "ENSG0003"}
+    assert de_df["gene"].notna().all()


### PR DESCRIPTION
Fixes the first two defects in #365.

## Skill affected

rnaseq-de

## Summary

- Accept nf-core `gene_id` + `gene_name` count matrices by dropping the annotation column before numeric coercion.
- After `reset_index()`, rename the identifier column to `gene` even when the index was named. Fail closed if that column is missing or empty.
- Leave output-directory overwrite behavior and LFC shrinkage for follow-up. Those are defects 3 and 4 in the issue.

## Test output

```text
load_counts nfcore ok
named index gene column ok
missing gene fail closed ok
pytest -k 'not pydeseq2'  # new tests passed; result.json checks need the real clawbio.common.report helper
```