### PR TITLE
docs: require the reproducibility bundle in CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,8 @@ Tests must pass on Python 3.10, 3.11, and 3.12. CI runs all three via GitHub Act
 - **Naming**: Skill folders use lowercase-hyphens (`gwas-lookup`). Python files use lowercase_underscores (`gwas_lookup.py`).
 - **Imports**: Sibling modules loaded via `importlib.util.spec_from_file_location` — no package structure.
 - **CLI**: Every skill script accepts `--input`, `--output`, and `--demo`. Use `argparse`.
-- **Output**: Skills write to `<output_dir>/report.md` (primary), plus `figures/`, `tables/`, `reproducibility/` subdirectories as needed. Return a `result.json` with structured findings.
+- **Output**: Skills write to `<output_dir>/report.md` (primary), plus `figures/` and `tables/` subdirectories as needed. Return a `result.json` with structured findings.
+- **Reproducibility**: Every skill with a Python implementation writes `<output_dir>/reproducibility/` (`commands.sh`, `environment.yml`, `checksums.sha256`) using `clawbio.common.reproducibility` — `write_commands_sh`, `write_environment_yml`, `write_checksums`. Do not hand-roll these writers. Label checksums relative to the output directory (`anchor=output_dir`) so `cd <output_dir> && sha256sum -c reproducibility/checksums.sha256` resolves.
 - **Dependencies**: Add to `requirements.txt` for core deps. Skill-specific heavy deps go in the skill's SKILL.md YAML `install` section.
 
 ## Project Structure
@@ -118,12 +119,13 @@ Even skills without Python scripts are usable — an AI agent reads the SKILL.md
 2. **Copy the template**: `cp templates/SKILL-TEMPLATE.md skills/<your-skill-name>/SKILL.md`
 3. **Fill in SKILL.md**: Complete all YAML frontmatter fields and every Markdown section
 4. **Add Python implementation** (optional): Main script accepting `--input`, `--output`, `--demo`
-5. **Add demo data**: Include a small synthetic dataset for `--demo` mode
-6. **Add tests**: Create `tests/test_<name>.py` with at least demo-mode coverage
-7. **Register in `clawbio.py`**: Add an entry to the `SKILLS` dict with script path, demo_args, description, and allowed_extra_flags
-8. **Register in `pytest.ini`**: Add the test path to `testpaths`
-9. **Regenerate catalog**: `python scripts/generate_catalog.py`
-10. **Verify**: `python clawbio.py list` shows the skill; `python -m pytest` passes
+5. **Write the reproducibility bundle** (if step 4 applies): Call `clawbio.common.reproducibility` helpers so the run writes `<output_dir>/reproducibility/`, and keep that directory listed in the SKILL.md `## Output Structure` tree — do not prune it to make `TestOutputContract` pass
+6. **Add demo data**: Include a small synthetic dataset for `--demo` mode
+7. **Add tests**: Create `tests/test_<name>.py` with at least demo-mode coverage
+8. **Register in `clawbio.py`**: Add an entry to the `SKILLS` dict with script path, demo_args, description, and allowed_extra_flags
+9. **Register in `pytest.ini`**: Add the test path to `testpaths`
+10. **Regenerate catalog**: `python scripts/generate_catalog.py`
+11. **Verify**: `python clawbio.py list` shows the skill; `python -m pytest` passes
 
 ## How to Modify an Existing Skill
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -615,10 +615,14 @@ When a user wants to create a new skill:
    - `## Maintenance`: Review cadence, staleness signals, deprecation criteria.
 4. Add synthetic demo data (never real patient data) and `--demo` flag support
 5. **Write tests first (red/green TDD):** create `skills/<name>/tests/test_<name>.py` with tests for expected inputs, outputs, edge cases, and demo mode. Run them and confirm they fail.
-6. Add Python implementation to make the tests pass
+6. Add Python implementation to make the tests pass. Write the reproducibility
+   bundle with `clawbio.common.reproducibility` (`write_commands_sh`,
+   `write_environment_yml`, `write_checksums`) rather than hand-rolling it, and
+   keep `reproducibility/` listed in the SKILL.md `## Output Structure` tree —
+   do not prune it to make `TestOutputContract` pass.
 7. **Stress test** (run 10 times with varied inputs). Every correction becomes a Gotcha.
 8. Run full test suite: `pytest skills/<name>/tests/`
-9. **Self-audit**: Run the SKILL.md conformance checklist (17 checks). All must PASS before PR.
+9. **Self-audit**: Run the SKILL.md conformance checklist (18 checks). All must PASS before PR.
 10. Read `CONTRIBUTING.md` for naming conventions, code standards, and wanted skills list
 
 ### SKILL.md Conformance Checklist (must all PASS)
@@ -641,6 +645,7 @@ When a user wants to create a new skill:
 | Section: `## Agent Boundary` | Present |
 | File: demo data | At least one demo file |
 | File: tests/ | Directory with at least one test |
+| File: reproducibility bundle | Skill writes `<output_dir>/reproducibility/` via `clawbio.common.reproducibility`, and `## Output Structure` lists it |
 | Line count | SKILL.md under 500 lines |
 
 ## Safety Rules

--- a/commands/new-skill.md
+++ b/commands/new-skill.md
@@ -101,6 +101,10 @@ Create `skills/$SKILL_NAME/$SKILL_NAME_UNDERSCORE.py` with:
 - `run()` function that does the core work
 - Pathlib for all paths, no hardcoded paths
 - Output: `report.md` + `summary.json` minimum
+- Reproducibility bundle: write `<output_dir>/reproducibility/` with
+  `clawbio.common.reproducibility` (`write_commands_sh`, `write_environment_yml`,
+  `write_checksums` with `anchor=output_dir`). Do not hand-roll these writers,
+  and keep `reproducibility/` in the SKILL.md `## Output Structure` tree
 - ClawBio disclaimer in every report
 - Graceful error handling for bad input
 
@@ -122,7 +126,7 @@ Read and display the generated report to the user.
 
 ## Step 9: Self-Audit (Conformance Check)
 
-Run the 17-point SKILL.md conformance checklist against the new skill. Check each item:
+Run the 18-point SKILL.md conformance checklist against the new skill. Check each item:
 
 | Check | Requirement |
 |-------|------------|
@@ -142,6 +146,7 @@ Run the 17-point SKILL.md conformance checklist against the new skill. Check eac
 | Section: `## Agent Boundary` | Present |
 | File: demo data | At least one demo file |
 | File: tests/ | Directory with at least one test |
+| File: reproducibility bundle | Skill writes `<output_dir>/reproducibility/` via `clawbio.common.reproducibility`, and `## Output Structure` lists it |
 | Line count | SKILL.md under 500 lines |
 
 Report PASS/FAIL for each. Fix any failures before proceeding.


### PR DESCRIPTION
## Summary

- Adds an 18th check to the `CLAUDE.md` SKILL.md conformance checklist requiring a `reproducibility/` bundle written via `clawbio.common.reproducibility`, and updates the "(17 checks)" reference in step 9
- Rewrites the `AGENTS.md` Output bullet, which told agents skills write `reproducibility/` "as needed", into its own required bullet naming the three helpers and the `anchor=output_dir` convention, plus a bundle step in How to Add a New Skill
- Applies the same 18th check to the **second copy of the checklist** in `commands/new-skill.md`, which the `/new-skill` command reads, and adds the bundle to its Step 7 implementation requirements
- All three files now say not to prune `reproducibility/` from the SKILL.md `## Output Structure` tree to make `TestOutputContract` pass

Docs only. No skill code changes, no existing skill touched.

## Why

Part 1 of #372. 34 of 101 skills produce no reproducibility artefacts at all, and only 12 use the shared layer. This is not legacy debt: the shared layer landed 2026-04-12 and **18 of those 34 were created after it**, the most recent three weeks ago.

The root cause is that nothing required a bundle. The conformance checklist is the authoritative definition of a conforming skill and reproducibility appeared nowhere in its 17 checks — the only occurrence of the word in `CLAUDE.md` was the routing row for `repro-enforcer`. `AGENTS.md`, which is what non-Claude agents read, actively described the directory as optional.

The one real enforcement mechanism, `TestOutputContract`, parses the Output Structure tree and asserts every promised file exists after a `--demo` run. But its guidance — *"Keep the list honest: do not document outputs the skill does not always write"* — offers removal as the remedy, so for an author who never built a bundle, deleting the two `reproducibility/` lines is both the easiest fix and the documented-correct one. The test then passes vacuously. That instruction is right on its own terms; the problem is it was the only pressure in the system, so with no counterweight it pointed at deletion.

This PR supplies the counterweight. It does not touch the 34 skills or the 46 hand-rolled ones — those are tracked separately in #372.

### Note on checklist duplication

The conformance checklist is duplicated across `CLAUDE.md`, `commands/new-skill.md` and (as code) `scaffold_skill.py`. I initially updated only the first and caught the second on review; the third is updated in #374. `CONTRIBUTING.md` correctly defers to `CLAUDE.md` rather than keeping a fourth copy. That duplication is itself a drift risk and is tracked separately.

## Skill affected

None — repository-level agent instructions only.

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology) — n/a, no skill changed
- [x] Tests included and passing (`pytest -v`) — n/a, docs-only; suite run below to confirm no regression
- [x] Demo data included for reviewers to test — n/a
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

Docs-only change, so the verification that matters is that the checklist now parses to 18 rows and the AGENTS.md step list renumbers cleanly:

```
$ n=$(sed -n '/^### SKILL.md Conformance Checklist/,$p' CLAUDE.md | grep '^|' | grep -v '^|---\|^| Check |' | wc -l)
$ echo "checklist checks: $n"
checklist checks: 18

$ sed -n '/^## How to Add a New Skill/,/^## How to Modify/p' AGENTS.md | grep -oE '^[0-9]+\.' | tr -d '.' | tr '\n' ' '
1 2 3 4 5 6 7 8 9 10 11
```

Follow-up: the scaffolder change (`scaffold_skill.py` emitting working bundle code and `TestOutputContract` by default) is deliberately a separate PR, since this one is docs and that one is code with its own tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)