### PR TITLE
fix(catalog): sync nutrigx version

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -3040,7 +3040,7 @@
       "name": "nutrigx",
       "cli_alias": "nutrigx",
       "description": "Personalised nutrition report from consumer genetic data (23andMe, AncestryDNA, VCF) — interrogates nutritionally-relevant SNPs and generates actionable dietary guidance, all computed locally.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "status": "mvp",
       "maturity_tier": "ci-validated",
       "maturity_evidence": {


### PR DESCRIPTION
Ready to merge from my side — all checks green.

**Why this is time-sensitive:** `main` currently has `skills/nutrigx/SKILL.md` at `0.2.0` while the checked-in `skills/catalog.json` still says `0.1.0`, so `tests/test_generate_catalog.py::test_checked_in_catalog_is_current` fails on every PR whose merge ref includes current `main` (reproduced on #366, #369, #370 before each was patched locally). Merging this one-line sync restores `main` consistency; the same change is already carried by the other open PRs, so they will not conflict.

I don't have merge rights on this repo, so a maintainer merge would be appreciated. 🙏