### PR TITLE
fix(nutrigx): correct rs4988235 lactose polarity and dominance

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -3040,7 +3040,7 @@
       "name": "nutrigx",
       "cli_alias": "nutrigx",
       "description": "Personalised nutrition report from consumer genetic data (23andMe, AncestryDNA, VCF) — interrogates nutritionally-relevant SNPs and generates actionable dietary guidance, all computed locally.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "status": "mvp",
       "maturity_tier": "ci-validated",
       "maturity_evidence": {

--- a/skills/nutrigx/SKILL.md
+++ b/skills/nutrigx/SKILL.md
@@ -132,7 +132,7 @@ The Bio Orchestrator should route to this skill when the user says anything like
 
 | Gene    | SNP        | Sensitivity          | Effect                          |
 |---------|------------|----------------------|---------------------------------|
-| MCM6    | rs4988235  | Lactose intolerance  | Non-persistence of lactase      |
+| MCM6    | rs4988235  | Lactose intolerance  | Risk allele G (GRCh38 plus / -13910C) is non-persistence; persistence allele A (-13910T) is dominant |
 | HLA-DQ2 | Proxy SNPs | Coeliac / gluten     | HLA-DQA1/DQB1 risk haplotypes   |
 
 ### Antioxidant & Detoxification
@@ -168,10 +168,14 @@ For each SNP in the panel:
 
 ### 3. Risk Scoring (`score_variants.py`)
 
-Each SNP is scored on a **0 / 0.5 / 1.0** scale:
+Each SNP is scored on a **0 / 0.5 / 1.0** scale by default:
 - `0.0` — homozygous reference (lowest risk)
 - `0.5` — heterozygous
 - `1.0` — homozygous risk allele
+
+Lactose (`rs4988235`) uses `inheritance: dominant_protective`. One copy of the
+persistence allele is enough, so AA and AG score as persistent (0.0) and only
+GG scores as non-persistence (1.0).
 
 Composite **Nutrient Risk Scores** (0–10) are computed per nutrient domain by
 summing weighted SNP scores. Weights are derived from reported effect sizes
@@ -313,6 +317,7 @@ Key literature underpinning the SNP panel and scoring algorithm:
 - Lecerf JM & de Lorgeril M (2011). Dietary cholesterol: from physiology to cardiovascular risk. *Br J Nutr*.
 - Tanaka T et al. (2009). Genome-wide association study of plasma polyunsaturated fatty acids in the InCHIANTI Study. *PLoS Genet* (FADS1/2).
 - Cornelis MC et al. (2006). Coffee, CYP1A2 genotype, and risk of myocardial infarction. *JAMA*.
+- Enattah NS et al. (2002). Identification of a variant associated with adult-type hypolactasia. *Nat Genet* 30:233–237. PMID 11788828.
 
 ---
 

--- a/skills/nutrigx/data/snp_panel.json
+++ b/skills/nutrigx/data/snp_panel.json
@@ -32,7 +32,7 @@
   {"rsid": "rs1229984", "gene": "ADH1B",  "ref_allele": "G", "risk_allele": "A", "nutrient_domain": "alcohol", "weight": 0.80, "effect_direction": "altered_acetaldehyde_accumulation", "pmid": "14685153"},
   {"rsid": "rs671",     "gene": "ALDH2",  "ref_allele": "G", "risk_allele": "A", "nutrient_domain": "alcohol", "weight": 0.90, "effect_direction": "impaired_acetaldehyde_clearance", "pmid": "12042820"},
 
-  {"rsid": "rs4988235", "gene": "MCM6",   "ref_allele": "G", "risk_allele": "A", "nutrient_domain": "lactose", "weight": 0.95, "effect_direction": "lactase_non_persistence", "pmid": "12369657"},
+  {"rsid": "rs4988235", "gene": "MCM6",   "ref_allele": "A", "risk_allele": "G", "nutrient_domain": "lactose", "weight": 0.95, "effect_direction": "lactase_non_persistence", "inheritance": "dominant_protective", "pmid": "11788828"},
 
   {"rsid": "rs4880",    "gene": "SOD2",   "ref_allele": "T", "risk_allele": "C", "nutrient_domain": "antioxidant", "weight": 0.55, "effect_direction": "decreased_mitochondrial_antioxidant", "pmid": "14607993"},
   {"rsid": "rs1050450", "gene": "GPX1",   "ref_allele": "C", "risk_allele": "T", "nutrient_domain": "antioxidant", "weight": 0.50, "effect_direction": "decreased_glutathione_peroxidase", "pmid": "11786716"},

--- a/skills/nutrigx/examples/generate_patient.py
+++ b/skills/nutrigx/examples/generate_patient.py
@@ -67,7 +67,7 @@ RISK_ALLELE_FREQS = {
     "rs4410790":  0.41,   # AHR
     "rs1229984":  0.05,   # ADH1B (mainly East Asian: ~0.70; European: ~0.05)
     "rs671":      0.00,   # ALDH2 (essentially absent in Europeans; ~0.30 East Asian)
-    "rs4988235":  0.35,   # MCM6 lactase non-persistence
+    "rs4988235":  0.35,   # MCM6 lactase non-persistence (G on GRCh38 plus)
     "rs4880":     0.47,   # SOD2
     "rs1050450":  0.28,   # GPX1
     "rs1800566":  0.22,   # NQO1
@@ -131,7 +131,7 @@ REF_ALLELES = {
     "rs4410790":  "C",
     "rs1229984":  "G",
     "rs671":      "G",
-    "rs4988235":  "G",
+    "rs4988235":  "A",
     "rs4880":     "T",
     "rs1050450":  "C",
     "rs1800566":  "C",
@@ -162,7 +162,7 @@ RISK_ALLELES = {
     "rs4410790":  "T",
     "rs1229984":  "A",
     "rs671":      "A",
-    "rs4988235":  "A",
+    "rs4988235":  "G",
     "rs4880":     "C",
     "rs1050450":  "T",
     "rs1800566":  "T",

--- a/skills/nutrigx/score_variants.py
+++ b/skills/nutrigx/score_variants.py
@@ -6,22 +6,30 @@ Each SNP contributes a weighted score; composite scores are 0–10.
 from collections import defaultdict
 
 
-def snp_raw_score(risk_count: int) -> float:
+def snp_raw_score(risk_count: int, inheritance: str = "additive") -> float:
     """
-    Convert risk allele count to a 0–1 dosage score.
-    0 copies → 0.0 (homozygous reference)
-    1 copy   → 0.5 (heterozygous)
-    2 copies → 1.0 (homozygous risk)
+    Convert risk allele count to a 0–1 score.
+
+    additive: 0 / 0.5 / 1.0 by copy number.
+    dominant_protective: any non-risk copy is protective (0.0 unless
+    homozygous for the risk allele). Used for lactase persistence at
+    rs4988235, where -13910T is dominant.
     """
     if risk_count is None:
         return None
-    dosage_map = {0: 0.0, 1: 0.5, 2: 1.0}
-    if risk_count not in dosage_map:
+    if risk_count not in (0, 1, 2):
         raise ValueError(
             f"Unexpected risk_count={risk_count!r}. "
             f"Expected 0, 1, 2, or None."
         )
-    return dosage_map[risk_count]
+    if inheritance == "dominant_protective":
+        return 1.0 if risk_count == 2 else 0.0
+    if inheritance not in ("additive", "", None):
+        raise ValueError(
+            f"Unexpected inheritance={inheritance!r}. "
+            f"Expected 'additive' or 'dominant_protective'."
+        )
+    return {0: 0.0, 1: 0.5, 2: 1.0}[risk_count]
 
 
 def compute_nutrient_risk_scores(snp_calls: dict, snp_panel: list) -> dict:
@@ -60,7 +68,10 @@ def compute_nutrient_risk_scores(snp_calls: dict, snp_panel: list) -> dict:
                 missing += 1
                 continue
 
-            raw = snp_raw_score(call["risk_count"])
+            raw = snp_raw_score(
+                call["risk_count"],
+                inheritance=panel_entry.get("inheritance", "additive"),
+            )
             if raw is None:
                 missing += 1
                 continue

--- a/skills/nutrigx/tests/test_nutrigx.py
+++ b/skills/nutrigx/tests/test_nutrigx.py
@@ -157,3 +157,48 @@ def test_empty_input_exits_cleanly(tmp_path):
     assert "ERROR" in result.stderr, (
         f"Should print ERROR message, got stderr: {result.stderr}"
     )
+
+
+def _lactose_score(genotype: str) -> dict:
+    panel = load_panel()
+    calls = extract_snp_genotypes({"rs4988235": genotype}, panel)
+    scores = compute_nutrient_risk_scores(calls, panel)
+    return {
+        "call": calls["rs4988235"],
+        "score": scores["lactose"],
+    }
+
+
+def test_rs4988235_panel_polarity_and_citation():
+    entry = next(s for s in load_panel() if s["rsid"] == "rs4988235")
+    assert entry["ref_allele"] == "A"
+    assert entry["risk_allele"] == "G"
+    assert entry["pmid"] == "11788828"
+    assert entry["inheritance"] == "dominant_protective"
+
+
+def test_rs4988235_aa_and_tt_are_persistent():
+    for genotype in ("AA", "TT"):
+        result = _lactose_score(genotype)
+        assert result["call"]["status"] == "found"
+        assert result["call"]["risk_count"] == 0
+        assert result["score"]["category"] == "Low"
+        assert result["score"]["score"] == 0.0
+
+
+def test_rs4988235_ag_and_ct_are_persistent_dominant():
+    for genotype in ("AG", "GA", "CT", "TC"):
+        result = _lactose_score(genotype)
+        assert result["call"]["status"] == "found"
+        assert result["call"]["risk_count"] == 1
+        assert result["score"]["category"] == "Low"
+        assert result["score"]["score"] == 0.0
+
+
+def test_rs4988235_gg_and_cc_are_non_persistent():
+    for genotype in ("GG", "CC"):
+        result = _lactose_score(genotype)
+        assert result["call"]["status"] == "found"
+        assert result["call"]["risk_count"] == 2
+        assert result["score"]["category"] == "Elevated"
+        assert result["score"]["score"] == 10.0


### PR DESCRIPTION
Fixes #237

## Summary
- Risk allele on GRCh38 plus is G (non-persistence), not A.
- PMID 11788828 replaces the unrelated 12369657.
- Lactase persistence is dominant, so heterozygotes score Low.

## Testing
- pytest skills/nutrigx/tests/test_nutrigx.py -k rs4988235  (4 passed)