### PR TITLE
fix(pathway-enricher): submit gene lists as multipart form data

### DIFF
--- a/skills/pathway-enricher/pathway_enricher.py
+++ b/skills/pathway-enricher/pathway_enricher.py
@@ -115,12 +115,12 @@ RATE_LIMIT_DELAY = 0.5      # seconds between library queries
 def _post_gene_list(genes: list[str], description: str = "ClawBio gene set") -> str:
     """Upload a gene list to Enrichr and return the userListId."""
     payload = {
-        "list": "\n".join(genes),
-        "description": description,
+        "list": (None, "\n".join(genes)),
+        "description": (None, description),
     }
     resp = requests.post(
         f"{ENRICHR_BASE}/addList",
-        data=payload,
+        files=payload,
         timeout=30,
     )
     resp.raise_for_status()

--- a/skills/pathway-enricher/tests/test_pathway_enricher.py
+++ b/skills/pathway-enricher/tests/test_pathway_enricher.py
@@ -111,15 +111,20 @@ def test_parse_gene_file_lowercases_normalised(tmp_path: Path) -> None:
 # Unit tests — Enrichr API helpers (mocked)
 # ---------------------------------------------------------------------------
 
-def test_post_gene_list_calls_correct_url() -> None:
-    """_post_gene_list posts to the Enrichr /addList endpoint."""
+def test_post_gene_list_uses_multipart_form_data() -> None:
+    """_post_gene_list follows Enrichr's multipart upload contract."""
     mock_req = _make_mock_requests()
     with patch.object(pe, "requests", mock_req):
         uid = pe._post_gene_list(["APOE", "BIN1"])
     assert uid == "12345"
-    mock_req.post.assert_called_once()
-    call_url = mock_req.post.call_args[0][0]
-    assert "addList" in call_url
+    mock_req.post.assert_called_once_with(
+        f"{pe.ENRICHR_BASE}/addList",
+        files={
+            "list": (None, "APOE\nBIN1"),
+            "description": (None, "ClawBio gene set"),
+        },
+        timeout=30,
+    )
 
 
 def test_query_library_parses_rows() -> None:


### PR DESCRIPTION
## Summary

- Submit Enrichr `/addList` gene lists as multipart form fields, matching the upstream API contract.
- Add regression coverage for the endpoint, multipart payload, description, and timeout.
- Restore the live `pathway-enricher --demo` workflow, which previously failed with HTTP 400.

## Skill affected

`pathway-enricher`

## Checklist

- [x] SKILL.md is present and complete
- [x] Tests included and passing
- [x] Demo data included for reviewers to test
- [x] No patient/sensitive data committed
- [x] Follows CONTRIBUTING.md conventions

## Test output

- Python 3.11: `16 passed`
- Python 3.12: `16 passed`
- Python 3.13: `16 passed`
- Live six-database demo: exit 0
- Generated report, result JSON, figures, CSV tables, checksums, replay commands, and environment metadata
- `git diff --check`: passed
- `compileall`: passed
