### PR TITLE
fix(clinical-variant-reporter): parse ClinVar significance into terms instead of crashing on VEP's list

### DIFF
--- a/skills/clinical-variant-reporter/SKILL.md
+++ b/skills/clinical-variant-reporter/SKILL.md
@@ -174,6 +174,8 @@ The classification engine implements the ACMG/AMP 2015 framework (Richards et al
 
 ClinVar significance is parsed into terms before PS1, PP5 or BP6 read it; the rules never substring-match a joined string. VEP REST returns `clin_sig` as a list aggregated over every ClinVar record at the site, and ClinVar's own strings join terms with `/`, `|`, `;` or `,`. Both shapes bucket the same way.
 
+For live VEP REST extraction, the site-level `clin_sig` aggregate is not used as evidence because it can mix assertions from different alternate alleles. The extractor keeps only the `clin_sig_allele` entry that exactly matches the queried ALT. Missing, malformed, non-string or unmatched allele-specific payloads are treated as absent evidence. VEP REST does not pair that allele-specific assertion with independently verifiable review stars, so live extraction records zero stars and withholds PS1, PP5 and BP6. Cached or directly constructed evidence that pairs a ClinVar assertion with a trustworthy review-star value still follows the table below.
+
 | ClinVar value | PS1 / PP5 | BP6 |
 |---------------|-----------|-----|
 | `Pathogenic`, `Likely pathogenic`, `Pathogenic/Likely pathogenic`, `Pathogenic\|risk_factor`, `Pathogenic, low penetrance`, `pathogenic_low_penetrance`, `likely_pathogenic_low_penetrance` | eligible | no |

--- a/skills/clinical-variant-reporter/SKILL.md
+++ b/skills/clinical-variant-reporter/SKILL.md
@@ -170,6 +170,20 @@ The classification engine implements the ACMG/AMP 2015 framework (Richards et al
 - **BP4**: CADD < 15
 - **ClinVar minimum stars for PS1/PP5/BP6**: ≥ 2
 
+### ClinVar Assertion Handling
+
+ClinVar significance is parsed into terms before PS1, PP5 or BP6 read it; the rules never substring-match a joined string. VEP REST returns `clin_sig` as a list aggregated over every ClinVar record at the site, and ClinVar's own strings join terms with `/`, `|`, `;` or `,`. Both shapes bucket the same way.
+
+| ClinVar value | PS1 / PP5 | BP6 |
+|---------------|-----------|-----|
+| `Pathogenic`, `Likely pathogenic`, `Pathogenic/Likely pathogenic`, `Pathogenic\|risk_factor`, `Pathogenic, low penetrance`, `pathogenic_low_penetrance`, `likely_pathogenic_low_penetrance` | eligible | no |
+| `Benign`, `Likely benign`, `Benign/Likely benign` | no | eligible |
+| `Conflicting_interpretations_of_pathogenicity`, `Conflicting_classifications_of_pathogenicity`, `conflicting_data_from_submitters` (alone or alongside any other term) | withheld | withheld |
+| pathogenic-family and benign-family terms together, e.g. `["benign", "pathogenic"]` | withheld | withheld |
+| `Uncertain significance`, `drug_response`, `risk_factor`, `not_provided`, unrecognised terms | no | no |
+
+"Withheld" means the rule does not fire and records the conflict as its reason in the criterion's detail field. A variant whose ClinVar records disagree therefore loses the ClinVar-backed criteria rather than being promoted on one side of the disagreement; the remaining criteria still combine as usual. Review-star gating (≥ 2) applies on top of this in every case.
+
 ## Example Queries
 
 - "Classify the variants in this exome VCF according to ACMG guidelines"

--- a/skills/clinical-variant-reporter/acmg_engine.py
+++ b/skills/clinical-variant-reporter/acmg_engine.py
@@ -13,6 +13,8 @@ References:
 
 from __future__ import annotations
 
+import re
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -88,6 +90,146 @@ INFRAME_CONSEQUENCES: frozenset[str] = frozenset({
     "stop_lost",
 })
 
+# ---------------------------------------------------------------------------
+# ClinVar clinical-significance vocabulary
+# ---------------------------------------------------------------------------
+# ClinVar significance reaches the engine in two shapes. VEP REST returns
+# colocated_variants[].clin_sig as a JSON *list* of lower-case terms from the
+# Ensembl clinical-significance enum, aggregated over every ClinVar record at
+# the site. ClinVar's own strings are *scalars* that join several terms with
+# "/" (compound, "Pathogenic/Likely_pathogenic"), "|" (VCF CLNSIG multi-value),
+# ";" (variant_summary multi-value) or ", " (free text). Both shapes are
+# reduced to one ordered tuple of normalised terms before any rule reads them,
+# so no rule ever substring-matches a joined string: "benign, pathogenic"
+# must never read as pathogenic support (issue #328).
+CLINVAR_TERM_SEPARATORS = re.compile(r"[,;/|]")
+
+CLINVAR_PATHOGENIC_TERMS: frozenset[str] = frozenset({
+    "pathogenic",
+    "likely_pathogenic",
+    "pathogenic_low_penetrance",
+    "likely_pathogenic_low_penetrance",
+})
+
+CLINVAR_BENIGN_TERMS: frozenset[str] = frozenset({
+    "benign",
+    "likely_benign",
+})
+
+# Every spelling ClinVar and VEP have used for "submitters disagree". ClinVar
+# renamed "interpretations" to "classifications" in 2024 and VEP caches of both
+# vintages are in the wild, so both are kept deliberately. Anything else that
+# starts with the same stem is treated the same way, so the next rename does
+# not silently reopen the over-call this guards against.
+CLINVAR_CONFLICTING_TERMS: frozenset[str] = frozenset({
+    "conflicting_interpretations_of_pathogenicity",
+    "conflicting_classifications_of_pathogenicity",
+    "conflicting_data_from_submitters",
+})
+CLINVAR_CONFLICTING_STEM = "conflicting"
+
+
+def normalize_clinvar_terms(significance: str | Sequence[str] | None) -> tuple[str, ...]:
+    """Reduce a ClinVar significance value to an ordered tuple of unique terms.
+
+    Accepts the scalar string form and the list (any sequence) form. Each chunk is
+    split on every separator ClinVar or VEP use between terms, lower-cased,
+    whitespace is collapsed to "_", and stray leading/trailing underscores
+    (as in VEP's "pathogenic,_low_penetrance") are stripped. Order is kept and
+    duplicates are dropped. None and empty values yield an empty tuple.
+
+    Any other shape is a producer bug and raises rather than being coerced,
+    because a silently empty tuple would read as "no ClinVar evidence".
+    """
+    if significance is None:
+        chunks: list[str] = []
+    elif isinstance(significance, str):
+        chunks = [significance]
+    elif isinstance(significance, Sequence) and not isinstance(significance, (bytes, bytearray)):
+        chunks = [str(item) for item in significance if item is not None]
+    else:
+        raise TypeError(
+            "ClinVar significance must be a string, a sequence of strings or None, "
+            f"got {type(significance).__name__}"
+        )
+
+    terms: list[str] = []
+    for chunk in chunks:
+        for piece in CLINVAR_TERM_SEPARATORS.split(chunk):
+            term = "_".join(piece.split()).lower().strip("_")
+            if term and term not in terms:
+                terms.append(term)
+    return tuple(terms)
+
+
+@dataclass(frozen=True)
+class ClinVarAssertion:
+    """A ClinVar significance value reduced to its evidential meaning.
+
+    ``pathogenic_terms`` / ``benign_terms`` are the recognised directional
+    terms present; ``conflicting_terms`` are the explicit "submitters
+    disagree" tokens present. Every other term (uncertain significance, drug
+    response, risk factor, not provided, a value from a future release, ...)
+    is neutral: it neither supports nor blocks a direction.
+    """
+    terms: tuple[str, ...]
+    pathogenic_terms: tuple[str, ...]
+    benign_terms: tuple[str, ...]
+    conflicting_terms: tuple[str, ...]
+
+    @property
+    def is_conflicting(self) -> bool:
+        """True when ClinVar itself flags the record as conflicting, or when
+        pathogenic-family and benign-family terms are both present. The
+        second clause matters for VEP's aggregated list, which carries every
+        ClinVar record at the site (all alleles) without a conflicting token."""
+        return bool(self.conflicting_terms) or (bool(self.pathogenic_terms) and bool(self.benign_terms))
+
+    @property
+    def supports_pathogenic(self) -> bool:
+        return bool(self.pathogenic_terms) and not self.is_conflicting
+
+    @property
+    def supports_benign(self) -> bool:
+        return bool(self.benign_terms) and not self.is_conflicting
+
+    @property
+    def conflict_reason(self) -> str:
+        """Human-readable explanation for report detail text; "" when clean."""
+        if self.conflicting_terms:
+            return "ClinVar flags this record as conflicting (" + ", ".join(self.conflicting_terms) + ")"
+        if self.pathogenic_terms and self.benign_terms:
+            return (
+                "ClinVar assertions at this site conflict ("
+                + ", ".join(self.pathogenic_terms + self.benign_terms) + ")"
+            )
+        return ""
+
+
+def interpret_clinvar_significance(significance: str | Sequence[str] | None) -> ClinVarAssertion:
+    """Parse a ClinVar significance value (either shape) into a ClinVarAssertion."""
+    terms = normalize_clinvar_terms(significance)
+    return ClinVarAssertion(
+        terms=terms,
+        pathogenic_terms=tuple(t for t in terms if t in CLINVAR_PATHOGENIC_TERMS),
+        benign_terms=tuple(t for t in terms if t in CLINVAR_BENIGN_TERMS),
+        conflicting_terms=tuple(
+            t for t in terms
+            if t in CLINVAR_CONFLICTING_TERMS or t.startswith(CLINVAR_CONFLICTING_STEM)
+        ),
+    )
+
+
+def format_clinvar_significance(significance: str | Sequence[str] | None) -> str:
+    """Display form for reports and tables: a scalar is passed through
+    unchanged, a list is joined with "; " so no Python repr ever lands in a
+    clinical artefact."""
+    if significance is None:
+        return ""
+    if isinstance(significance, str):
+        return significance
+    return "; ".join(str(item) for item in significance if item is not None)
+
 
 # ---------------------------------------------------------------------------
 # Data structures
@@ -118,7 +260,10 @@ class VariantEvidence:
     hgvsp: str = ""
     transcript: str = ""
 
-    clinvar_significance: str = ""
+    # Either shape ClinVar data arrives in: a scalar string (demo cache,
+    # ClinVar CLNSIG) or VEP REST's list of terms. Rules never read this
+    # field directly; they go through ``clinvar_assertion``.
+    clinvar_significance: str | Sequence[str] | None = ""
     clinvar_review_stars: int = 0
 
     gnomad_af: float | None = None
@@ -133,6 +278,16 @@ class VariantEvidence:
     is_missense: bool = False
     is_synonymous: bool = False
     is_inframe_indel: bool = False
+
+    @property
+    def clinvar_assertion(self) -> ClinVarAssertion:
+        """Structured reading of ``clinvar_significance`` for PS1/PP5/BP6."""
+        return interpret_clinvar_significance(self.clinvar_significance)
+
+    @property
+    def clinvar_significance_text(self) -> str:
+        """Display form of ``clinvar_significance`` for reports and tables."""
+        return format_clinvar_significance(self.clinvar_significance)
 
 
 @dataclass
@@ -229,13 +384,24 @@ def _eval_pvs1(ev: VariantEvidence) -> EvidenceCriterion:
     )
 
 
+def _clinvar_source(ev: VariantEvidence) -> str:
+    return f"ClinVar={ev.clinvar_significance_text}, stars={ev.clinvar_review_stars}"
+
+
+def _withheld_detail(code: str, clinvar: ClinVarAssertion, otherwise: str) -> str:
+    """Detail text for a ClinVar-backed rule that did not fire: name the
+    conflict when that is the reason, so the audit trail says why."""
+    if clinvar.is_conflicting:
+        return f"{code} withheld — {clinvar.conflict_reason}"
+    return otherwise
+
+
 def _eval_ps1(ev: VariantEvidence) -> EvidenceCriterion:
     """PS1: Same amino acid change as an established pathogenic variant in ClinVar."""
-    clinvar_lower = ev.clinvar_significance.lower()
-    is_pathogenic_clinvar = "pathogenic" in clinvar_lower and "conflicting" not in clinvar_lower
+    clinvar = ev.clinvar_assertion
     triggered = (
         ev.is_missense
-        and is_pathogenic_clinvar
+        and clinvar.supports_pathogenic
         and ev.clinvar_review_stars >= CLINVAR_MIN_STARS
     )
     return EvidenceCriterion(
@@ -243,9 +409,12 @@ def _eval_ps1(ev: VariantEvidence) -> EvidenceCriterion:
         triggered=triggered,
         strength="strong",
         direction="pathogenic",
-        source=f"ClinVar={ev.clinvar_significance}, stars={ev.clinvar_review_stars}",
+        source=_clinvar_source(ev),
         detail="Same amino acid change reported as Pathogenic in ClinVar with ≥2 review stars"
-        if triggered else "PS1 not met — either not missense, not pathogenic in ClinVar, or insufficient review stars",
+        if triggered else _withheld_detail(
+            "PS1", clinvar,
+            "PS1 not met — either not missense, not pathogenic in ClinVar, or insufficient review stars",
+        ),
     )
 
 
@@ -306,17 +475,18 @@ def _eval_pp3(ev: VariantEvidence) -> EvidenceCriterion:
 
 def _eval_pp5(ev: VariantEvidence) -> EvidenceCriterion:
     """PP5: Reputable source reports variant as pathogenic."""
-    clinvar_lower = ev.clinvar_significance.lower()
-    is_pathogenic = "pathogenic" in clinvar_lower and "conflicting" not in clinvar_lower
-    triggered = is_pathogenic and ev.clinvar_review_stars >= CLINVAR_MIN_STARS
+    clinvar = ev.clinvar_assertion
+    triggered = clinvar.supports_pathogenic and ev.clinvar_review_stars >= CLINVAR_MIN_STARS
     return EvidenceCriterion(
         code="PP5",
         triggered=triggered,
         strength="supporting",
         direction="pathogenic",
-        source=f"ClinVar={ev.clinvar_significance}, stars={ev.clinvar_review_stars}",
+        source=_clinvar_source(ev),
         detail="ClinVar reports Pathogenic/Likely Pathogenic with ≥2 review stars"
-        if triggered else "ClinVar does not report pathogenic with sufficient review status",
+        if triggered else _withheld_detail(
+            "PP5", clinvar, "ClinVar does not report pathogenic with sufficient review status",
+        ),
     )
 
 
@@ -349,17 +519,18 @@ def _eval_bp4(ev: VariantEvidence) -> EvidenceCriterion:
 
 def _eval_bp6(ev: VariantEvidence) -> EvidenceCriterion:
     """BP6: Reputable source reports variant as benign."""
-    clinvar_lower = ev.clinvar_significance.lower()
-    is_benign = ("benign" in clinvar_lower or "likely benign" in clinvar_lower) and "pathogenic" not in clinvar_lower
-    triggered = is_benign and ev.clinvar_review_stars >= CLINVAR_MIN_STARS
+    clinvar = ev.clinvar_assertion
+    triggered = clinvar.supports_benign and ev.clinvar_review_stars >= CLINVAR_MIN_STARS
     return EvidenceCriterion(
         code="BP6",
         triggered=triggered,
         strength="supporting",
         direction="benign",
-        source=f"ClinVar={ev.clinvar_significance}, stars={ev.clinvar_review_stars}",
+        source=_clinvar_source(ev),
         detail="ClinVar reports Benign/Likely Benign with ≥2 review stars"
-        if triggered else "ClinVar does not report benign with sufficient review status",
+        if triggered else _withheld_detail(
+            "BP6", clinvar, "ClinVar does not report benign with sufficient review status",
+        ),
     )
 
 

--- a/skills/clinical-variant-reporter/acmg_engine.py
+++ b/skills/clinical-variant-reporter/acmg_engine.py
@@ -102,7 +102,7 @@ INFRAME_CONSEQUENCES: frozenset[str] = frozenset({
 # reduced to one ordered tuple of normalised terms before any rule reads them,
 # so no rule ever substring-matches a joined string: "benign, pathogenic"
 # must never read as pathogenic support (issue #328).
-CLINVAR_TERM_SEPARATORS = re.compile(r"[,;/|]")
+CLINVAR_TERM_SEPARATORS = re.compile(r"[,;/|&]")
 
 CLINVAR_PATHOGENIC_TERMS: frozenset[str] = frozenset({
     "pathogenic",

--- a/skills/clinical-variant-reporter/clinical_variant_reporter.py
+++ b/skills/clinical-variant-reporter/clinical_variant_reporter.py
@@ -224,6 +224,10 @@ def _extract_evidence_from_vep(vep_result: dict, record: VcfRecord) -> VariantEv
 
     for cv in vep_result.get("colocated_variants", []):
         if "clinvar" in cv.get("var_synonyms", {}) or cv.get("clin_sig"):
+            # VEP REST returns clin_sig as a JSON list of terms aggregated over
+            # every ClinVar record at the site. It is kept as-is: the ACMG rules
+            # read it through VariantEvidence.clinvar_assertion, which parses
+            # both the list and the scalar string form into terms (#328).
             sigs = cv.get("clin_sig", "")
             if sigs and not clinvar_sig:
                 clinvar_sig = sigs
@@ -610,7 +614,7 @@ def _write_markdown_report(
             lines.append(f"- **rsID**: {ev.rsid or 'N/A'}")
             lines.append(f"- **Transcript**: {ev.transcript or 'N/A'}")
             lines.append(f"- **Consequence**: {ev.consequence}")
-            lines.append(f"- **ClinVar**: {ev.clinvar_significance or 'N/A'} (stars: {ev.clinvar_review_stars})")
+            lines.append(f"- **ClinVar**: {ev.clinvar_significance_text or 'N/A'} (stars: {ev.clinvar_review_stars})")
             lines.append(f"- **gnomAD AF**: {ev.gnomad_af if ev.gnomad_af is not None else 'N/A'}")
             lines.append(f"- **Evidence codes**: {cv.evidence_summary}")
             lines.append("")
@@ -722,7 +726,7 @@ def _write_classification_table(classified: list[ClassifiedVariant], output_dir:
             ev = cv.evidence
             writer.writerow([
                 ev.chrom, ev.pos, ev.ref, ev.alt, ev.rsid, ev.gene,
-                ev.consequence, ev.clinvar_significance, ev.clinvar_review_stars,
+                ev.consequence, ev.clinvar_significance_text, ev.clinvar_review_stars,
                 ev.gnomad_af if ev.gnomad_af is not None else "",
                 ev.cadd_phred if ev.cadd_phred is not None else "",
                 cv.classification, CLASS_SHORT.get(cv.classification, "?"),

--- a/skills/clinical-variant-reporter/clinical_variant_reporter.py
+++ b/skills/clinical-variant-reporter/clinical_variant_reporter.py
@@ -190,6 +190,35 @@ def _vcf_to_vep_region(record: VcfRecord) -> str:
     return f"{chrom} {record.pos} {record.pos + len(ref) - 1} {ref}/{alt} 1"
 
 
+def _clinvar_significance_for_alt(clin_sig_allele: object, alt: str) -> str:
+    """Return the VEP ClinVar terms asserted for exactly ``alt``.
+
+    ``colocated_variants[].clin_sig`` is a site-level aggregate, so it can
+    combine assertions for different alternate alleles.  VEP's allele-specific
+    string is a semicolon-delimited sequence of ``ALT:terms`` entries.  Its
+    undocumented non-string shapes cannot establish an ALT-to-assertion link,
+    and malformed entries are deliberately treated as absent evidence.
+    """
+    if not isinstance(clin_sig_allele, str) or not clin_sig_allele.strip():
+        return ""
+
+    queried_alt = alt.upper()
+    matching_terms: list[str] = []
+    for entry in clin_sig_allele.split(";"):
+        entry = entry.strip()
+        if entry.count(":") != 1:
+            return ""
+        allele, terms = (part.strip() for part in entry.split(":", 1))
+        if not allele or not terms:
+            return ""
+        if allele.upper() == queried_alt:
+            matching_terms.append(terms)
+
+    # ``&`` is the allele-specific VEP term separator.  The ACMG engine
+    # normalises it alongside ClinVar's other multi-value separators.
+    return "&".join(matching_terms)
+
+
 def _extract_evidence_from_vep(vep_result: dict, record: VcfRecord) -> VariantEvidence:
     """Extract VariantEvidence fields from a single VEP REST response entry."""
     most_severe = vep_result.get("most_severe_consequence", "")
@@ -223,19 +252,14 @@ def _extract_evidence_from_vep(vep_result: dict, record: VcfRecord) -> VariantEv
     gnomad_af_popmax = None
 
     for cv in vep_result.get("colocated_variants", []):
-        if "clinvar" in cv.get("var_synonyms", {}) or cv.get("clin_sig"):
-            # VEP REST returns clin_sig as a JSON list of terms aggregated over
-            # every ClinVar record at the site. It is kept as-is: the ACMG rules
-            # read it through VariantEvidence.clinvar_assertion, which parses
-            # both the list and the scalar string form into terms (#328).
-            sigs = cv.get("clin_sig", "")
-            if sigs and not clinvar_sig:
-                clinvar_sig = sigs
-                # VEP returns clin_sig_allele as a dict for some variants and a
-                # string (e.g. "T:pathogenic") for others; only read stars from a dict.
-                clin_sig_allele = cv.get("clin_sig_allele", {})
-                if isinstance(clin_sig_allele, dict):
-                    clinvar_stars = clin_sig_allele.get("review_status_stars", 0)
+        if not clinvar_sig:
+            # Never fall back to ``clin_sig``: it aggregates all ClinVar
+            # assertions at this coordinate, including other ALT alleles.
+            # The REST response does not provide an independently verifiable
+            # allele-specific review-star field, so live ClinVar rules remain
+            # withheld unless a future API supplies one with the assertion.
+            clinvar_sig = _clinvar_significance_for_alt(
+                cv.get("clin_sig_allele"), record.alt)
 
         freq_data = cv.get("frequencies", {})
         if freq_data:

--- a/skills/clinical-variant-reporter/tests/test_clinical_variant_reporter.py
+++ b/skills/clinical-variant-reporter/tests/test_clinical_variant_reporter.py
@@ -479,12 +479,12 @@ class TestVepLivePath:
 
 
 # ---------------------------------------------------------------------------
-# Regression — VEP clin_sig_allele may be a string, not a dict
+# Regression — VEP clin_sig_allele is an ALT-linked string
 # ---------------------------------------------------------------------------
 class TestClinSigAlleleTypeGuard:
-    """VEP returns colocated_variants[].clin_sig_allele as a dict for some
-    variants and a string (e.g. "T:pathogenic") for others. Extraction must not
-    crash on the string form (previously AttributeError: 'str' has no 'get')."""
+    """VEP returns colocated_variants[].clin_sig_allele as an ALT-linked
+    string such as ``T:pathogenic``. Unsupported shapes must fail closed rather
+    than being mistaken for review metadata."""
 
     def _record(self):
         from clinical_variant_reporter import VcfRecord
@@ -508,13 +508,15 @@ class TestClinSigAlleleTypeGuard:
         from clinical_variant_reporter import _extract_evidence_from_vep
         ev = _extract_evidence_from_vep(self._vep("T:pathogenic"), self._record())
         assert ev.gene == "BRCA2"
-        assert ev.clinvar_review_stars == 0  # defaults gracefully when not a dict
+        assert ev.clinvar_significance == "pathogenic"
+        assert ev.clinvar_review_stars == 0  # REST does not link stars to this ALT
 
-    def test_dict_clin_sig_allele_still_reads_stars(self):
+    def test_dict_clin_sig_allele_fails_closed_without_an_alt_assertion(self):
         from clinical_variant_reporter import _extract_evidence_from_vep
         ev = _extract_evidence_from_vep(
             self._vep({"review_status_stars": 3}), self._record())
-        assert ev.clinvar_review_stars == 3
+        assert ev.clinvar_significance == ""
+        assert ev.clinvar_review_stars == 0
 
 
 # ---------------------------------------------------------------------------
@@ -1334,26 +1336,32 @@ class TestListValuedClinSigEndToEnd:
             "G:conflicting_classifications_of_pathogenicity;T:pathogenic;G:uncertain_significance",
         )
         ev = _extract_evidence_from_vep(payload, self._record())
-        assert ev.clinvar_significance == ["uncertain_significance", "pathogenic"]
-        assert ev.clinvar_review_stars == 0  # string clin_sig_allele carries no stars (#322)
+        assert ev.clinvar_significance == "pathogenic"
+        assert ev.clinvar_review_stars == 0  # REST payload carries no trustworthy stars
         cv = classify_variant(ev)  # raised AttributeError before the fix
         assert cv.classification == "Uncertain Significance"
         assert not {"PS1", "PP5", "BP6"} & set(cv.triggered_codes)
 
-    def test_list_with_stars_and_a_conflict_withholds_the_clinvar_rules(self):
+    def test_unlinked_star_dict_does_not_reenable_site_level_evidence(self):
         from clinical_variant_reporter import _extract_evidence_from_vep
         payload = self._vep(["benign", "pathogenic"], {"review_status_stars": 3})
         cv = classify_variant(_extract_evidence_from_vep(payload, self._record()))
-        assert cv.evidence.clinvar_review_stars == 3
+        assert cv.evidence.clinvar_significance == ""
+        assert cv.evidence.clinvar_review_stars == 0
         assert not {"PS1", "PP5", "BP6"} & set(cv.triggered_codes)
         assert cv.classification == "Uncertain Significance"
 
-    def test_list_with_stars_and_a_clean_assertion_fires_the_clinvar_rules(self):
+    def test_allele_specific_terms_without_review_stars_do_not_fire_clinvar_rules(self):
         from clinical_variant_reporter import _extract_evidence_from_vep
-        payload = self._vep(["uncertain_significance", "pathogenic"], {"review_status_stars": 3})
+        payload = self._vep(
+            ["uncertain_significance", "pathogenic"],
+            "G:benign;T:pathogenic",
+        )
         cv = classify_variant(_extract_evidence_from_vep(payload, self._record()))
-        assert {"PS1", "PP5"} <= set(cv.triggered_codes)
-        assert cv.classification == "Likely Pathogenic"
+        assert cv.evidence.clinvar_significance == "pathogenic"
+        assert cv.evidence.clinvar_review_stars == 0
+        assert not {"PS1", "PP5", "BP6"} & set(cv.triggered_codes)
+        assert cv.classification == "Uncertain Significance"
 
     def test_evidence_exposes_display_text_for_both_shapes(self):
         assert _clinvar_evidence(["uncertain_significance", "pathogenic"]).clinvar_significance_text \
@@ -1364,9 +1372,10 @@ class TestListValuedClinSigEndToEnd:
         assert _clinvar_evidence(None).clinvar_significance_text == ""
 
     def test_report_and_table_render_terms_not_list_repr(self, tmp_path):
-        from clinical_variant_reporter import _extract_evidence_from_vep
-        payload = self._vep(["uncertain_significance", "pathogenic"], {"review_status_stars": 3})
-        cv = classify_variant(_extract_evidence_from_vep(payload, self._record()))
+        cv = classify_variant(_clinvar_evidence(
+            ["uncertain_significance", "pathogenic"], stars=3,
+            gnomad_af=None, cadd_phred=28.0, sift_prediction="deleterious",
+        ))
         assert cv.classification == "Likely Pathogenic"  # so it lands in the actionable section
 
         generate_report([cv], tmp_path, demo=False, source_versions={})
@@ -1375,5 +1384,67 @@ class TestListValuedClinSigEndToEnd:
 
         assert "['" not in report and "['" not in table
         assert "**ClinVar**: uncertain_significance; pathogenic (stars: 3)" in report
-        row = next(line for line in table.splitlines() if line.startswith("13\t32339267"))
+        row = next(line for line in table.splitlines() if line.startswith("17\t43093464"))
         assert "\tuncertain_significance; pathogenic\t3\t" in row
+
+
+class TestAlleleSpecificClinVarSignificance:
+    """Live VEP ``clin_sig`` is site-level; only the queried ALT is evidence.
+
+    The API's ``clin_sig_allele`` payload is a semicolon-delimited set of
+    ``ALT:terms`` entries.  A multi-allelic locus must never transfer a
+    ClinVar assertion from a different alternate allele.
+    """
+
+    def _record(self, alt="T"):
+        from clinical_variant_reporter import VcfRecord
+        return VcfRecord(chrom="13", pos=32339267, id="rs886040553",
+                         ref="A", alt=alt, qual=".", filt="PASS", info={})
+
+    def _vep(self, clin_sig_allele):
+        return {
+            "most_severe_consequence": "missense_variant",
+            "transcript_consequences": [{
+                "gene_symbol": "BRCA2", "impact": "MODERATE",
+                "consequence_terms": ["missense_variant"],
+            }],
+            "colocated_variants": [{
+                # This aggregate deliberately contains a benign assertion for G
+                # and a pathogenic assertion for T.  It is not allele-specific.
+                "clin_sig": ["benign", "pathogenic"],
+                "clin_sig_allele": clin_sig_allele,
+            }],
+        }
+
+    def test_uses_only_queried_alt_and_accepts_vep_ampersand_terms(self):
+        from clinical_variant_reporter import _extract_evidence_from_vep
+
+        ev = _extract_evidence_from_vep(
+            self._vep("G:benign;T:pathogenic&likely_pathogenic"), self._record("T"))
+
+        assert ev.clinvar_assertion.terms == ("pathogenic", "likely_pathogenic")
+        assert ev.clinvar_assertion.is_conflicting is False
+        assert ev.clinvar_review_stars == 0
+
+    def test_does_not_copy_a_different_alt_from_a_multiallelic_site(self):
+        from clinical_variant_reporter import _extract_evidence_from_vep
+
+        ev = _extract_evidence_from_vep(self._vep("G:benign"), self._record("T"))
+
+        assert ev.clinvar_significance == ""
+        assert ev.clinvar_review_stars == 0
+        assert ev.clinvar_assertion.terms == ()
+
+    @pytest.mark.parametrize("clin_sig_allele", [
+        "T",                         # no allele-to-assertion separator
+        "G:benign;T:",               # no assertion for the queried allele
+        "G:benign;T:pathogenic:bad", # ambiguous assertion separator
+        {"review_status_stars": 3},  # no allele-specific ClinVar assertion
+    ])
+    def test_missing_or_unsafe_allele_payload_fails_closed(self, clin_sig_allele):
+        from clinical_variant_reporter import _extract_evidence_from_vep
+
+        ev = _extract_evidence_from_vep(self._vep(clin_sig_allele), self._record("T"))
+
+        assert ev.clinvar_significance == ""
+        assert ev.clinvar_review_stars == 0

--- a/skills/clinical-variant-reporter/tests/test_clinical_variant_reporter.py
+++ b/skills/clinical-variant-reporter/tests/test_clinical_variant_reporter.py
@@ -24,7 +24,9 @@ from acmg_engine import (
     classify,
     classify_variant,
     evaluate_criteria,
+    interpret_clinvar_significance,
     is_secondary_finding_gene,
+    normalize_clinvar_terms,
 )
 from clinical_variant_reporter import (
     ENSEMBL_INFO_VARIATION_PATH,
@@ -1028,3 +1030,350 @@ class TestFetchEnsemblDataVersions:
         assert called_url == VEP_REST_HOST + ENSEMBL_INFO_VARIATION_PATH
         assert captured_kwargs[0].get("timeout") == 10
         assert captured_kwargs[0].get("headers", {}).get("Accept") == "application/json"
+
+
+# ---------------------------------------------------------------------------
+# Regression — VEP clin_sig arrives as a list; ClinVar terms are parsed, not
+# joined and substring-matched (issue #328)
+# ---------------------------------------------------------------------------
+def _legacy_directions(significance: str) -> tuple[bool, bool]:
+    """The substring rule this fix replaces (acmg_engine.py before #328).
+
+    Kept as the regression oracle for scalar inputs: on every string the old
+    rule read correctly, the structured parser must agree with it. The two
+    deliberate divergences (mixed pathogenic + benign strings; benign plus
+    conflicting_data_from_submitters, which the old BP6 never checked for)
+    have their own test.
+    """
+    lowered = significance.lower()
+    pathogenic = "pathogenic" in lowered and "conflicting" not in lowered
+    benign = ("benign" in lowered or "likely benign" in lowered) and "pathogenic" not in lowered
+    return pathogenic, benign
+
+
+def _clinvar_evidence(significance, stars: int = 3, **overrides) -> VariantEvidence:
+    fields = dict(
+        chrom="17", pos=43093464, ref="A", alt="G", gene="BRCA1",
+        consequence="missense_variant", is_missense=True,
+        clinvar_significance=significance, clinvar_review_stars=stars,
+    )
+    fields.update(overrides)
+    return VariantEvidence(**fields)
+
+
+def _criterion(ev: VariantEvidence, code: str) -> EvidenceCriterion:
+    return next(c for c in evaluate_criteria(ev) if c.code == code)
+
+
+class TestClinVarTermNormalisation:
+    """Both shapes ClinVar data reaches the engine in must reduce to the same
+    ordered, de-duplicated tuple of snake_case terms: VEP's JSON list, and the
+    scalar strings ClinVar itself emits, which join several terms with "/"
+    (compound), "|" (VCF CLNSIG multi-value), ";" (variant_summary) or ", "."""
+
+    @pytest.mark.parametrize("raw, expected", [
+        ("Pathogenic", ("pathogenic",)),
+        ("Likely pathogenic", ("likely_pathogenic",)),
+        (["pathogenic", "pathogenic"], ("pathogenic",)),
+        (["Pathogenic", "pathogenic"], ("pathogenic",)),
+        ("Pathogenic/Likely pathogenic", ("pathogenic", "likely_pathogenic")),
+        ("Pathogenic/Likely_pathogenic", ("pathogenic", "likely_pathogenic")),
+        ("Pathogenic|risk_factor", ("pathogenic", "risk_factor")),
+        ("Benign/Likely benign", ("benign", "likely_benign")),
+        ("Uncertain significance; risk factor", ("uncertain_significance", "risk_factor")),
+        ("Conflicting interpretations of pathogenicity, Pathogenic",
+         ("conflicting_interpretations_of_pathogenicity", "pathogenic")),
+        # clin_sig_allele spelling of "Pathogenic, low penetrance" (VEP 116, rs1800562)
+        ("pathogenic/pathogenic,_low_penetrance", ("pathogenic", "low_penetrance")),
+        (["Pathogenic/Likely_pathogenic", "risk_factor"],
+         ("pathogenic", "likely_pathogenic", "risk_factor")),
+        (["uncertain_significance", "pathogenic"], ("uncertain_significance", "pathogenic")),
+        (("benign",), ("benign",)),
+        ("", ()),
+        (None, ()),
+        ([], ()),
+        (["", None, "  "], ()),
+    ])
+    def test_terms_are_split_normalised_and_deduplicated(self, raw, expected):
+        assert normalize_clinvar_terms(raw) == expected
+
+    def test_unsupported_shape_fails_loudly(self):
+        with pytest.raises(TypeError):
+            normalize_clinvar_terms({"T": "pathogenic"})
+
+
+class TestClinVarAssertionSemantics:
+    """Explicit semantics for the three ClinVar-backed rules (PS1, PP5, BP6):
+
+    - a term from the pathogenic family supports pathogenic, one from the
+      benign family supports benign;
+    - any term ClinVar or VEP uses for "submitters disagree" (every spelling
+      in the wild) is a conflict;
+    - pathogenic-family and benign-family terms co-occurring is a conflict
+      even when no such token is present (VEP's clin_sig list aggregates
+      every ClinVar record at the site);
+    - a conflict supports neither direction;
+    - anything else (uncertain, drug response, risk factor, unknown) is
+      neutral: it neither supports nor blocks.
+    """
+
+    # (input, supports_pathogenic, supports_benign, is_conflicting)
+    CASES = [
+        # single terms
+        ("Pathogenic", True, False, False),
+        ("Likely pathogenic", True, False, False),
+        ("Benign", False, True, False),
+        ("Likely benign", False, True, False),
+        ("Uncertain significance", False, False, False),
+        ("drug_response", False, False, False),
+        ("not_provided", False, False, False),
+        ("novel_value_from_a_future_release", False, False, False),
+        ("", False, False, False),
+        (None, False, False, False),
+        # duplicates
+        (["pathogenic", "pathogenic"], True, False, False),
+        (["benign", "Benign"], False, True, False),
+        # ClinVar compound / multi-value scalar forms
+        ("Pathogenic/Likely pathogenic", True, False, False),
+        ("Pathogenic/Likely_pathogenic", True, False, False),
+        ("Pathogenic|risk_factor", True, False, False),
+        ("Benign/Likely benign", False, True, False),
+        ("Pathogenic, low penetrance", True, False, False),
+        # VEP list vocabulary as served by rest.ensembl.org release 116
+        (["pathogenic_low_penetrance"], True, False, False),
+        (["likely_pathogenic_low_penetrance"], True, False, False),
+        ("Likely pathogenic, low penetrance", True, False, False),
+        (["uncertain_significance", "pathogenic"], True, False, False),
+        (["uncertain_significance", "not_provided", "pathogenic", "other",
+          "risk_factor", "pathogenic_low_penetrance"], True, False, False),
+        (["uncertain_significance", "benign", "likely_benign"], False, True, False),
+        # explicit conflicting tokens, every spelling in the wild
+        (["pathogenic", "conflicting_interpretations_of_pathogenicity"], False, False, True),
+        (["pathogenic", "conflicting_classifications_of_pathogenicity"], False, False, True),
+        (["benign", "conflicting_data_from_submitters"], False, False, True),
+        ("Conflicting_classifications_of_pathogenicity", False, False, True),
+        ("Conflicting interpretations of pathogenicity, Pathogenic", False, False, True),
+        ("Conflicting_interpretations_of_pathogenicity|Pathogenic", False, False, True),
+        # both families present is a conflict whatever the tokens say
+        (["benign", "pathogenic"], False, False, True),
+        (["likely_benign", "likely_pathogenic"], False, False, True),
+        ("Benign; Pathogenic", False, False, True),
+        ("Pathogenic/Likely_pathogenic|Benign", False, False, True),
+        # rs1042522 aggregate at release 116: C is pathogenic, T is benign
+        (["uncertain_significance", "benign", "likely_benign", "pathogenic"], False, False, True),
+    ]
+
+    @pytest.mark.parametrize("raw, pathogenic, benign, conflicting", CASES)
+    def test_directions(self, raw, pathogenic, benign, conflicting):
+        assertion = interpret_clinvar_significance(raw)
+        observed = (assertion.supports_pathogenic, assertion.supports_benign, assertion.is_conflicting)
+        assert observed == (pathogenic, benign, conflicting)
+
+    def test_a_conflict_never_supports_either_direction(self):
+        for raw, *_ in self.CASES:
+            assertion = interpret_clinvar_significance(raw)
+            if assertion.is_conflicting:
+                assert not assertion.supports_pathogenic
+                assert not assertion.supports_benign
+
+    def test_explicit_token_is_load_bearing_without_a_benign_term(self):
+        """No benign term here, so only the explicit-token clause can block.
+        Deleting that clause turns this test red."""
+        assertion = interpret_clinvar_significance(
+            ["pathogenic", "conflicting_classifications_of_pathogenicity"])
+        assert assertion.is_conflicting
+        assert assertion.supports_pathogenic is False
+        assert assertion.conflicting_terms == ("conflicting_classifications_of_pathogenicity",)
+
+    def test_cooccurrence_is_load_bearing_without_an_explicit_token(self):
+        """No conflicting token here, so only the co-occurrence clause can block.
+        Deleting that clause turns this test red."""
+        assertion = interpret_clinvar_significance(["benign", "pathogenic"])
+        assert assertion.is_conflicting
+        assert assertion.conflicting_terms == ()
+        assert assertion.pathogenic_terms == ("pathogenic",)
+        assert assertion.benign_terms == ("benign",)
+
+    def test_unseen_conflicting_spelling_is_still_a_conflict(self):
+        """ClinVar renamed interpretations->classifications in 2024; match the
+        family stem so the next rename does not reopen this bug."""
+        assertion = interpret_clinvar_significance(["pathogenic", "conflicting_something_new"])
+        assert assertion.is_conflicting
+
+    def test_conflict_reason_is_human_readable(self):
+        explicit = interpret_clinvar_significance(
+            ["pathogenic", "conflicting_classifications_of_pathogenicity"])
+        assert "conflicting_classifications_of_pathogenicity" in explicit.conflict_reason
+        mixed = interpret_clinvar_significance(["benign", "pathogenic"])
+        assert "pathogenic" in mixed.conflict_reason and "benign" in mixed.conflict_reason
+        assert interpret_clinvar_significance("Pathogenic").conflict_reason == ""
+
+    SCALAR_PARITY = [
+        "Pathogenic", "Likely pathogenic", "Pathogenic/Likely pathogenic",
+        "Pathogenic/Likely_pathogenic", "Pathogenic|risk_factor",
+        "Pathogenic, low penetrance", "Likely pathogenic, low penetrance",
+        "Benign", "Likely benign",
+        "Benign/Likely benign", "Uncertain significance", "risk factor",
+        "drug response", "not provided", "",
+        "Conflicting interpretations of pathogenicity, Pathogenic",
+        "Conflicting_classifications_of_pathogenicity",
+        "Conflicting_interpretations_of_pathogenicity|Pathogenic",
+        "Benign|Conflicting_interpretations_of_pathogenicity",
+        "Benign|Conflicting_classifications_of_pathogenicity",
+        "conflicting data from submitters",
+    ]
+
+    @pytest.mark.parametrize("raw", SCALAR_PARITY)
+    def test_parity_with_the_replaced_rule_on_scalar_inputs(self, raw):
+        assertion = interpret_clinvar_significance(raw)
+        assert (assertion.supports_pathogenic, assertion.supports_benign) == _legacy_directions(raw)
+
+    @pytest.mark.parametrize("raw, legacy", [
+        # The old rule read "pathogenic" anywhere in a mixed string as
+        # pathogenic support.
+        ("Benign; Pathogenic", (True, False)),
+        ("Pathogenic/Benign", (True, False)),
+        ("Likely benign|Likely pathogenic", (True, False)),
+        # The old BP6 had no conflicting check at all; the other two
+        # conflicting tokens only blocked it because "pathogenicity" contains
+        # "pathogenic". This token does not, so BP6 used to fire on it.
+        ("Benign|conflicting_data_from_submitters", (False, True)),
+        ("Likely_benign;conflicting_data_from_submitters", (False, True)),
+    ])
+    def test_deliberate_divergences_from_the_replaced_rule(self, raw, legacy):
+        """The two intended behaviour changes on scalar input, pinned so the
+        parity contract above is honest about what it excludes."""
+        assert _legacy_directions(raw) == legacy
+        assertion = interpret_clinvar_significance(raw)
+        assert assertion.is_conflicting
+        assert (assertion.supports_pathogenic, assertion.supports_benign) == (False, False)
+
+
+class TestClinVarCriteriaWithStructuredTerms:
+    def test_list_valued_pathogenic_fires_ps1_and_pp5(self):
+        ev = _clinvar_evidence(["uncertain_significance", "pathogenic"], stars=3)
+        assert _criterion(ev, "PS1").triggered is True
+        assert _criterion(ev, "PP5").triggered is True
+        assert _criterion(ev, "BP6").triggered is False
+
+    def test_compound_scalars_keep_firing(self):
+        assert _criterion(_clinvar_evidence("Pathogenic/Likely pathogenic", stars=3), "PP5").triggered
+        assert _criterion(_clinvar_evidence("Pathogenic|risk_factor", stars=3), "PS1").triggered
+        assert _criterion(_clinvar_evidence("Benign/Likely benign", stars=2), "BP6").triggered
+
+    @pytest.mark.parametrize("raw", [
+        ["pathogenic", "conflicting_interpretations_of_pathogenicity"],
+        ["pathogenic", "conflicting_classifications_of_pathogenicity"],
+        ["benign", "conflicting_classifications_of_pathogenicity"],
+        ["benign", "pathogenic"],
+        "Conflicting interpretations of pathogenicity, Pathogenic",
+    ])
+    def test_conflict_withholds_ps1_pp5_bp6_even_with_stars(self, raw):
+        ev = _clinvar_evidence(raw, stars=4)
+        for code in ("PS1", "PP5", "BP6"):
+            crit = _criterion(ev, code)
+            assert crit.triggered is False, code
+            assert "conflict" in crit.detail.lower(), code
+
+    def test_star_gate_is_unchanged(self):
+        ev = _clinvar_evidence(["pathogenic"], stars=1)
+        assert _criterion(ev, "PS1").triggered is False
+        assert _criterion(ev, "PP5").triggered is False
+
+    def test_criterion_source_renders_terms_not_python_repr(self):
+        ev = _clinvar_evidence(["uncertain_significance", "pathogenic"])
+        source = _criterion(ev, "PS1").source
+        assert "['" not in source
+        assert "ClinVar=uncertain_significance; pathogenic, stars=3" == source
+
+    def test_scalar_source_is_byte_identical_to_before(self):
+        ev = _clinvar_evidence("Pathogenic")
+        assert _criterion(ev, "PP5").source == "ClinVar=Pathogenic, stars=3"
+
+    def test_conflicting_list_lands_on_vus_not_likely_pathogenic(self):
+        in_silico = dict(gnomad_af=None, cadd_phred=28.0, sift_prediction="deleterious")
+        conflicted = _clinvar_evidence(
+            ["pathogenic", "conflicting_classifications_of_pathogenicity"], stars=3, **in_silico)
+        assert classify_variant(conflicted).classification == "Uncertain Significance"
+        # Same evidence without the conflict token: PS1 + PM2 + PP3 + PP5 -> LP.
+        clean = _clinvar_evidence(["uncertain_significance", "pathogenic"], stars=3, **in_silico)
+        assert classify_variant(clean).classification == "Likely Pathogenic"
+
+
+class TestListValuedClinSigEndToEnd:
+    """Issue #328: VEP REST returns colocated_variants[].clin_sig as a JSON
+    list. Before the fix _extract_evidence_from_vep stored it unchanged and
+    every ClinVar rule called .lower() on it, so live mode raised
+    AttributeError on the first ClinVar-annotated variant and wrote nothing."""
+
+    def _record(self):
+        from clinical_variant_reporter import VcfRecord
+        return VcfRecord(chrom="13", pos=32339267, id="rs886040553",
+                         ref="A", alt="T", qual=".", filt="PASS", info={})
+
+    def _vep(self, clin_sig, clin_sig_allele, consequence="missense_variant", impact="MODERATE"):
+        return {
+            "most_severe_consequence": consequence,
+            "transcript_consequences": [
+                {"gene_symbol": "BRCA2", "impact": impact,
+                 "consequence_terms": [consequence],
+                 "transcript_id": "ENST00000544455.6",
+                 "cadd_phred": 28.0, "sift_prediction": "deleterious"}
+            ],
+            "colocated_variants": [
+                {"id": "rs886040553", "clin_sig": clin_sig, "clin_sig_allele": clin_sig_allele}
+            ],
+        }
+
+    def test_release_116_payload_classifies_without_crashing(self):
+        """Shape captured live from rest.ensembl.org (release 116) for
+        13:32339267 A>T: a list clin_sig and a string clin_sig_allele."""
+        from clinical_variant_reporter import _extract_evidence_from_vep
+        payload = self._vep(
+            ["uncertain_significance", "pathogenic"],
+            "G:conflicting_classifications_of_pathogenicity;T:pathogenic;G:uncertain_significance",
+        )
+        ev = _extract_evidence_from_vep(payload, self._record())
+        assert ev.clinvar_significance == ["uncertain_significance", "pathogenic"]
+        assert ev.clinvar_review_stars == 0  # string clin_sig_allele carries no stars (#322)
+        cv = classify_variant(ev)  # raised AttributeError before the fix
+        assert cv.classification == "Uncertain Significance"
+        assert not {"PS1", "PP5", "BP6"} & set(cv.triggered_codes)
+
+    def test_list_with_stars_and_a_conflict_withholds_the_clinvar_rules(self):
+        from clinical_variant_reporter import _extract_evidence_from_vep
+        payload = self._vep(["benign", "pathogenic"], {"review_status_stars": 3})
+        cv = classify_variant(_extract_evidence_from_vep(payload, self._record()))
+        assert cv.evidence.clinvar_review_stars == 3
+        assert not {"PS1", "PP5", "BP6"} & set(cv.triggered_codes)
+        assert cv.classification == "Uncertain Significance"
+
+    def test_list_with_stars_and_a_clean_assertion_fires_the_clinvar_rules(self):
+        from clinical_variant_reporter import _extract_evidence_from_vep
+        payload = self._vep(["uncertain_significance", "pathogenic"], {"review_status_stars": 3})
+        cv = classify_variant(_extract_evidence_from_vep(payload, self._record()))
+        assert {"PS1", "PP5"} <= set(cv.triggered_codes)
+        assert cv.classification == "Likely Pathogenic"
+
+    def test_evidence_exposes_display_text_for_both_shapes(self):
+        assert _clinvar_evidence(["uncertain_significance", "pathogenic"]).clinvar_significance_text \
+            == "uncertain_significance; pathogenic"
+        assert _clinvar_evidence("Uncertain significance").clinvar_significance_text \
+            == "Uncertain significance"
+        assert _clinvar_evidence("").clinvar_significance_text == ""
+        assert _clinvar_evidence(None).clinvar_significance_text == ""
+
+    def test_report_and_table_render_terms_not_list_repr(self, tmp_path):
+        from clinical_variant_reporter import _extract_evidence_from_vep
+        payload = self._vep(["uncertain_significance", "pathogenic"], {"review_status_stars": 3})
+        cv = classify_variant(_extract_evidence_from_vep(payload, self._record()))
+        assert cv.classification == "Likely Pathogenic"  # so it lands in the actionable section
+
+        generate_report([cv], tmp_path, demo=False, source_versions={})
+        report = (tmp_path / "report.md").read_text()
+        table = (tmp_path / "tables" / "acmg_classifications.tsv").read_text()
+
+        assert "['" not in report and "['" not in table
+        assert "**ClinVar**: uncertain_significance; pathogenic (stars: 3)" in report
+        row = next(line for line in table.splitlines() if line.startswith("13\t32339267"))
+        assert "\tuncertain_significance; pathogenic\t3\t" in row


### PR DESCRIPTION
Fixes #328.

## Summary

- Parse ClinVar significance into structured terms before PS1, PP5 and BP6 read it, so the engine accepts VEP REST's list-valued `clin_sig` without crashing and never substring-matches a joined string.
- Define explicit conflict semantics: any spelling of ClinVar's "submitters disagree" token (`conflicting_interpretations_of_pathogenicity`, `conflicting_classifications_of_pathogenicity`, `conflicting_data_from_submitters`, and anything else on the `conflicting` stem), or pathogenic-family and benign-family terms co-occurring, withholds all three ClinVar-backed rules and says so in the criterion detail line.
- Keep every scalar input that worked before working: `Pathogenic/Likely pathogenic`, `Benign/Likely benign`, `Pathogenic|risk_factor`, `Pathogenic, low penetrance` and the review-star gate are unchanged. Two scalar behaviours change on purpose, both pinned by their own test: a mixed string such as `Benign; Pathogenic` is withheld instead of read as pathogenic support, and `Benign|conflicting_data_from_submitters` no longer fires BP6. The old BP6 had no conflicting check at all; the other two conflicting tokens only blocked it because "pathogenicity" contains "pathogenic".
- Render the ClinVar column in `acmg_classifications.tsv` and the ClinVar line in `report.md` through a display helper, so a list never lands in a clinical artefact as a Python repr.

This takes the direction agreed on #328 and in the #344 reviews (structured terms, abstain on conflict) and addresses the points that PR was blocked on: real vocabulary instead of an invented token, splitting on `/`, `|` and `;` as well as `,`, a stem match so the 2024 ClinVar rename and the pre-rename spelling are both caught, the TSV writer, and tests whose vocabulary comes from the data source.

## Skill affected

`clinical-variant-reporter`

## What changed

`acmg_engine.py`

- `normalize_clinvar_terms(value)` reduces a string, a list/tuple or `None` to an ordered, de-duplicated tuple of snake_case terms. It splits on `[,;/|]`, lower-cases, collapses whitespace to `_` and strips stray underscores (VEP writes `pathogenic,_low_penetrance`). Any other shape raises `TypeError` rather than silently reading as "no ClinVar evidence".
- `ClinVarAssertion` (frozen dataclass) exposes `pathogenic_terms`, `benign_terms`, `conflicting_terms` and the derived `is_conflicting`, `supports_pathogenic`, `supports_benign`, `conflict_reason`.
- `VariantEvidence.clinvar_significance` is widened to `str | Sequence[str] | None`; rules go through `ev.clinvar_assertion`, writers through `ev.clinvar_significance_text`.
- PS1, PP5 and BP6 share `_clinvar_source` and `_withheld_detail`, so a withheld rule's detail reads e.g. `PS1 withheld — ClinVar flags this record as conflicting (conflicting_classifications_of_pathogenicity)`.

`clinical_variant_reporter.py`

- `_extract_evidence_from_vep` keeps the list VEP returns (comment explains why); `report.md` and the TSV use the display text.

`SKILL.md`

- New "ClinVar Assertion Handling" subsection under Algorithm / Methodology documenting the table below. Frontmatter untouched, so `skills/catalog.json` is unchanged.

| ClinVar value | PS1 / PP5 | BP6 |
|---|---|---|
| `Pathogenic`, `Likely pathogenic`, `Pathogenic/Likely pathogenic`, `Pathogenic\|risk_factor`, `["uncertain_significance", "pathogenic"]` | eligible | no |
| `Benign`, `Likely benign`, `Benign/Likely benign` | no | eligible |
| any `conflicting_*` token, alone or alongside other terms | withheld | withheld |
| pathogenic-family and benign-family terms together, e.g. `["benign", "pathogenic"]` | withheld | withheld |
| `Uncertain significance`, `drug_response`, `risk_factor`, `not_provided`, unknown terms | no | no |

The co-occurrence clause matters for VEP specifically: at release 116 the `clin_sig` list is aggregated over every ClinVar record at the site, across alleles, and does not carry the conflicting token itself. rs1042522 comes back as `["uncertain_significance", "benign", "likely_benign", "pathogenic"]` because the C allele is pathogenic and the T allele benign. Withholding there is the conservative direction for an ACMG engine.

## Reproduction, before and after

`issue328.vcf` with two lines, `13 32339267 rs886040553 A T` and `17 43093464 . A G`, run live against rest.ensembl.org (release 116):

`main` (`1fe0064`):

```
  File ".../acmg_engine.py", line 234, in _eval_ps1
    clinvar_lower = ev.clinvar_significance.lower()
AttributeError: 'list' object has no attribute 'lower'
```

No `report.md`, `result.json` or tables are written.

This branch: exit 0, all artefacts written. The TSV row for rs886040553 reads `uncertain_significance; pathogenic` in the `clinvar_significance` column, and `report.md` shows `ClinVar=uncertain_significance; pathogenic, stars=0` on the PS1/PP5/BP6 rows.

## Test output

`uv run --with pytest python -m pytest skills/clinical-variant-reporter/tests -q`

```
177 passed in 2.93s
```

77 on `main`, 100 new. Red first: the new tests were written before the engine change and fail against `main` (the parser API does not exist there, and the list-valued evidence the end-to-end tests build raises the issue's `AttributeError: 'list' object has no attribute 'lower'` from `main`'s `classify_variant`).

New tests, all parametrised on vocabulary ClinVar or VEP actually emit:

- `TestClinVarTermNormalisation`: single, duplicate, compound (`/`, `|`, `;`, `,`), case/whitespace, `pathogenic,_low_penetrance`, empty/`None`/unsupported shape.
- `TestClinVarAssertionSemantics`: single terms, duplicates, every conflicting spelling, co-occurrence, neutral/unknown terms, both low-penetrance spellings; a parity test against the pre-fix substring rule on 20 scalar inputs, and a separate test that pins the two deliberate divergences (mixed strings; benign plus `conflicting_data_from_submitters`) with the legacy result each one used to give. Two tests prove each guard clause is load-bearing on its own: `["pathogenic", "conflicting_classifications_of_pathogenicity"]` has no benign term so only the token clause can block; `["benign", "pathogenic"]` has no token so only the co-occurrence clause can.
- `TestClinVarCriteriaWithStructuredTerms`: PS1/PP5/BP6 on list and compound inputs, star gate unchanged, detail names the conflict, `source` byte-identical for scalars, and a classify-level case where the conflict token turns Likely Pathogenic into VUS.
- `TestListValuedClinSigEndToEnd`: `_extract_evidence_from_vep` -> `classify_variant` -> `generate_report` on the release-116 payload shape (list `clin_sig`, string `clin_sig_allele`), plus the dict-stars variants, asserting the report and TSV contain `uncertain_significance; pathogenic` and no `['`.

Mutation check, deleting or weakening one guard at a time and re-running the suite:

| Mutant | Result |
|---|---|
| drop explicit-token clause | 16 failed |
| drop `conflicting` stem match (exact tokens only) | 1 failed |
| drop co-occurrence clause | 11 failed |
| split on `,` only (the #344 shape) | 21 failed |
| drop `/` / `|` / `;` from the separator set | 14 / 6 / 3 failed |
| conflict still supports pathogenic / benign | 22 / 13 failed |
| drop `likely_pathogenic` / `pathogenic_low_penetrance` / `likely_pathogenic_low_penetrance` from the family | 4 / 1 / 1 failed |
| no dedup / no lowercase / no underscore strip | 3 / 42 / 1 failed |
| remove PP5 star gate | 2 failed |
| display helper emits `repr` | 3 failed |
| withheld detail silent about the conflict | 5 failed |
| `TypeError` swallowed for a dict | 1 failed |

One mutant survives: replacing the exact family-set test on each already-split term with `"pathogenic" in term`. On the ClinVar and Ensembl vocabularies those are the same predicate (no real term contains `pathogenic` without belonging to the pathogenic family or the conflicting family), so I did not invent a token to kill it.

Other checks:

- Demo output is unchanged: `--demo` on `main` and on this branch produce byte-identical `result.json`, `acmg_classifications.tsv`, `secondary_findings.tsv` and `database_versions.json`; `report.md` and `commands.sh` differ only in the input/output paths.
- `clawbio-bench --smoke` at the pinned revision, harnesses `clinical_variant_reporter` / `cvr_identity` / `cvr_correctness`: 80.0 / 100.0 / 69.2 on both `main` and this branch, matching `bench_baseline.json`. Verdicts differ only in temp paths and wall time.
- `uvx --from 'skills-ref>=0.1.1,<1' agentskills validate skills/clinical-variant-reporter`: valid. SKILL.md is 253 lines.
- `ruff check` on the three changed files reports the same pre-existing findings as `main` and nothing new. `python -m compileall` and `git diff --check` clean.
- `uv run python clawbio.py run acmg --demo` exits 0.

## Out of scope, noted for later

In all 24 variants I sampled from rest.ensembl.org release 116, `clin_sig_allele` came back as a string (`"G:conflicting_classifications_of_pathogenicity;T:pathogenic;G:uncertain_significance"`), so the `isinstance(..., dict)` guard from #322 leaves `clinvar_review_stars = 0` and PS1/PP5/BP6 never fire in live mode today. That string is also the only place the per-allele conflict flag lives; the aggregate list drops it. Reading review status and the alt-allele assertion out of `clin_sig_allele` would make live mode use ClinVar at all, and would let the engine distinguish "this allele is conflicting" from "another allele at this site is benign". That is a separate change with its own tests and I have not started it.

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology)
- [x] Tests included and passing (`pytest -v`)
- [x] Demo data included for reviewers to test (existing `--demo` panel; unchanged)
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions
