### PR TITLE
feat(gwas-prs): add reproducibility bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
         run: uv run pytest skills/clinpgx/tests/test_clinpgx.py -v
 
       - name: Run GWAS PRS tests
-        run: uv run pytest skills/gwas-prs/tests/test_gwas_prs.py -v
+        run: uv run pytest skills/gwas-prs/tests/ -v
 
       - name: Run GWAS Lookup tests
         run: uv run pytest skills/gwas-lookup/tests/test_gwas_lookup.py -v

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -2265,7 +2265,7 @@
       "name": "gwas-prs",
       "cli_alias": "prs",
       "description": "Calculate polygenic risk scores from DTC genetic data using the PGS Catalog",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "status": "mvp",
       "maturity_tier": "ci-validated",
       "maturity_evidence": {

--- a/skills/gwas-prs/SKILL.md
+++ b/skills/gwas-prs/SKILL.md
@@ -3,7 +3,7 @@ name: gwas-prs
 description: Calculate polygenic risk scores from DTC genetic data using the PGS Catalog
 license: MIT
 metadata:
-  version: 0.1.0
+  version: 0.2.0
   openclaw:
     requires:
       bins:
@@ -111,14 +111,18 @@ When the user asks for a polygenic risk score calculation:
 
 ```
 output_directory/
-├── report.md              # Full narrative report with risk categories
-├── tables/
-│   └── scores.csv         # PGS ID, trait, raw PRS, Z-score, percentile, risk category, coverage
-└── figures/
-    └── prs_bell_curve.png # Bell curve with individual score marked (optional)
+├── prs_report.md          # Full narrative report with risk categories
+├── prs_results.json       # Compact per-score result records
+├── prs_variants.csv       # Per-variant dosage and contribution details
+├── result.json            # Standard ClawBio result envelope
+└── reproducibility/
+    ├── commands.sh        # Portable replay command
+    ├── environment.yml    # Rebuildable Python environment
+    ├── provenance.json    # Input and scoring-file hashes plus safe parameters
+    └── checksums.sha256   # Integrity digests for outputs and bundle metadata
 ```
 
-### report.md Format
+### prs_report.md Format
 
 The report includes:
 - Patient summary (file name, total SNPs, date)
@@ -127,7 +131,7 @@ The report includes:
 - Methodology notes and references
 - Safety disclaimer
 
-### `prs_results.json` identity fields
+### `prs_results.json` Fields
 
 | Column | Description |
 |---|---|
@@ -136,14 +140,41 @@ The report includes:
 | curated_panel_id | Canonical panel id when `curated_demo_panel` is true |
 | legacy_pgs_id | Historical accession once used for the bundled panel |
 | legacy_pgs_compatibility | True only for the pinned PGS000013 benchmark compatibility path |
+| curated_demo_panel | True when the scored file is a bundled ClawBio panel |
+| pgs_catalog_id | Catalog accession the panel derives from, or the scored PGS ID; null when none applies |
 | trait | Trait name |
-| raw_prs | Sum of dosage * weight |
+| raw_score | Sum of dosage * weight |
 | z_score | (PRS - mean) / SD |
 | percentile | Population percentile (0-100) |
 | risk_category | Low / Average / Elevated / High |
-| variants_matched | Number of variants found in patient file |
+| variants_used | Number of variants found in patient file |
 | variants_total | Total variants in scoring file |
-| coverage_pct | Percentage of variants matched |
+| overlap_fraction | Fraction of scoring variants matched |
+| method | Percentile estimation method |
+| reference_population | Population used for percentile context |
+
+### prs_variants.csv Columns
+
+`prs_variants.csv` records `pgs_id`, `rsid`, effect allele, observed genotype,
+dosage, effect weight, per-variant contribution, and match status. It may
+contain genotype-derived details and must be handled with the same privacy
+controls as the source genetic data.
+
+### Reproducibility Bundle
+
+The shared `clawbio.common.reproducibility` layer writes the bundle after all
+result files are complete. `provenance.json` stores the SHA-256 of the input and
+every scoring file actually used (with its `score_id`, nullable `pgs_id`,
+`curated_panel_id` and `legacy_pgs_id`), but omits the genotype path and
+contents. The selector is recorded in the order `gwas_prs.py` resolves it:
+`demo`, `panel_id`, `pgs_id` or `trait`. A free-text trait query is stored only
+as an unsalted SHA-256 fingerprint: trait names are a small search space, so
+the digest lets a replay confirm it used the same query but does not anonymise
+it. Non-demo `commands.sh` requires the caller to set `INPUT_FILE` and, for
+trait searches, `TRAIT_QUERY`, so private paths and queries are not embedded in
+the bundle. `environment.yml` declares `numpy` and `pandas` as well as
+`requests` and `opentelemetry-sdk` because importing `clawbio.common` loads
+them eagerly.
 
 ## Dependencies
 

--- a/skills/gwas-prs/gwas_prs.py
+++ b/skills/gwas-prs/gwas_prs.py
@@ -31,13 +31,18 @@ import requests
 # Shared library imports
 # ---------------------------------------------------------------------------
 
-_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-if str(_PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(_PROJECT_ROOT))
+_SKILL_DIR = Path(__file__).resolve().parent
+_PROJECT_ROOT = _SKILL_DIR.parent.parent
+for _import_path in (_PROJECT_ROOT, _SKILL_DIR):
+    if str(_import_path) not in sys.path:
+        sys.path.insert(0, str(_import_path))
 
-from clawbio.common.parsers import parse_genetic_file, genotypes_to_simple
-from clawbio.common.checksums import sha256_hex
-from clawbio.common.report import write_result_json, DISCLAIMER as _SHARED_DISCLAIMER
+from repro_bundle import create_reproducibility_bundle  # noqa: E402
+
+from clawbio.common.checksums import sha256_hex  # noqa: E402
+from clawbio.common.parsers import genotypes_to_simple, parse_genetic_file  # noqa: E402
+from clawbio.common.report import DISCLAIMER as _SHARED_DISCLAIMER  # noqa: E402
+from clawbio.common.report import write_result_json  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -58,7 +63,7 @@ RISK_CATEGORIES = [
     (100, "High"),
 ]
 
-SKILL_DIR = Path(__file__).resolve().parent
+SKILL_DIR = _SKILL_DIR
 DATA_DIR = SKILL_DIR / "data"
 
 # ---------------------------------------------------------------------------
@@ -1546,6 +1551,7 @@ def main():
             "percentile_info": pct_info,
             "metadata": metadata,
             "scoring_variants": scoring_variants,
+            "scoring_file_path": Path(filepath),
             "curated_demo_panel": curated,
             "curated_panel_id": score_id if curated else None,
             "legacy_pgs_id": curated_meta.get("legacy_pgs_id"),
@@ -1660,6 +1666,32 @@ def main():
             input_checksum=sha256_hex(str(input_path)) if input_path.exists() else "",
         )
         print(f"Result envelope written to {result_json_path}")
+
+        reproducibility_paths = create_reproducibility_bundle(
+            output_dir=output_dir,
+            input_path=input_path,
+            input_info=input_info,
+            scoring_files=[
+                {
+                    "score_id": result["score_id"],
+                    "pgs_id": result["pgs_id"],
+                    "trait": result["trait"],
+                    "filepath": result["scoring_file_path"],
+                    "curated_demo_panel": result["curated_demo_panel"],
+                    "curated_panel_id": result["curated_panel_id"],
+                    "legacy_pgs_id": result["legacy_pgs_id"],
+                    "legacy_pgs_compatibility": result["legacy_pgs_compatibility"],
+                    "pgs_catalog_id": result["pgs_catalog_id"],
+                }
+                for result in all_results
+            ],
+            args=args,
+            output_paths=[report_path, json_path, csv_path, result_json_path],
+        )
+        print(
+            "Reproducibility bundle written to "
+            f"{reproducibility_paths['commands'].parent}"
+        )
 
         print(f"\nFull output in {output_dir}/")
     else:

--- a/skills/gwas-prs/repro_bundle.py
+++ b/skills/gwas-prs/repro_bundle.py
@@ -1,0 +1,256 @@
+"""Shared reproducibility bundle integration for GWAS-PRS.
+
+The bundle records input and scoring-file digests without storing genotype
+paths or contents. Non-demo replay scripts require caller-supplied environment
+variables for private input paths and free-text trait queries.
+
+Score selection is recorded in the same order ``main()`` in ``gwas_prs.py``
+resolves it (``--demo``, then ``--panel-id``, then ``--pgs-id``, then
+``--trait``), so the replay command and ``provenance.json`` always describe the
+run that actually happened. The CLI rejects more than one selector, but the
+bundle does not rely on that: if the order in ``main()`` changes, change
+``_selection`` here in the same commit.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shlex
+import sys
+from collections.abc import Iterable
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from clawbio.common.checksums import sha256_file  # noqa: E402
+from clawbio.common.reproducibility import (  # noqa: E402
+    ReproCommand,
+    ReproPath,
+    write_checksums,
+    write_environment_yml,
+    write_portable_commands_sh,
+)
+from clawbio.common.textio import write_text_lf  # noqa: E402
+
+SCHEMA_VERSION = 1
+
+# Everything the replay environment must install before ``gwas_prs.py`` can
+# import. ``requests`` is imported by the skill itself. The other three arrive
+# through ``clawbio.common``: its package ``__init__`` imports ``audit``
+# (opentelemetry) and ``scrna_io`` (numpy, pandas) eagerly, so any skill that
+# imports ``clawbio.common.checksums`` pays for them even though this skill
+# never calls them. Verified by running ``--demo`` in a clean interpreter with
+# only ``requests`` and ``opentelemetry-sdk`` installed: it fails on
+# ``import numpy``. ``scipy`` and ``matplotlib`` are optional at runtime and
+# are deliberately not declared.
+REPLAY_PIP_DEPENDENCIES: tuple[str, ...] = (
+    "requests>=2.31",
+    "opentelemetry-sdk>=1.20,<2",
+    "numpy>=1.24",
+    "pandas>=2.0",
+)
+
+_VERSION_LINE = re.compile(r"^\s*version:\s*['\"]?([0-9]+\.[0-9]+\.[0-9]+)['\"]?\s*$")
+
+
+def _read_skill_version() -> str:
+    """The ``metadata.version`` declared in this skill's SKILL.md frontmatter.
+
+    Matches the first ``version:`` key inside the leading ``---`` block at any
+    indentation, so a re-indented frontmatter does not break import.
+    """
+    text = (Path(__file__).with_name("SKILL.md")).read_text(encoding="utf-8")
+    in_frontmatter = False
+    for line in text.splitlines():
+        if line.strip() == "---":
+            if in_frontmatter:
+                break
+            in_frontmatter = True
+            continue
+        if not in_frontmatter:
+            continue
+        match = _VERSION_LINE.match(line)
+        if match:
+            return match.group(1)
+    raise RuntimeError("gwas-prs SKILL.md does not declare metadata.version")
+
+
+TOOL_VERSION = _read_skill_version()
+
+
+def create_reproducibility_bundle(
+    *,
+    output_dir: Path | str,
+    input_path: Path | str,
+    input_info: dict[str, Any],
+    scoring_files: list[dict[str, Any]],
+    args: Any,
+    output_paths: Iterable[Path | str],
+) -> dict[str, Path]:
+    """Write commands, environment, provenance, and checksum artefacts."""
+
+    output_dir = Path(output_dir)
+    input_path = Path(input_path)
+
+    commands_path = write_portable_commands_sh(
+        output_dir,
+        _repro_command(args, output_dir),
+        repo_root=None,
+    )
+    environment_path = write_environment_yml(
+        output_dir,
+        env_name="clawbio-gwas-prs",
+        pip_deps=list(REPLAY_PIP_DEPENDENCIES),
+        python_version="3.11",
+    )
+
+    provenance_path = output_dir / "reproducibility" / "provenance.json"
+    provenance = {
+        "schema_version": SCHEMA_VERSION,
+        "tool": {"name": "ClawBio GWAS-PRS", "version": TOOL_VERSION},
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "input": {
+            "sha256": sha256_file(input_path),
+            "format": str(input_info.get("format", "unknown")),
+            "total_snps": int(input_info.get("total_snps", 0)),
+        },
+        "parameters": _safe_parameters(args),
+        "scoring_files": [
+            _scoring_file_provenance(item)
+            for item in sorted(
+                scoring_files,
+                key=lambda item: (
+                    str(item.get("score_id") or item.get("pgs_id") or ""),
+                    Path(item["filepath"]).name,
+                ),
+            )
+        ],
+    }
+    write_text_lf(provenance_path, json.dumps(provenance, indent=2) + "\n")
+
+    checksum_targets = [
+        *(Path(path) for path in output_paths),
+        commands_path,
+        environment_path,
+        provenance_path,
+    ]
+    checksums_path = write_checksums(
+        checksum_targets,
+        output_dir,
+        anchor=output_dir,
+    )
+    return {
+        "commands": commands_path,
+        "environment": environment_path,
+        "provenance": provenance_path,
+        "checksums": checksums_path,
+    }
+
+
+def _selection(args: Any) -> tuple[str, str | None]:
+    """Which selector ``main()`` acted on, in ``main()``'s own precedence.
+
+    Returns ``(mode, value)``: ``("demo", None)``, ``("panel_id", id)``,
+    ``("pgs_id", id)`` or ``("trait", query)``.
+    """
+    if bool(args.demo):
+        return "demo", None
+    if args.panel_id:
+        return "panel_id", str(args.panel_id)
+    if args.pgs_id:
+        return "pgs_id", str(args.pgs_id)
+    if args.trait:
+        return "trait", str(args.trait)
+    raise ValueError("no score selector set: expected --demo, --panel-id, --pgs-id or --trait")
+
+
+def _repro_command(args: Any, output_dir: Path) -> ReproCommand:
+    command_args: list[str | ReproPath] = []
+    preflight: list[str] = []
+    mode, value = _selection(args)
+    if mode == "demo":
+        command_args.append("--demo")
+    else:
+        preflight.append(
+            ': "${INPUT_FILE:?Set INPUT_FILE to the genotype file used for this run}"'
+        )
+        command_args.extend(["--input", '"${INPUT_FILE}"'])
+        if mode == "panel_id":
+            command_args.extend(["--panel-id", shlex.quote(str(value))])
+        elif mode == "pgs_id":
+            command_args.extend(["--pgs-id", shlex.quote(str(value))])
+        else:
+            preflight.append(
+                ': "${TRAIT_QUERY:?Set TRAIT_QUERY to the trait used for this run}"'
+            )
+            command_args.extend(["--trait", '"${TRAIT_QUERY}"'])
+
+    command_args.extend(
+        [
+            "--output",
+            ReproPath(output_dir, anchor="output_dir"),
+            "--min-overlap",
+            str(args.min_overlap),
+            "--max-variants",
+            str(args.max_variants),
+            "--build",
+            str(args.build),
+            "--cache-dir",
+            '"${PGS_CACHE_DIR:-$HOME/.clawbio/pgs_cache}"',
+        ]
+    )
+    if bool(args.no_cache):
+        command_args.append("--no-cache")
+    return ReproCommand(
+        script_path=Path("skills/gwas-prs/gwas_prs.py"),
+        args=command_args,
+        comment="Replay this ClawBio GWAS-PRS run",
+        preflight=preflight,
+    )
+
+
+def _safe_parameters(args: Any) -> dict[str, Any]:
+    mode, value = _selection(args)
+    selection: dict[str, Any] = {"mode": mode}
+    if mode == "panel_id":
+        selection["panel_id"] = value
+    elif mode == "pgs_id":
+        selection["pgs_id"] = value
+    elif mode == "trait":
+        # A fingerprint, not anonymisation: trait names are a small search
+        # space, so this digest only lets a replay confirm it used the same
+        # query without the query itself being written into the bundle.
+        selection["query_sha256"] = _hash_text(str(value))
+    return {
+        "selection": selection,
+        "build": str(args.build),
+        "min_overlap": float(args.min_overlap),
+        "max_variants": int(args.max_variants),
+        "cache_enabled": not bool(args.no_cache),
+    }
+
+
+def _scoring_file_provenance(item: dict[str, Any]) -> dict[str, Any]:
+    path = Path(item["filepath"])
+    pgs_id = item.get("pgs_id")
+    return {
+        "score_id": str(item.get("score_id") or pgs_id or ""),
+        "pgs_id": None if pgs_id is None else str(pgs_id),
+        "filename": path.name,
+        "sha256": sha256_file(path),
+        "curated_demo_panel": bool(item.get("curated_demo_panel")),
+        "curated_panel_id": item.get("curated_panel_id"),
+        "legacy_pgs_id": item.get("legacy_pgs_id"),
+        "legacy_pgs_compatibility": bool(item.get("legacy_pgs_compatibility")),
+        "pgs_catalog_id": item.get("pgs_catalog_id"),
+    }
+
+
+def _hash_text(value: str) -> str:
+    return f"sha256:{hashlib.sha256(value.encode('utf-8')).hexdigest()}"

--- a/skills/gwas-prs/tests/test_repro_bundle.py
+++ b/skills/gwas-prs/tests/test_repro_bundle.py
@@ -1,0 +1,490 @@
+"""Tests for the GWAS-PRS shared reproducibility bundle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+PROJECT_ROOT = SKILL_DIR.parents[1]
+sys.path.insert(0, str(SKILL_DIR))
+sys.path.insert(0, str(PROJECT_ROOT))
+
+import repro_bundle  # noqa: E402
+
+from clawbio.common.checksums import sha256_file  # noqa: E402
+
+
+def args_for(
+    output_dir: Path,
+    input_path: Path,
+    *,
+    demo: bool = False,
+    trait: str | None = None,
+    pgs_id: str | None = None,
+    panel_id: str | None = None,
+):
+    """Mirror the argparse.Namespace ``gwas_prs.main()`` builds."""
+    if not demo and not any([trait, pgs_id, panel_id]):
+        trait = "type 2 diabetes"
+    return argparse.Namespace(
+        demo=demo,
+        input=str(input_path),
+        trait=trait,
+        pgs_id=pgs_id,
+        panel_id=panel_id,
+        output=str(output_dir),
+        min_overlap=0.5,
+        max_variants=50000,
+        build="GRCh37",
+        no_cache=False,
+        cache_dir="/private/cache/path",
+    )
+
+
+def make_run(
+    tmp_path: Path,
+    *,
+    demo: bool = False,
+    trait: str | None = None,
+    pgs_id: str | None = None,
+    panel_id: str | None = None,
+    scoring_files: list[dict] | None = None,
+):
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    input_path = tmp_path / "patient-jane-doe.txt"
+    input_path.write_text("synthetic genotype content\n", encoding="utf-8")
+    scoring_path = tmp_path / "CLAWBIO-T2D-8_GRCh37.txt"
+    scoring_path.write_text("synthetic scoring content\n", encoding="utf-8")
+
+    output_paths = []
+    for name, content in (
+        ("prs_report.md", "report\n"),
+        ("prs_results.json", "[]\n"),
+        ("prs_variants.csv", "header\n"),
+        ("result.json", "{}\n"),
+    ):
+        path = output_dir / name
+        path.write_text(content, encoding="utf-8")
+        output_paths.append(path)
+
+    args = args_for(
+        output_dir, input_path, demo=demo, trait=trait, pgs_id=pgs_id, panel_id=panel_id,
+    )
+    if scoring_files is None:
+        scoring_files = [
+            {
+                "score_id": "CLAWBIO-T2D-8",
+                "pgs_id": None,
+                "trait": "Type 2 diabetes",
+                "filepath": scoring_path,
+                "curated_demo_panel": True,
+                "curated_panel_id": "CLAWBIO-T2D-8",
+                "legacy_pgs_id": "PGS000013",
+                "legacy_pgs_compatibility": False,
+                "pgs_catalog_id": None,
+            }
+        ]
+    paths = repro_bundle.create_reproducibility_bundle(
+        output_dir=output_dir,
+        input_path=input_path,
+        input_info={"format": "23andme", "total_snps": 1},
+        scoring_files=scoring_files,
+        args=args,
+        output_paths=output_paths,
+    )
+    return output_dir, input_path, scoring_path, paths
+
+
+def flat(commands: str) -> str:
+    return commands.replace(" \\\n  ", " ")
+
+
+def test_bundle_uses_the_shared_reproducibility_layer(tmp_path) -> None:
+    output_dir, _input_path, _scoring_path, paths = make_run(tmp_path)
+
+    assert paths == {
+        "commands": output_dir / "reproducibility" / "commands.sh",
+        "environment": output_dir / "reproducibility" / "environment.yml",
+        "provenance": output_dir / "reproducibility" / "provenance.json",
+        "checksums": output_dir / "reproducibility" / "checksums.sha256",
+    }
+    assert repro_bundle.write_checksums.__module__ == ("clawbio.common.reproducibility")
+    assert repro_bundle.write_environment_yml.__module__ == (
+        "clawbio.common.reproducibility"
+    )
+    assert repro_bundle.write_portable_commands_sh.__module__ == (
+        "clawbio.common.reproducibility"
+    )
+
+
+def test_provenance_contains_hashes_without_private_paths_or_raw_input(
+    tmp_path,
+) -> None:
+    _output_dir, input_path, scoring_path, paths = make_run(tmp_path)
+
+    provenance = json.loads(paths["provenance"].read_text(encoding="utf-8"))
+    serialized = json.dumps(provenance, sort_keys=True)
+
+    assert provenance["input"] == {
+        "sha256": sha256_file(input_path),
+        "format": "23andme",
+        "total_snps": 1,
+    }
+    assert provenance["scoring_files"] == [
+        {
+            "score_id": "CLAWBIO-T2D-8",
+            "pgs_id": None,
+            "filename": scoring_path.name,
+            "sha256": sha256_file(scoring_path),
+            "curated_demo_panel": True,
+            "curated_panel_id": "CLAWBIO-T2D-8",
+            "legacy_pgs_id": "PGS000013",
+            "legacy_pgs_compatibility": False,
+            "pgs_catalog_id": None,
+        }
+    ]
+    assert provenance["parameters"]["selection"] == {
+        "mode": "trait",
+        "query_sha256": ("sha256:" + hashlib.sha256(b"type 2 diabetes").hexdigest()),
+    }
+    assert str(tmp_path) not in serialized
+    assert input_path.name not in serialized
+    assert "synthetic genotype content" not in serialized
+    assert "type 2 diabetes" not in serialized
+    assert "/private/cache/path" not in serialized
+
+
+def test_provenance_keeps_a_null_pgs_id_null(tmp_path) -> None:
+    """Curated panels carry ``pgs_id: None``; it must not become the string
+    "None" (which it did before ``score_id`` was threaded through)."""
+    _output_dir, _input_path, _scoring_path, paths = make_run(tmp_path, demo=True)
+
+    provenance = json.loads(paths["provenance"].read_text(encoding="utf-8"))
+    assert provenance["scoring_files"][0]["pgs_id"] is None
+    assert '"None"' not in paths["provenance"].read_text(encoding="utf-8")
+
+
+def test_provenance_sorts_scoring_files_by_score_id(tmp_path) -> None:
+    scoring_files = []
+    for score_id in ("CLAWBIO-T2D-8", "CLAWBIO-AF-12", "PGS000031"):
+        path = tmp_path / f"{score_id}_GRCh37.txt"
+        path.write_text(f"{score_id}\n", encoding="utf-8")
+        scoring_files.append({
+            "score_id": score_id,
+            "pgs_id": score_id if score_id.startswith("PGS") else None,
+            "filepath": path,
+        })
+    _output_dir, _input_path, _scoring_path, paths = make_run(
+        tmp_path, demo=True, scoring_files=scoring_files,
+    )
+    provenance = json.loads(paths["provenance"].read_text(encoding="utf-8"))
+    assert [item["score_id"] for item in provenance["scoring_files"]] == [
+        "CLAWBIO-AF-12", "CLAWBIO-T2D-8", "PGS000031",
+    ]
+
+
+def test_environment_declares_every_eager_runtime_dependency(tmp_path) -> None:
+    _output_dir, _input_path, _scoring_path, paths = make_run(tmp_path)
+
+    environment = paths["environment"].read_text(encoding="utf-8")
+
+    for dependency in repro_bundle.REPLAY_PIP_DEPENDENCIES:
+        assert dependency in environment
+    assert set(repro_bundle.REPLAY_PIP_DEPENDENCIES) == {
+        "requests>=2.31",
+        "opentelemetry-sdk>=1.20,<2",
+        "numpy>=1.24",
+        "pandas>=2.0",
+    }
+
+
+def test_numpy_and_pandas_really_are_eager_imports() -> None:
+    """The skill never calls numpy or pandas, but importing ``clawbio.common``
+    (for checksums and the reproducibility layer) loads its package
+    ``__init__``, which imports ``scrna_io`` and therefore both libraries.
+    If this ever stops being true, drop them from REPLAY_PIP_DEPENDENCIES."""
+    assert "clawbio.common" in sys.modules
+    assert "numpy" in sys.modules
+    assert "pandas" in sys.modules
+    assert "opentelemetry" in sys.modules
+
+
+def test_commands_are_portable_and_require_input_file(tmp_path) -> None:
+    _output_dir, input_path, _scoring_path, paths = make_run(tmp_path)
+
+    commands = paths["commands"].read_text(encoding="utf-8")
+    flat_commands = flat(commands)
+
+    assert "CLAWBIO_ROOT:=/path/to/ClawBio" in commands
+    assert '"$CLAWBIO_ROOT/skills/gwas-prs/gwas_prs.py"' in commands
+    assert (
+        "${INPUT_FILE:?Set INPUT_FILE to the genotype file used for this run}"
+        in commands
+    )
+    assert "${TRAIT_QUERY:?Set TRAIT_QUERY to the trait used for this run}" in commands
+    assert '--input "${INPUT_FILE}"' in flat_commands
+    assert '--trait "${TRAIT_QUERY}"' in flat_commands
+    assert '--output "$OUTPUT_DIR"' in flat_commands
+    assert '"${PGS_CACHE_DIR:-$HOME/.clawbio/pgs_cache}"' in flat_commands
+    assert "type 2 diabetes" not in commands
+    assert str(tmp_path) not in commands
+    assert input_path.name not in commands
+
+
+def test_demo_command_needs_no_private_input_path(tmp_path) -> None:
+    _output_dir, _input_path, _scoring_path, paths = make_run(tmp_path, demo=True)
+
+    commands = paths["commands"].read_text(encoding="utf-8")
+
+    assert "--demo" in commands
+    assert "INPUT_FILE" not in commands
+    assert "--trait" not in commands
+    assert "--pgs-id" not in commands
+    assert "--panel-id" not in commands
+
+
+def test_pgs_id_is_shell_quoted_in_replay_command(tmp_path) -> None:
+    _output_dir, _input_path, _scoring_path, paths = make_run(
+        tmp_path,
+        pgs_id="PGS000013; echo unsafe",
+    )
+
+    commands = paths["commands"].read_text(encoding="utf-8")
+
+    assert "--pgs-id 'PGS000013; echo unsafe'" in flat(commands)
+    provenance = json.loads(paths["provenance"].read_text(encoding="utf-8"))
+    assert provenance["parameters"]["selection"] == {
+        "mode": "pgs_id",
+        "pgs_id": "PGS000013; echo unsafe",
+    }
+
+
+def test_panel_id_run_replays_the_panel_and_records_it(tmp_path) -> None:
+    """``--panel-id`` (added in #380) is the normal way to score a bundled
+    panel; the bundle must replay and record it rather than fall through."""
+    _output_dir, _input_path, _scoring_path, paths = make_run(
+        tmp_path, panel_id="CLAWBIO-T2D-8",
+    )
+
+    commands = paths["commands"].read_text(encoding="utf-8")
+    flat_commands = flat(commands)
+    assert "--panel-id CLAWBIO-T2D-8" in flat_commands
+    assert "--pgs-id" not in flat_commands
+    assert "--trait" not in flat_commands
+    assert "TRAIT_QUERY" not in commands
+    assert '--input "${INPUT_FILE}"' in flat_commands
+
+    provenance = json.loads(paths["provenance"].read_text(encoding="utf-8"))
+    assert provenance["parameters"]["selection"] == {
+        "mode": "panel_id",
+        "panel_id": "CLAWBIO-T2D-8",
+    }
+
+
+@pytest.mark.parametrize(
+    "selectors, expected_mode, expected_flag",
+    [
+        # main() resolves --demo, then --panel-id, then --pgs-id, then --trait.
+        # The CLI rejects more than one selector, but the bundle must not
+        # depend on that: whichever branch main() would take is the one the
+        # replay command and provenance must describe.
+        ({"demo": True, "panel_id": "CLAWBIO-T2D-8", "pgs_id": "PGS000031", "trait": "t2d"},
+         "demo", "--demo"),
+        ({"panel_id": "CLAWBIO-T2D-8", "pgs_id": "PGS000031", "trait": "t2d"},
+         "panel_id", "--panel-id CLAWBIO-T2D-8"),
+        ({"pgs_id": "PGS000031", "trait": "t2d"}, "pgs_id", "--pgs-id PGS000031"),
+        ({"trait": "t2d"}, "trait", '--trait "${TRAIT_QUERY}"'),
+    ],
+)
+def test_selection_precedence_mirrors_main(
+    tmp_path, selectors, expected_mode, expected_flag,
+) -> None:
+    _output_dir, _input_path, _scoring_path, paths = make_run(tmp_path, **selectors)
+
+    provenance = json.loads(paths["provenance"].read_text(encoding="utf-8"))
+    assert provenance["parameters"]["selection"]["mode"] == expected_mode
+
+    flat_commands = flat(paths["commands"].read_text(encoding="utf-8"))
+    assert expected_flag in flat_commands
+    for other in ("--demo", "--panel-id", "--pgs-id", "--trait"):
+        if not expected_flag.startswith(other):
+            assert other not in flat_commands, other
+
+
+def test_selection_precedence_matches_the_order_in_main_source() -> None:
+    """Pin the precedence to ``gwas_prs.py`` itself: the ``if/elif`` chain in
+    ``main()`` must test the selectors in the same order ``_selection`` does."""
+    source = (SKILL_DIR / "gwas_prs.py").read_text(encoding="utf-8")
+    main_body = source[source.index("def main():"):]
+    order_in_main = [
+        name
+        for name, _pos in sorted(
+            (
+                (name, main_body.index(f"{keyword} args.{name}:"))
+                for name, keyword in (
+                    ("demo", "if"), ("panel_id", "elif"), ("pgs_id", "elif"), ("trait", "elif"),
+                )
+            ),
+            key=lambda item: item[1],
+        )
+    ]
+    bundle_source = (SKILL_DIR / "repro_bundle.py").read_text(encoding="utf-8")
+    selection_body = bundle_source[bundle_source.index("def _selection("):]
+    order_in_bundle = [
+        name
+        for name, _pos in sorted(
+            ((name, selection_body.index(f"args.{name}")) for name in order_in_main),
+            key=lambda item: item[1],
+        )
+    ]
+    assert order_in_main == ["demo", "panel_id", "pgs_id", "trait"]
+    assert order_in_bundle == order_in_main
+
+
+def test_no_selector_is_an_error_not_a_silent_pgs_id_of_none(tmp_path) -> None:
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    args = args_for(output_dir, tmp_path / "in.txt")
+    args.trait = None
+    with pytest.raises(ValueError, match="no score selector"):
+        repro_bundle._safe_parameters(args)
+
+
+def test_checksum_manifest_covers_outputs_and_bundle_metadata(tmp_path) -> None:
+    output_dir, _input_path, _scoring_path, paths = make_run(tmp_path)
+
+    entries = {}
+    for line in paths["checksums"].read_text(encoding="utf-8").splitlines():
+        digest, label = line.split("  ", 1)
+        entries[label] = digest
+
+    expected = {
+        "prs_report.md",
+        "prs_results.json",
+        "prs_variants.csv",
+        "result.json",
+        "reproducibility/commands.sh",
+        "reproducibility/environment.yml",
+        "reproducibility/provenance.json",
+    }
+    assert set(entries) == expected
+    for label, digest in entries.items():
+        assert digest == sha256_file(output_dir / label)
+
+
+def test_bundle_text_files_use_lf_line_endings(tmp_path) -> None:
+    _output_dir, _input_path, _scoring_path, paths = make_run(tmp_path)
+
+    for path in paths.values():
+        assert b"\r" not in path.read_bytes(), path
+
+
+def test_demo_cli_writes_the_documented_output_contract(tmp_path) -> None:
+    output_dir = tmp_path / "demo"
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(SKILL_DIR / "gwas_prs.py"),
+            "--demo",
+            "--output",
+            str(output_dir),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    expected = {
+        "prs_report.md",
+        "prs_results.json",
+        "prs_variants.csv",
+        "result.json",
+        "reproducibility/commands.sh",
+        "reproducibility/environment.yml",
+        "reproducibility/provenance.json",
+        "reproducibility/checksums.sha256",
+    }
+    actual = {
+        path.relative_to(output_dir).as_posix()
+        for path in output_dir.rglob("*")
+        if path.is_file()
+    }
+    assert actual == expected
+
+    results = json.loads((output_dir / "prs_results.json").read_text(encoding="utf-8"))
+    assert set(results[0]) == {
+        "score_id",
+        "pgs_id",
+        "curated_panel_id",
+        "legacy_pgs_id",
+        "legacy_pgs_compatibility",
+        "curated_demo_panel",
+        "pgs_catalog_id",
+        "trait",
+        "raw_score",
+        "variants_used",
+        "variants_total",
+        "overlap_fraction",
+        "percentile",
+        "risk_category",
+        "z_score",
+        "method",
+        "reference_population",
+    }
+
+    skill_text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    for path in expected:
+        assert path.split("/", 1)[-1] in skill_text
+    for field in results[0]:
+        assert f"| {field} |" in skill_text, field
+    assert "tables/scores.csv" not in skill_text
+
+    provenance = json.loads(
+        (output_dir / "reproducibility" / "provenance.json").read_text(encoding="utf-8")
+    )
+    assert provenance["parameters"]["selection"] == {"mode": "demo"}
+    assert {item["score_id"] for item in provenance["scoring_files"]} == {
+        result["score_id"] for result in results
+    }
+    assert all(item["pgs_id"] is None for item in provenance["scoring_files"])
+
+
+def test_version_and_ci_contracts_stay_in_sync() -> None:
+    frontmatter = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8").split("---", 2)[1]
+    declared = re.search(r"^\s*version:\s*(\S+)\s*$", frontmatter, re.MULTILINE)
+    assert declared is not None
+    catalog = json.loads(
+        (PROJECT_ROOT / "skills" / "catalog.json").read_text(encoding="utf-8")
+    )
+    catalog_entry = next(
+        item for item in catalog["skills"] if item["name"] == "gwas-prs"
+    )
+    workflow = (PROJECT_ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert re.fullmatch(r"\d+\.\d+\.\d+", repro_bundle.TOOL_VERSION)
+    assert repro_bundle.TOOL_VERSION == declared.group(1)
+    assert catalog_entry["version"] == repro_bundle.TOOL_VERSION
+    assert "uv run pytest skills/gwas-prs/tests/ -v" in workflow
+
+
+def test_skill_version_parser_tolerates_reindented_frontmatter(tmp_path, monkeypatch) -> None:
+    skill_md = tmp_path / "SKILL.md"
+    skill_md.write_text(
+        "---\nname: gwas-prs\nmetadata:\n    version: 9.9.9\n---\n# body\nversion: 0.0.0\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(repro_bundle, "__file__", str(tmp_path / "repro_bundle.py"))
+    assert repro_bundle._read_skill_version() == "9.9.9"


### PR DESCRIPTION
## Summary

- Add a reproducibility bundle to `gwas-prs` using the shared `clawbio.common.reproducibility` layer.
- Record input and scoring-file SHA-256 digests without storing genotype paths, contents, or raw trait queries.
- Generate portable replay commands, a rebuildable environment, provenance, and output checksums.
- Align the documented output contract and skill/catalog version with the current implementation.
- Expand targeted CI to execute the complete `skills/gwas-prs/tests/` directory.

Related to #372.

## Skill affected

`gwas-prs`

## Checklist

- [x] SKILL.md is present and complete
- [x] Tests included and passing
- [x] Demo data included for reviewers
- [x] No patient/sensitive data committed
- [x] Follows CONTRIBUTING.md conventions

## Test output

- `uv run --with pytest python -m pytest skills/gwas-prs/tests -q`
  - 115 passed
- `uv run python clawbio.py run prs --demo --output <temp>`
  - exit 0
  - generated all 8 documented files
- `agentskills validate skills/gwas-prs`
  - valid
- Clean Python 3.11 replay environment:
  - installed only requests, opentelemetry-sdk, numpy, and pandas
  - generated `commands.sh` completed successfully
- Ruff checks and formatting for new files passed
- `python -m compileall` passed
- `git diff --check` passed

The repo-level catalog suite currently has one unrelated baseline failure for
the NutriGx 0.2.0 catalog sync. That fix is isolated in #377 and is not
duplicated here.