### PR TITLE
fix(rnaseq-de): verify LFC shrinkage matches the requested contrast

### DIFF
--- a/skills/rnaseq-de/rnaseq_de.py
+++ b/skills/rnaseq-de/rnaseq_de.py
@@ -6,6 +6,7 @@ import argparse
 import hashlib
 import math
 import sys
+import warnings
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -241,6 +242,9 @@ def de_simple(
     return result
 
 
+_LN2 = math.log(2)
+
+
 def _try_de_pydeseq2(
     counts: pd.DataFrame,
     metadata: pd.DataFrame,
@@ -250,6 +254,7 @@ def _try_de_pydeseq2(
     denominator: str,
 ) -> tuple[pd.DataFrame, dict[str, str | bool]] | None:
     try:
+        import pydeseq2
         from pydeseq2.dds import DeseqDataSet
         from pydeseq2.ds import DeseqStats
     except Exception:
@@ -282,25 +287,60 @@ def _try_de_pydeseq2(
             refit_cooks=True,
         )
 
-    dds.deseq2()
-    stats = DeseqStats(dds, contrast=[factor, numerator, denominator])
-    stats.summary()
+    try:
+        dds.deseq2()
+        stats = DeseqStats(dds, contrast=[factor, numerator, denominator])
+        stats.summary()
+    except Exception as exc:
+        # Some pydeseq2 releases crash inside their own machinery on valid
+        # input (e.g. 0.5.0/0.5.1 with recent anndata raise a bare IndexError
+        # in fit_genewise_dispersions). Surface why the backend died instead
+        # of letting an opaque internal traceback escape (issue #365).
+        raise RuntimeError(
+            f"The pydeseq2 backend failed (pydeseq2 "
+            f"{getattr(pydeseq2, '__version__', 'unknown')}): "
+            f"{type(exc).__name__}: {exc}. "
+            "If this persists, rerun with --backend simple for Welch-t "
+            "statistics instead of DESeq2."
+        ) from exc
+
     shrinkage = {
         "lfc_shrinkage_applied": False,
         "lfc_shrinkage_coeff": "",
         "lfc_shrinkage_note": "",
     }
+    # DeseqStats.lfc_shrink(coeff) REPLACES results_df["log2FoldChange"]
+    # with that single coefficient's column. That is only the requested
+    # contrast when the design's reference level is the contrast denominator
+    # and the coefficient is exactly factor[T.numerator]. Shrink only when
+    # both hold; otherwise publish the unshrunk Wald MLE for the requested
+    # contrast and say so loudly (issue #365, defect 4).
     coeff = _resolve_shrinkage_coeff(dds, factor, numerator)
-    if coeff:
+    if not coeff:
+        shrinkage["lfc_shrinkage_note"] = (
+            "No pydeseq2 coefficient exactly matches the requested contrast "
+            f"(expected '{factor}[T.{numerator}]' with '{denominator}' as the "
+            "reference level); publishing the unshrunk Wald MLE for the "
+            "requested contrast."
+        )
+        warnings.warn(shrinkage["lfc_shrinkage_note"], stacklevel=2)
+    elif not _coefficient_matches_contrast(stats, dds, coeff):
+        shrinkage["lfc_shrinkage_note"] = (
+            f"Resolved coefficient '{coeff}' does not reproduce the requested "
+            "contrast's MLE log2FoldChange; refusing LFC shrinkage and "
+            "publishing the unshrunk Wald MLE for the requested contrast."
+        )
+        warnings.warn(shrinkage["lfc_shrinkage_note"], stacklevel=2)
+    else:
         try:
             stats.lfc_shrink(coeff=coeff)
             shrinkage["lfc_shrinkage_applied"] = True
             shrinkage["lfc_shrinkage_coeff"] = coeff
         except Exception as exc:
             shrinkage["lfc_shrinkage_note"] = f"Attempted LFC shrinkage with '{coeff}' but failed: {exc}"
-    else:
-        shrinkage["lfc_shrinkage_note"] = "Could not identify a PyDESeq2 coefficient for LFC shrinkage."
-    res = _require_gene_column(stats.results_df.reset_index())
+    res = _require_gene_column(
+        stats.results_df.reset_index(), identifier_name=counts.index.name
+    )
     if "baseMean" not in res.columns:
         base_mean = (counts.div(counts.sum(axis=0), axis=1) * 1_000_000.0).mean(axis=1)
         res = res.merge(base_mean.rename("baseMean"), left_on="gene", right_index=True, how="left")
@@ -309,12 +349,15 @@ def _try_de_pydeseq2(
     return res[keep].sort_values("padj", ascending=True), shrinkage
 
 
-def _require_gene_column(results: pd.DataFrame) -> pd.DataFrame:
+def _require_gene_column(
+    results: pd.DataFrame, identifier_name: str | None = None
+) -> pd.DataFrame:
     """Return DE results with a non-empty `gene` column, or fail closed."""
     res = results.copy()
     if "gene" not in res.columns:
-        for name in (*_GENE_ID_COLUMNS, "index"):
-            if name in res.columns:
+        hints = (*_GENE_ID_COLUMNS, str(identifier_name) if identifier_name else None, "index")
+        for name in hints:
+            if name and name in res.columns:
                 res = res.rename(columns={name: "gene"})
                 break
     if "gene" not in res.columns:
@@ -328,19 +371,41 @@ def _require_gene_column(results: pd.DataFrame) -> pd.DataFrame:
 
 
 def _resolve_shrinkage_coeff(dds: object, factor: str, numerator: str) -> str:
+    """Return the LFC coefficient that is exactly ``factor[T.numerator]``.
+
+    Exact match only. Fuzzy suffix/substring matching can silently resolve a
+    *different level's* coefficient (e.g. levels 'A' and 'AB'), which
+    ``DeseqStats.lfc_shrink`` would then publish in place of the requested
+    contrast (issue #365). When the exact column is absent — meaning the
+    numerator is not a fitted non-reference level — return "" so the caller
+    keeps the unshrunk MLE for the requested contrast.
+    """
     lfc_table = getattr(getattr(dds, "varm", {}), "get", lambda *_args, **_kwargs: None)("LFC")
     columns = [str(col) for col in getattr(lfc_table, "columns", [])]
     preferred = f"{factor}[T.{numerator}]"
-    if preferred in columns:
-        return preferred
-    suffix = f"[T.{numerator}]"
-    for col in columns:
-        if col.startswith(f"{factor}[") and col.endswith(suffix):
-            return col
-    for col in columns:
-        if col != "Intercept" and col.startswith(f"{factor}[") and numerator in col:
-            return col
-    return ""
+    return preferred if preferred in columns else ""
+
+
+def _coefficient_matches_contrast(stats: object, dds: object, coeff: str) -> bool:
+    """True only if ``coeff``'s MLE column equals the requested contrast's MLE.
+
+    ``DeseqStats.lfc_shrink(coeff)`` replaces ``results_df["log2FoldChange"]``
+    with that single coefficient's column, so shrinking is safe only when the
+    column *is* the requested contrast. Comparing the two MLE vectors verifies
+    this against the fitted model itself, without depending on pydeseq2's
+    column-naming or reference-level conventions (issue #365, defect 4).
+    """
+    try:
+        lfc_table = dds.varm["LFC"]
+        coeff_mle = np.asarray(lfc_table[coeff], dtype=float) / _LN2
+        contrast_mle = np.asarray(stats.results_df["log2FoldChange"], dtype=float)
+        if coeff_mle.shape != contrast_mle.shape:
+            return False
+        return bool(
+            np.allclose(coeff_mle, contrast_mle, rtol=1e-6, atol=1e-8, equal_nan=True)
+        )
+    except Exception:
+        return False
 
 
 def run_de(

--- a/skills/rnaseq-de/tests/test_rnaseq_de.py
+++ b/skills/rnaseq-de/tests/test_rnaseq_de.py
@@ -2,13 +2,17 @@ import json
 import sys
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+import rnaseq_de
 from rnaseq_de import (
     _require_gene_column,
+    _resolve_shrinkage_coeff,
+    _try_de_pydeseq2,
     align_and_validate,
     compute_qc,
     de_simple,
@@ -205,3 +209,170 @@ def test_run_analysis_nfcore_counts_keep_gene_ids(tmp_path):
     de_df = pd.read_csv(out_dir / "tables" / "de_results.csv")
     assert set(de_df["gene"]) == {"ENSG0001", "ENSG0002", "ENSG0003"}
     assert de_df["gene"].notna().all()
+
+
+# ---------------------------------------------------------------------------
+# Issue #365, defect 4: the published log2FoldChange must reflect the
+# requested contrast. DeseqStats.lfc_shrink(coeff) replaces the published
+# LFC with a single coefficient's column, so shrinkage is only safe when
+# that coefficient *is* the requested contrast.
+# ---------------------------------------------------------------------------
+
+
+def _make_nb_dataset(
+    n_genes: int = 240,
+    per_group: int = 4,
+    de_fraction: float = 0.25,
+    seed: int = 41,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Negative-binomial counts with a known effect direction per gene."""
+    rng = np.random.default_rng(seed)
+    genes = [f"ENSG{i:06d}" for i in range(n_genes)]
+    base = rng.gamma(2.0, 60.0, size=n_genes)
+    # even genes up in treatment, odd genes down, the rest near-null via fraction
+    de = rng.random(n_genes) < de_fraction
+    up = de & (np.arange(n_genes) % 2 == 0)
+    down = de & (np.arange(n_genes) % 2 == 1)
+    lfc = np.zeros(n_genes)
+    lfc[up] = 2.5
+    lfc[down] = -2.5
+    samples = [f"ctrl_{i}" for i in range(per_group)] + [f"trt_{i}" for i in range(per_group)]
+    conds = ["control"] * per_group + ["treated"] * per_group
+    counts = np.zeros((n_genes, 2 * per_group))
+    for j, cond in enumerate(conds):
+        mu = base * (2 ** lfc if cond == "treated" else 1.0)
+        counts[:, j] = rng.negative_binomial(10, 10 / (10 + mu))
+    cts = pd.DataFrame(counts.astype(int), index=pd.Index(genes, name="gene_id"), columns=samples)
+    meta = pd.DataFrame({"condition": conds}, index=pd.Index(samples, name="sample_id"))
+    return cts, meta
+
+
+def test_pydeseq2_lfc_reflects_requested_contrast(tmp_path):
+    """End-to-end acceptance test from #365: nf-core native counts in, gene
+    column populated out, and published log2FoldChange tracking ratios of the
+    normalized group means (correlation near 1, not ~0.33)."""
+    pytest.importorskip("pydeseq2")
+    cts, meta = _make_nb_dataset()
+    counts_path = tmp_path / "salmon.merged.gene_counts.tsv"
+    nfcore = cts.reset_index()  # gene_id becomes the first column
+    nfcore.insert(1, "gene_name", [f"SYM{i}" for i in range(len(cts))])
+    nfcore.to_csv(counts_path, sep="\t", index=False)
+    meta_path = tmp_path / "design.csv"
+    meta.to_csv(meta_path)
+
+    out_dir = tmp_path / "out"
+    result = run_analysis(
+        counts_path=counts_path,
+        metadata_path=meta_path,
+        formula="~ condition",
+        contrast="condition,treated,control",
+        output_dir=out_dir,
+        backend="pydeseq2",
+    )
+    assert result["backend_used"] == "pydeseq2"
+
+    de_df = pd.read_csv(out_dir / "tables" / "de_results.csv")
+    norm = pd.read_csv(out_dir / "tables" / "normalized_counts.csv", index_col=0)
+    # defect 1+2 regression: identifiers survive the handoff
+    assert de_df["gene"].notna().all()
+    assert set(de_df["gene"]) <= set(cts.index)
+    assert len(de_df) > 100
+    # defect 4: published LFC tracks the normalized group-mean ratios
+    meta_groups = meta["condition"].reindex(norm.columns)
+    naive = (
+        np.log2(norm.loc[:, meta_groups == "treated"].mean(axis=1) + 1)
+        - np.log2(norm.loc[:, meta_groups == "control"].mean(axis=1) + 1)
+    )
+    published = de_df.set_index("gene")["log2FoldChange"].reindex(naive.index)
+    assert published.corr(naive) > 0.9
+    top5 = de_df.head(5)
+    assert (top5["log2FoldChange"].abs() > 0.5).all(), (
+        f"top genes by padj carry near-zero effect sizes: {list(top5['log2FoldChange'])}"
+    )
+
+
+def test_pydeseq2_refuses_shrinkage_on_mismatched_coefficient(monkeypatch):
+    """A resolved coefficient that is not the requested contrast must never
+    replace the published LFC, even if a (buggy or future) resolver hands one
+    back that exists in the fitted model."""
+    pytest.importorskip("pydeseq2")
+    rng = np.random.default_rng(17)
+    n_genes = 120
+    genes = [f"ENSG{i:06d}" for i in range(n_genes)]
+    base = rng.gamma(2.0, 60.0, size=n_genes)
+    lfc = np.where(np.arange(n_genes) % 2 == 0, 2.0, -2.0)  # trtA effect only
+    samples = (
+        [f"ctl_{i}" for i in range(4)]
+        + [f"trtA_{i}" for i in range(4)]
+        + [f"trtB_{i}" for i in range(4)]
+    )
+    conds = ["control"] * 4 + ["trtA"] * 4 + ["trtB"] * 4
+    counts = np.zeros((n_genes, 12))
+    for j, c in enumerate(conds):
+        mu = base * (2 ** lfc if c == "trtA" else 1.0)
+        counts[:, j] = rng.negative_binomial(10, 10 / (10 + mu))
+    cts = pd.DataFrame(counts.astype(int), index=pd.Index(genes, name="gene_id"), columns=samples)
+    meta = pd.DataFrame({"condition": conds}, index=pd.Index(samples, name="sample_id"))
+
+    # simulate a resolver that hands back the WRONG level's coefficient
+    monkeypatch.setattr(rnaseq_de, "_resolve_shrinkage_coeff", lambda dds, f, n: "condition[T.trtB]")
+    with pytest.warns(UserWarning, match="does not reproduce the requested contrast"):
+        res, shrinkage = _try_de_pydeseq2(cts, meta, ["condition"], "condition", "trtA", "control")
+
+    assert shrinkage["lfc_shrinkage_applied"] is False
+    assert "unshrunk Wald MLE" in shrinkage["lfc_shrinkage_note"]
+    # the published LFC is still the requested contrast (trtA vs control):
+    # even genes were designed up in trtA, odd genes down
+    by_gene = res.set_index("gene")["log2FoldChange"]
+    up_genes = [g for i, g in enumerate(genes) if i % 2 == 0]
+    down_genes = [g for i, g in enumerate(genes) if i % 2 == 1]
+    assert (by_gene.reindex(up_genes) > 0).mean() > 0.9
+    assert (by_gene.reindex(down_genes) < 0).mean() > 0.9
+
+
+def test_resolve_shrinkage_coeff_exact_match_only():
+    """The resolver must return '' rather than a substring-matching column
+    for a different level (the sign-flip trap from #365)."""
+    pytest.importorskip("pydeseq2")
+
+    class FakeLFC:
+        pass
+
+    fake_dds = FakeLFC()
+    fake_dds.varm = {
+        "LFC": pd.DataFrame(
+            columns=["Intercept", "condition[T.AB]"],
+            index=["g1", "g2"],
+        )
+    }
+    # numerator 'A' is the reference level here (no condition[T.A] column);
+    # 'A' is a substring of 'condition[T.AB]' and the old resolver fell for it
+    assert _resolve_shrinkage_coeff(fake_dds, "condition", "A") == ""
+    assert _resolve_shrinkage_coeff(fake_dds, "condition", "AB") == "condition[T.AB]"
+    assert _resolve_shrinkage_coeff(fake_dds, "condition", "missing") == ""
+
+
+def test_pydeseq2_internal_failure_is_reported_clearly(monkeypatch, tmp_path):
+    """A crash inside pydeseq2 must surface as a clear RuntimeError naming the
+    backend and the simple-backend escape hatch, not a bare IndexError."""
+    pytest.importorskip("pydeseq2")
+    from pydeseq2.dds import DeseqDataSet
+
+    def _boom(self):
+        raise IndexError("too many indices for array")
+
+    monkeypatch.setattr(DeseqDataSet, "deseq2", _boom)
+    cts, meta = _make_nb_dataset(n_genes=60)
+    counts_path = tmp_path / "counts.csv"
+    meta_path = tmp_path / "meta.csv"
+    cts.to_csv(counts_path)
+    meta.to_csv(meta_path)
+    with pytest.raises(RuntimeError, match="pydeseq2 backend failed.*--backend simple"):
+        run_analysis(
+            counts_path=counts_path,
+            metadata_path=meta_path,
+            formula="~ condition",
+            contrast="condition,treated,control",
+            output_dir=tmp_path / "out",
+            backend="pydeseq2",
+        )


### PR DESCRIPTION
Fixes defect 4 (the remaining silent one) of #365. Defects 1–2 were fixed in #371; defect 3 (rerun overwrite guard) stays as-is per that issue's own assessment that it is defensible.

## Skill affected

rnaseq-de

## Summary

**The mechanism, verified against pydeseq2 0.5.1–0.5.4 source:** `DeseqStats.lfc_shrink(coeff)` *replaces* `results_df["log2FoldChange"]` with that single coefficient's column. The published effect sizes are therefore only the requested contrast when the coefficient **is** that contrast — i.e. when the design's reference level is the contrast denominator and the column is exactly `factor[T.numerator]`. The skill relies on its re-leveling to guarantee this but never verified it, and the resolver's fallback loops matched by suffix/substring, which can resolve a **different level's** coefficient (e.g. levels `A`/`AB`) and silently publish a sign-flipped or near-null effect in place of the requested contrast.

Changes to `rnaseq_de.py`:

- `_resolve_shrinkage_coeff()` now returns a coefficient by **exact match only** (`factor[T.numerator]` present in `dds.varm["LFC"].columns`); the suffix and substring fallbacks are gone.
- New `_coefficient_matches_contrast()` guard: before shrinking, the candidate coefficient's MLE column must reproduce the requested contrast's MLE `log2FoldChange` (compared against the fitted model itself, so the check does not depend on pydeseq2's column-naming or reference-level conventions). If it doesn't — or no exact coefficient resolves — shrinkage is refused, the **unshrunk Wald MLE for the requested contrast** is published, and the reason is stated loudly: `warnings.warn` plus the existing `lfc_shrinkage_note` fields that already flow into `report.md` and `result.json` (`lfc_shrinkage_applied: false`).
- A crash inside pydeseq2's own machinery now surfaces as a clear `RuntimeError` naming the pydeseq2 version and the `--backend simple` escape hatch, instead of a bare internal traceback. Concretely: pydeseq2 0.5.0/0.5.1 with recent anndata raise a raw `IndexError` inside `fit_genewise_dispersions` on valid input; the same installed base behaves differently with older anndata, which is consistent with the version-dependent corruption reported in #365.
- `_require_gene_column()` accepts the input's identifier column name as a hint, so a count matrix whose first column is not one of the hardcoded gene-id spellings no longer fails only on the pydeseq2 path.

P-values, `baseMean`, output formats, and the simple backend are unchanged. On the standard path (re-leveling respected) shrinkage still applies exactly as before — `test_pydeseq2_reports_lfc_shrinkage` is untouched and still passes.

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology) — unchanged
- [x] Tests included and passing (`pytest -v`)
- [x] Demo data included for reviewers to test (not needed for this bug fix)
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) conventions

## Test output

New tests (17 total in the file, all passing on the CI-locked stack — pydeseq2 0.5.4, anndata 0.12.6, pandas 3.0.2 — and on pydeseq2 0.5.1/0.5.2/0.5.3):

- `test_pydeseq2_lfc_reflects_requested_contrast` — the acceptance test proposed in #365: feeds an nf-core-shaped `salmon.merged.gene_counts.tsv` (`gene_id` + `gene_name`) through `run_analysis(backend="pydeseq2")`, asserts gene identifiers survive, the published `log2FoldChange` correlates > 0.9 with log2 ratios of the normalized group means, and top-by-padj genes carry real effect sizes (not |LFC| < 0.05).
- `test_pydeseq2_refuses_shrinkage_on_mismatched_coefficient` — three-level factor, resolver monkeypatched to hand back the wrong level's coefficient: shrinkage refused with the loud note, and the published LFC still matches the requested contrast's direction.
- `test_resolve_shrinkage_coeff_exact_match_only` — regression for the substring trap: levels `A`/`AB` with `A` as reference must resolve to `""`, not `condition[T.AB]`.
- `test_pydeseq2_internal_failure_is_reported_clearly` — monkeypatched internal crash surfaces as `RuntimeError` naming the backend and `--backend simple`.

```text
$ pytest skills/rnaseq-de/tests/test_rnaseq_de.py -q
17 passed, 4 warnings in 5.74s
```

One honest caveat, in the spirit of the #360/#356 threads: I could not reproduce the reporter's exact corr ≈ 0.33 numbers on any pydeseq2 version reachable today (0.5.1–0.5.4 all publish correct LFCs on my synthetic and realistic-data runs when the re-leveling is respected; 0.5.0/0.5.1 with recent anndata crash loudly instead). What I could verify from source is that the published LFC after `lfc_shrink` is *unconditionally* the resolved coefficient's column, that nothing enforced the coefficient ≡ contrast invariant, and that the substring fallback is capable of resolving a wrong-level coefficient. This PR makes the invariant explicit and verified rather than accidental, which is the fix #365 asks for.
