### PR TITLE
fix(gwas-prs): make the PGS000013 panel alias opt-in, refuse silent substitution

### DIFF
--- a/.github/workflows/bench-leaderboard.yml
+++ b/.github/workflows/bench-leaderboard.yml
@@ -35,6 +35,12 @@ jobs:
 
       - name: Run benchmark (smoke mode)
         id: bench
+        env:
+          # The pinned clawbio_bench revision requests the curated T2D panel as
+          # --pgs-id PGS000013. Since ClawBio issue #356 that alias is opt-in;
+          # only this benchmark run opts in. Drop this line once clawbio_bench
+          # requests --panel-id CLAWBIO-T2D-8 directly.
+          CLAWBIO_ALLOW_LEGACY_PGS_ALIAS: "1"
         run: |
           mkdir -p bench_runs/latest
           uv run clawbio-bench --smoke --repo . --output bench_runs/latest --quiet || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,6 +389,12 @@ jobs:
       # (#342) would go straight back on. So the bench is allowed to report,
       # and the *baseline comparison* below is the gate.
       - name: Run scientific correctness audit (smoke)
+        env:
+          # The pinned clawbio_bench revision requests the curated T2D panel as
+          # --pgs-id PGS000013. Since ClawBio issue #356 that alias is opt-in;
+          # only benchmark runs opt in. Drop this once clawbio_bench requests
+          # --panel-id CLAWBIO-T2D-8 directly.
+          CLAWBIO_ALLOW_LEGACY_PGS_ALIAS: "1"
         run: |
           mkdir -p results
           uv run clawbio-bench --smoke --repo . || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [Unreleased]
-
 ### Added
 - **`SECURITY.md`**: a private disclosure path (GitHub private vulnerability reporting,
   now enabled on the repository, with an email fallback), response commitments, what is
@@ -38,8 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sandbox whose README now states its scope: synthetic fixtures for exercising the
   orchestrator, with no biological meaning. `genome-match` and `recombinator`, which
   consume those fixtures, are unchanged. Catalogue count 97 to 96.
-
-## [0.7.0] - 2026-09-03
 
 ## [0.7.0] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   orchestrator, with no biological meaning. `genome-match` and `recombinator`, which
   consume those fixtures, are unchanged. Catalogue count 97 to 96.
 
+### Fixed
+- **gwas-prs no longer substitutes the curated T2D panel for PGS000013** (#356,
+  remaining half). `--pgs-id PGS000013` now goes to the PGS Catalog like any other
+  accession and, when it cannot, fails with a message saying what the accession is
+  (Khera 2018, coronary artery disease, 6,630,150 variants) and how to request the
+  curated panel instead (`--panel-id CLAWBIO-T2D-8`). The benchmark compatibility
+  alias still exists but is opt-in through `CLAWBIO_ALLOW_LEGACY_PGS_ALIAS=1`, which
+  only `.github/workflows/bench-leaderboard.yml` sets for the pinned `clawbio_bench`
+  revision. A network failure on that path now reports cleanly instead of raising.
+
 ## [0.7.0] - 2026-09-03
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [Unreleased]
+
+### Added
+- **`SECURITY.md`**: a private disclosure path (GitHub private vulnerability reporting,
+  now enabled on the repository, with an email fallback), response commitments, what is
+  in and out of scope, and which versions receive fixes.
+- **`docs/data-handling.md`**: every skill that can send data off the machine, grouped by
+  what it sends (reference downloads only, query terms you typed, your variants, whole
+  sequences or files, or chat messages to a hosted LLM), with the host, the trigger, the
+  credential variable and the offline behaviour for each. Enforced by
+  `tests/test_data_handling_doc.py`, which scans every skill for outbound-call code and
+  fails if a networked skill is absent from the page.
+
+### Changed
+- README and `docs/architecture.md` no longer claim that "no network calls" are made for
+  data processing. Several skills send variants to Ensembl VEP, gnomAD and ClinVar, and the
+  six `gi-*` skills upload whole sequences to a hosted model. The privacy statement now says
+  exactly that and points at the data-handling page. The README versioning line also read
+  `v0.5.0` two releases late; it now says `v0.7.0`.
+
 ### Removed
 - **`soul2dna` is no longer a ClawBio skill** (#111). The skill folder was a thin
   wrapper around the Genomebook sandbox compiler and presented "compile character
@@ -18,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sandbox whose README now states its scope: synthetic fixtures for exercising the
   orchestrator, with no biological meaning. `genome-match` and `recombinator`, which
   consume those fixtures, are unchanged. Catalogue count 97 to 96.
+
+## [0.7.0] - 2026-09-03
 
 ## [0.7.0] - 2026-09-03
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ ClawBio skill                = specification-constrained, versioned, reproducibl
 
 - **Specification-first**: Domain expertise resides in `SKILL.md`, not in model weights. Specifications are versioned, human-readable, peer-reviewable, and trivially updatable.
 - **Agent-agnostic**: Skills execute identically whether invoked by Claude, ChatGPT, or a locally hosted model via Ollama. Reproducibility is decoupled from any specific AI vendor.
-- **Local-first by default**: Your genome is analysed on your machine. Skills that send data to external services (hosted inference, public annotation APIs) are individually labelled and run only when you explicitly invoke them.
+- **Local-first by default**: Your genome is analysed on your machine, and the `clawbio` package itself makes no network calls. Some skills do reach public annotation APIs or hosted models, and a few send your variants or sequences to do so. Every one of them is named, with what it sends and to whom, in [docs/data-handling.md](docs/data-handling.md), and a test fails if a networked skill is missing from that page.
 - **Reproducible**: Many skills export replay metadata such as `commands.sh`, `environment.yml`, and SHA-256 checksums so runs can be rechecked without the original agent session.
 - **MIT licensed**: Open-source, free, community-driven.
 
@@ -230,6 +230,8 @@ cp templates/SKILL-TEMPLATE.md skills/<your-skill-name>/SKILL.md
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full submission process. Join the contributors community on Telegram: [t.me/ClawBioContributors](https://t.me/ClawBioContributors).
+
+**Security and data handling.** Report vulnerabilities privately through [SECURITY.md](SECURITY.md), never in a public issue. Before running ClawBio on data you are responsible for, read [docs/data-handling.md](docs/data-handling.md): it lists every skill that can send data off your machine, what it sends, to which host, and which environment variable holds its credential.
 
 ---
 
@@ -660,7 +662,7 @@ See [Contributing a Skill](#contributing-a-skill) above for the submission proce
 
 ## Versioning
 
-ClawBio follows [Semantic Versioning](https://semver.org/). The current release is **v0.5.0**. See [CHANGELOG.md](CHANGELOG.md) for a full history of additions and breaking changes.
+ClawBio follows [Semantic Versioning](https://semver.org/). The current release is **v0.7.0**. See [CHANGELOG.md](CHANGELOG.md) for a full history of additions and breaking changes.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,75 @@
+# Security Policy
+
+ClawBio runs bioinformatics skills on a user's own machine, often against that
+user's own genome. A vulnerability here can expose genetic data, so reports are
+handled privately until a fix or mitigation is available.
+
+## Reporting a vulnerability
+
+Do not open a public issue for a security problem.
+
+1. Preferred: GitHub private vulnerability reporting. Open
+   <https://github.com/ClawBio/ClawBio/security/advisories/new> and describe
+   the problem. The report is visible only to the maintainers until an
+   advisory is published.
+2. Fallback: email the maintainer listed in `pyproject.toml`
+   (`mc.admin@manuelcorpas.com`) with `ClawBio security` in the subject line.
+
+Include what you can of: the skill or module affected, the version or commit,
+a minimal reproduction, and what an attacker gains. A proof of concept against
+the bundled demo data is welcome. Never send real patient or personal genomic
+data in a report.
+
+## What to expect
+
+ClawBio has one maintainer at present, so these are commitments made in good
+faith, not contractual service levels.
+
+- Acknowledgement within 5 working days.
+- An initial assessment (accepted, needs more information, or out of scope)
+  within 14 days.
+- A fix or a documented mitigation targeted within 90 days of acceptance,
+  and sooner for anything that exposes genetic data or executes untrusted
+  input.
+- Coordinated disclosure: a public advisory and a CHANGELOG entry are
+  published with the fix. Reporters are credited unless they ask not to be.
+
+## Scope
+
+In scope:
+
+- The `clawbio` Python package, the CLI, and every skill under `skills/`.
+- Skill documentation, demo data or fixtures that could steer an AI agent
+  into unsafe behaviour (prompt injection through `SKILL.md` or bundled files).
+- Secrets, tokens or credentials committed to the repository, or leaked
+  through a skill's output or reproducibility bundle.
+- Supply chain: dependency pins, `uv.lock`, GitHub Actions workflows, and the
+  PyPI release path.
+- Any skill that sends data off the machine without saying so in its
+  `SKILL.md` and in [docs/data-handling.md](docs/data-handling.md).
+
+Out of scope, please use a normal issue instead:
+
+- Scientific accuracy: wrong annotations, misleading percentiles, incorrect
+  guideline mappings. These matter and are handled in the open through issues
+  and ClawBench, not through this policy.
+- Vulnerabilities in third-party services that a skill calls (Ensembl, NCBI,
+  PGS Catalog, Open Targets and others). Report those upstream, and tell us if
+  ClawBio should stop calling the service.
+- Rate-limit or denial-of-service effects on public APIs caused by running a
+  skill in a loop.
+
+## Supported versions
+
+Security fixes go into the latest minor release only.
+
+| Version | Supported |
+|---------|-----------|
+| 0.7.x   | Yes       |
+| < 0.7   | No, upgrade to the current release |
+
+## Good-faith research
+
+Research that follows this policy, avoids accessing or destroying other
+people's data, and gives the maintainers reasonable time to respond will be
+treated as authorised and welcome.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -108,12 +108,15 @@ return the standard report and output bundle.
 
 ## Privacy Model
 
-ClawBio enforces a strict local-first privacy model:
+ClawBio is local-first, which means something specific rather than absolute:
 
-- **No network calls** for data processing. All computation happens locally.
-- **Optional network** only for: literature search (PubMed API), structure database queries (PDB/UniProt), and package installation.
-- **Explicit consent** required before any data leaves the machine.
-- **File access scoping**: Skills operate within the current working directory by default. Access to parent directories requires user confirmation.
+- **The `clawbio` package makes no network calls.** No telemetry, no update checks, no analytics. The audit layer (`clawbio/common/audit.py`) writes to a local JSONL file only.
+- **Most skills never touch the network.** They read your files, compute, and write to the output directory.
+- **Some skills do reach external services**, and they fall into classes: reference data downloads (nothing of yours is sent), query terms you typed (gene symbols, rsIDs, free text), your variants (VEP, gnomAD and ClinVar lookups send chromosome, position and alleles from your VCF), and whole sequences or files uploaded to a hosted model or platform (the `gi-*` skills, `galaxy-bridge --run`). Each such skill is listed by name, with what it sends, in [data-handling.md](data-handling.md), and `tests/test_data_handling_doc.py` fails if a networked skill is missing from that page.
+- **Nothing is sent unless you run the skill.** `--demo` runs are offline except where the page says otherwise. Credentials are read from environment variables and never stored by ClawBio.
+- **File access scoping**: skills operate within the current working directory by default. Access to parent directories requires user confirmation.
+
+ClawBio does not currently offer a local backend for the Ensembl VEP-dependent skills, so a fully air-gapped deployment must exclude them or supply its own annotation source.
 
 ## Reproducibility Contract
 

--- a/docs/data-handling.md
+++ b/docs/data-handling.md
@@ -1,0 +1,143 @@
+# Data handling: what leaves your machine
+
+ClawBio is local-first. This page says exactly what that means, skill by skill,
+so that an institution can decide which skills it may run on data it is
+responsible for. It was written against `main` on 2026-09-04 by reading the
+code, not the descriptions. `tests/test_data_handling_doc.py` scans every skill
+for outbound-call code and fails if a networked skill is missing from this page,
+so the list cannot silently fall behind the code.
+
+## The short version
+
+- The `clawbio` package (CLI, runner, shared helpers) makes no network calls.
+  There is no telemetry, no update check, no analytics. The audit layer in
+  `clawbio/common/audit.py` writes a local JSONL file and nothing else.
+- Most skills never touch the network. They read your files, compute, and write
+  to the output directory you name.
+- The skills that do reach the network are all listed below, in five classes,
+  from least to most sensitive. Nothing is sent unless you run the skill, and a
+  `--demo` run is offline unless the table says otherwise.
+- Credentials are read from the environment variables named below. ClawBio
+  never stores them, and reproducibility bundles do not contain them.
+
+## The classes
+
+| Class | What is sent | Typical example |
+|-------|--------------|-----------------|
+| 1 | Nothing of yours. The skill downloads public reference data, summary statistics, package metadata or model weights. | `gwas-prs` fetching a PGS Catalog scoring file |
+| 2 | Query terms you typed: gene symbols, rsIDs, regions, drug names, trial IDs, SQL, free text. | `clinpgx` looking up a gene and drug |
+| 3 | Your variants: chromosome, position and alleles read from your VCF or genotype file, sometimes as HGVS strings or rsIDs. No sample identifier is sent, but a set of variants can identify a person on its own. | `vcf-annotator` sending each variant to Ensembl VEP |
+| 4 | Whole sequences or files uploaded to a third-party service or a hosted model. | `gi-annotation` uploading a FASTA sequence |
+| 5 | Your chat messages, photos and voice notes to a hosted language model. | The RoboTerri bot |
+
+## Class 3: skills that send your variants
+
+| Skill | Host(s) | What is sent | When | Offline |
+|-------|---------|--------------|------|---------|
+| `clinical-variant-reporter` | rest.ensembl.org, grch37.rest.ensembl.org (VEP) | Each variant as a region or HGVS string. No sample ID, no genotype for other loci. | Every non-demo run | `--demo` uses the bundled evidence cache and makes no call |
+| `vcf-annotator` | rest.ensembl.org (VEP), gnomad.broadinstitute.org (GraphQL), eutils.ncbi.nlm.nih.gov (ClinVar) | Per variant: `chrom:g.posref>alt` to VEP, `chrom-pos-ref-alt` to gnomAD, the rsID to ClinVar. NCBI requests carry `NCBI_TOOL_EMAIL` if set. | Every non-demo run | `--demo` uses bundled fixtures |
+| `variant-annotation` | rest.ensembl.org (VEP region endpoint) | A batch of variant strings in one POST body. | On a cache miss. Results are cached under `~/.clawbio/variant_annotation_cache` with a TTL. | Runs from the cache only for variants already seen |
+
+There is currently no local Ensembl VEP backend for these three skills. An
+air-gapped deployment must exclude them or supply its own annotation source.
+
+## Class 4: skills that upload sequences or files
+
+| Skill | Host(s) | What is sent | When | Credential |
+|-------|---------|--------------|------|------------|
+| `gi-annotation`, `gi-chromatin`, `gi-enhancer`, `gi-expression`, `gi-promoter`, `gi-splice` | api.genomicintelligence.ai (or `GI_BASE_URL`) | The entire nucleotide sequence from your FASTA, in the request body, through `clawbio/gi/gi_client.py`. | Every non-demo run. Fails without a key; there is no local fallback. | `GI_API_KEY` |
+| `galaxy-bridge` | usegalaxy.org by default, or `GALAXY_URL` (usegalaxy.eu is the other documented server) | Only with `--run`: your input file is uploaded to a history on that Galaxy server and the tool runs there. Without `--run` the skill only fetches the public tool catalogue (class 1). | `--run` only | `GALAXY_API_KEY` |
+| `flow-bio` | app.flow.bio (or `FLOW_URL`) | Queries against your own Flow account and, if you use the upload path, the sample files you name. | On run | `FLOW_TOKEN`, or `FLOW_USERNAME` and `FLOW_PASSWORD` |
+
+Each `gi-*` SKILL.md carries the same warning the client enforces: do not submit
+identifiable patient data to the hosted service without a data-use agreement.
+
+## Class 2: skills that send what you asked about
+
+| Skill | Host(s) | What is sent | Credential |
+|-------|---------|--------------|------------|
+| `gwas-lookup` | rest.ensembl.org, www.ebi.ac.uk (GWAS Catalog, eQTL Catalogue), gtexportal.org, r12.finngen.fi, pheweb.org, pheweb.jp, portaldev.sph.umich.edu, api.platform.opentargets.org, sashagusev.github.io | The rsID you pass with `--rsid`, and the gene and region derived from it. If that rsID is one of your own variants, it leaves the machine. Results cache locally; `--demo` uses pre-fetched data. | none |
+| `fine-mapping` | rest.ensembl.org | Region and gene lookups for the locus being fine-mapped, used to annotate the report. Summary statistics are processed locally. | none |
+| `locuscompare-region-render` | rest.ensembl.org (plus the class 1 downloads below) | Region and gene lookups for the plotted locus. | none |
+| `pathway-enricher` | maayanlab.cloud (Enrichr) | Your gene list, in full. | none |
+| `clinical-trial-finder` | clinicaltrials.gov, www.clinicaltrialsregister.eu, api.platform.opentargets.org, www.ebi.ac.uk, id.nlm.nih.gov and hl7.org terminology lookups | The gene, rsID, condition or free-text query you pass; a `--input` file of genes is sent term by term. | none |
+| `clinpgx` | api.clinpgx.org | Gene, drug and star-allele names. | none |
+| `omics-target-evidence-mapper` | api.platform.opentargets.org, rest.uniprot.org, clinicaltrials.gov, eutils.ncbi.nlm.nih.gov | Target and gene symbols. | none |
+| `lit-synthesizer` | eutils.ncbi.nlm.nih.gov, api.biorxiv.org | Your free-text literature query. | none |
+| `pubmed-summariser` | eutils.ncbi.nlm.nih.gov | Your free-text PubMed query. | none |
+| `article-data-fetcher` | eutils, pmc, ftp and edata at ncbi.nlm.nih.gov, api.crossref.org, api.datacite.org, api.figshare.com, datadryad.org, www.ebi.ac.uk | Article identifiers (PMID, PMCID, DOI). | none |
+| `protocols-io` | www.protocols.io | Search terms and protocol identifiers, against your account. | `PROTOCOLS_IO_ACCESS_TOKEN` |
+| `labstep` | The Labstep service, through the `labstepPy` client | Reads and writes to your own Labstep workspace: experiment, protocol and inventory records you ask for or create. `--demo` is offline synthetic data. | `LABSTEP_API_KEY` |
+| `illumina-bridge` | ica.illumina.com (or `ILLUMINA_ICA_BASE_URL`) | Metadata queries against your own Illumina Connected Analytics projects. | `ILLUMINA_ICA_API_KEY` |
+| `xena-tcga-gene-query` | biotree.top:38123 over plain HTTP by default (or `UCSCXENA_API_BASE_URL`) | Gene symbols and cohort names. Note the default endpoint is unencrypted HTTP to a third-party host. | `UCSCXENA_API_KEY` |
+| `bigquery-public` | Google BigQuery (www.googleapis.com) | The SQL you write against public datasets, under your Google credentials. | Google application default credentials |
+| `ukb-navigator` | Voyage AI, only if `VOYAGE_API_KEY` is set | The text of your query, for embedding. Without the key the skill uses the local ChromaDB default embedding and makes no call. | `VOYAGE_API_KEY` (optional) |
+| `bgpt-mcp` | bgpt.pro (remote MCP server at `/mcp/sse` and `/mcp/stream`) | Your free-text literature question. This skill has no code of its own; the agent connects to the remote server directly. Free for the first results, key thereafter. | optional bgpt.pro key |
+
+## Class 1: skills that download reference data only
+
+Nothing derived from your data is sent. These skills fetch public files and
+cache them locally where noted.
+
+| Skill | Host(s) | What is fetched | Credential |
+|-------|---------|-----------------|------------|
+| `gwas-prs` | www.pgscatalog.org, ftp.ebi.ac.uk | PGS Catalog score metadata and harmonised scoring files. Your genotypes are scored locally and never leave. | none |
+| `just-prs-mcp` | PyPI, through `uvx`, on first run | The pinned `just-prs-mcp` package. The MCP server it starts is local stdio, not remote. | none |
+| `eqtl-catalogue-region-fetch` | ftp.ebi.ac.uk, www.ebi.ac.uk | eQTL Catalogue summary statistics for a region. Cache: `EQTL_CATALOGUE_CACHE_DIR`. | none |
+| `gwas-catalog-region-fetch` | ftp.ebi.ac.uk | GWAS Catalog summary statistics for a region. Cache: `GWAS_CATALOG_CACHE_DIR`. | none |
+| `ld-1000g-region-compute` | ftp.1000genomes.ebi.ac.uk, www.cog-genomics.org | 1000 Genomes reference genotypes for the region, and the plink binary if `PLINK_BIN` is unset. LD is computed locally. | none |
+| `ukb-ppp-region-fetch` | www.synapse.org, repo-prod.prod.sagebase.org | UKB-PPP summary statistics for a region. Cache: `UKB_PPP_CACHE_DIR`. | `SYNAPSE_AUTH_TOKEN` |
+| `bioconductor-bridge` | bioconductor.org | Package metadata for recommendations. | none |
+| `busco-assessor` | eutils.ncbi.nlm.nih.gov, ftp.ensemblgenomes.org | Taxonomy lookups and BUSCO lineage datasets. | `NCBI_API_KEY` (optional) |
+| `deepspot-m` | huggingface.co | Model weights on first use. Inference is local. | none |
+| `proteomics-clock` | raw.githubusercontent.com | Published coefficient tables, cached under `CLAWBIO_CACHE`. | none |
+| `nfcore-rnaseq-wrapper`, `nfcore-sarek-wrapper`, `nfcore-scrnaseq-wrapper` | nf-co.re, github.com, and the container registries the pipeline declares | Nextflow pulls the pinned pipeline and its containers. Your samples stay in the local work directory. Set `NXF_OFFLINE=true` with pre-pulled assets to forbid all of it. | none (Sentieon licence variables for that sarek path only) |
+
+## Class 5: the RoboTerri bot
+
+`bot/` (Telegram, Discord and WhatsApp adapters) is an optional conversational
+interface, not part of the skill library. Every message, photo and voice note
+you send it goes to the language model at `LLM_BASE_URL` using `LLM_API_KEY`
+(falling back to `OPENAI_API_KEY`); the default model is `gemini-2.0-flash`
+through an OpenAI-compatible endpoint, and voice replies use the `tts-1` model
+on the same key. The messaging platforms themselves see every message by
+construction. `drug-photo` has no code of its own: the photo is interpreted by
+the vision model of whichever agent is driving the skill.
+
+## Viewer assets
+
+Two skills reference public CDNs for display only. `struct-predictor` fetches
+3Dmol.js from cdnjs.cloudflare.com when building its HTML viewer and falls back
+to an inline copy; `analyze-fasta` HTML reports reference fonts.googleapis.com
+when opened in a browser. Neither sends any data.
+
+## Checked and found to make no outbound call
+
+These were on the list of things to check because their names or descriptions
+suggest a service, and they do not call one: `bioqc-mcp` (a local stdio MCP
+server), `turingdb-graph` (localhost only), `affinity-proteomics`, `wgs-prs`,
+`genome-compare`, `pharmgx-reporter` (the Ensembl URLs in its source are
+comments and citation links), and `drug-photo` (no code).
+
+## Running ClawBio with egress blocked
+
+- Everything not in classes 2 to 5 works with outbound network blocked once
+  class 1 assets are cached.
+- Class 3 skills need Ensembl VEP, gnomAD or ClinVar. Until a local backend
+  exists, exclude them or route their hosts through an internal mirror you
+  control.
+- Never put an API key in a skill's input file or output directory.
+  Reproducibility bundles record commands and file paths, so review them
+  before sharing.
+- ClawBio is a research tool, not a medical device. This page is a factual
+  description of network behaviour, not a compliance statement under GDPR,
+  HIPAA or any other regime. Your institution's own review still applies.
+
+## Keeping this page true
+
+`tests/test_data_handling_doc.py` scans every skill for outbound-call code
+(`requests`, `urllib`, `httpx`, the Genomic Intelligence client, Nextflow and
+`uvx` launches, cloud SDKs) and for declared remote endpoints in SKILL.md
+frontmatter, and fails when a skill it finds is not named on this page. When
+you add a network call to a skill, add a row here in the same pull request and
+say what is sent.

--- a/docs/data-handling.md
+++ b/docs/data-handling.md
@@ -106,10 +106,12 @@ the vision model of whichever agent is driving the skill.
 
 ## Viewer assets
 
-Two skills reference public CDNs for display only. `struct-predictor` fetches
-3Dmol.js from cdnjs.cloudflare.com when building its HTML viewer and falls back
-to an inline copy; `analyze-fasta` HTML reports reference fonts.googleapis.com
-when opened in a browser. Neither sends any data.
+Two skills reference public CDNs for display only. Neither sends any data.
+
+| Skill | Host(s) | What is fetched |
+|-------|---------|-----------------|
+| `struct-predictor` | cdnjs.cloudflare.com | 3Dmol.js, fetched when the HTML viewer is built, with an inline copy as fallback. |
+| `analyze-fasta` | fonts.googleapis.com | Web fonts referenced by the HTML report, loaded by your browser when you open it. |
 
 ## Checked and found to make no outbound call
 

--- a/llms.txt
+++ b/llms.txt
@@ -13,6 +13,8 @@
 - [docs/CLAWBIO-BRIEF.md](docs/CLAWBIO-BRIEF.md): Evergreen project brief for collaborators, investors, and agents
 - [docs/reference-genome.md](docs/reference-genome.md): Corpas 30x WGS reference genome used across demos, tutorials, and benchmarking
 - [CONTRIBUTING.md](CONTRIBUTING.md): Contribution workflow, naming conventions, code standards
+- [SECURITY.md](SECURITY.md): How to report a vulnerability privately, response commitments, scope, supported versions
+- [docs/data-handling.md](docs/data-handling.md): Every skill that can send data off the machine, what it sends, to which host, and which credential it needs
 
 ## Slash Commands
 

--- a/skills/gwas-prs/SKILL.md
+++ b/skills/gwas-prs/SKILL.md
@@ -75,11 +75,18 @@ When the user asks for a polygenic risk score calculation:
 
    > The panel files use names such as `CLAWBIO-T2D-8_GRCh37.txt`; they no
    > longer occupy PGS Catalog download-cache paths. `--trait` and all PGS
-   > accessions except PGS000013 therefore use genuine Catalog data. The pinned
-   > `clawbio_bench` revision still invokes `--pgs-id PGS000013` and searches
-   > that field in `prs_results.json`, so that single call is an explicit,
-   > marked compatibility alias for `CLAWBIO-T2D-8`. Normal panel runs must use
-   > `--panel-id CLAWBIO-T2D-8`. See issue #356.
+   > accessions therefore use genuine Catalog data, PGS000013 included:
+   > `--pgs-id PGS000013` fetches Khera 2018 (coronary artery disease,
+   > 6,630,150 variants) from the Catalog and refuses to substitute the
+   > 8-variant curated panel. Normal panel runs must use
+   > `--panel-id CLAWBIO-T2D-8`.
+   >
+   > One exception exists for the benchmark. The pinned `clawbio_bench`
+   > revision still invokes `--pgs-id PGS000013` and searches that field in
+   > `prs_results.json`, so the alias to `CLAWBIO-T2D-8` can be switched on
+   > by setting `CLAWBIO_ALLOW_LEGACY_PGS_ALIAS=1` in the environment. The
+   > benchmark workflow sets it; nothing else should. Every artefact produced
+   > under the alias carries `legacy_pgs_compatibility: true`. See issue #356.
 
 3. **Parse scoring file**: Read the PGS harmonised scoring file. Extract rsID, effect allele, other allele, and effect weight for each variant.
 

--- a/skills/gwas-prs/gwas_prs.py
+++ b/skills/gwas-prs/gwas_prs.py
@@ -15,6 +15,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import os
 import gzip
 import hashlib
 import json
@@ -204,6 +205,39 @@ CURATED_SCORES: dict[str, dict] = {
 LEGACY_PGS_PANEL_COMPAT = {
     "PGS000013": "CLAWBIO-T2D-8",
 }
+
+# What the aliased accession really is, so a refusal can say so.
+LEGACY_PGS_ACCESSION_FACTS = {
+    "PGS000013": "Khera AV et al. 2018, coronary artery disease, 6,630,150 variants",
+}
+
+# Issue #356, remaining half. The alias above fires only when the caller opts
+# in by setting this variable to a true value. The benchmark workflow sets it
+# (.github/workflows/bench-leaderboard.yml); nothing else should. Without it,
+# ``--pgs-id PGS000013`` is treated as what it is, a PGS Catalog accession,
+# and fetched from the Catalog like any other. Scoring the wrong panel in
+# answer to a specific request is never the default.
+LEGACY_ALIAS_ENV = "CLAWBIO_ALLOW_LEGACY_PGS_ALIAS"
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def legacy_alias_enabled(environ=None) -> bool:
+    """True only when ``CLAWBIO_ALLOW_LEGACY_PGS_ALIAS`` holds a true value."""
+    env = os.environ if environ is None else environ
+    return str(env.get(LEGACY_ALIAS_ENV, "")).strip().lower() in _TRUE_VALUES
+
+
+def explain_legacy_accession(pgs_id: str, panel_id: str) -> None:
+    """Tell the caller what the accession is and how to get the panel instead."""
+    facts = LEGACY_PGS_ACCESSION_FACTS.get(pgs_id, "a published PGS Catalog score")
+    print(
+        f"GWAS-PRS: {pgs_id} is a PGS Catalog accession ({facts}), "
+        f"not the curated panel {panel_id}."
+    )
+    print("  ClawBio does not substitute the panel for the accession.")
+    print(f"  For the curated panel use --panel-id {panel_id}.")
+    print("  See ClawBio issue #356.")
+    print()
 
 
 # ---------------------------------------------------------------------------
@@ -1237,7 +1271,7 @@ def main():
             pgs_id = "PGS" + pgs_id.lstrip("0")
 
         compat_panel_id = LEGACY_PGS_PANEL_COMPAT.get(pgs_id)
-        if compat_panel_id:
+        if compat_panel_id and legacy_alias_enabled():
             meta = CURATED_SCORES[compat_panel_id]
             filepath = curated_panel_path(compat_panel_id, args.build)
             if not filepath.exists():
@@ -1266,6 +1300,8 @@ def main():
                 },
             })
         else:
+            if compat_panel_id:
+                explain_legacy_accession(pgs_id, compat_panel_id)
             print(f"GWAS-PRS: fetching score {pgs_id}")
             print()
             local_path = DATA_DIR / f"{pgs_id}_hmPOS_{args.build}.txt"
@@ -1289,8 +1325,10 @@ def main():
                 try:
                     print(f"  Fetching metadata for {pgs_id}...")
                     meta_data = client.get_score_metadata(pgs_id)
-                except requests.HTTPError as e:
+                except requests.RequestException as e:
                     print(f"Error: could not fetch {pgs_id}: {e}")
+                    if compat_panel_id:
+                        print(f"  For the curated panel use --panel-id {compat_panel_id}.")
                     sys.exit(1)
 
                 trait_name = "Unknown"

--- a/skills/gwas-prs/tests/test_curated_panel_ids.py
+++ b/skills/gwas-prs/tests/test_curated_panel_ids.py
@@ -10,6 +10,7 @@ are provenance or a narrowly-scoped compatibility alias only.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from importlib.util import module_from_spec, spec_from_file_location
@@ -42,7 +43,9 @@ ENGINE = _load_module("gwas_prs_panel_ids", SKILL_DIR / "gwas_prs.py")
 API = _load_module("gwas_prs_api_panel_ids", SKILL_DIR / "api.py")
 
 
-def _run_cli(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+def _run_cli(
+    tmp_path: Path, *args: str, env: dict | None = None
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [
             sys.executable,
@@ -56,6 +59,7 @@ def _run_cli(tmp_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
         capture_output=True,
         text=True,
         timeout=120,
+        env={**os.environ, **(env or {})},
     )
 
 
@@ -124,7 +128,12 @@ class TestPanelCli:
         assert "choose exactly one" in (proc.stdout + proc.stderr).lower()
 
     def test_pinned_benchmark_alias_stays_machine_compatible(self, tmp_path):
-        proc = _run_cli(tmp_path, "--pgs-id", "PGS000013")
+        # The alias is opt-in since #356's refusal landed; the benchmark
+        # workflow sets this variable. See test_legacy_alias_opt_in.py.
+        proc = _run_cli(
+            tmp_path, "--pgs-id", "PGS000013",
+            env={"CLAWBIO_ALLOW_LEGACY_PGS_ALIAS": "1"},
+        )
         assert proc.returncode == 0, proc.stdout + proc.stderr
         assert "benchmark compatibility" in (proc.stdout + proc.stderr).lower()
         result = json.loads((tmp_path / "prs_results.json").read_text())[0]

--- a/skills/gwas-prs/tests/test_legacy_alias_opt_in.py
+++ b/skills/gwas-prs/tests/test_legacy_alias_opt_in.py
@@ -1,0 +1,135 @@
+"""Issue #356, remaining half: the ``--pgs-id PGS000013`` alias must be opt-in.
+
+PGS000013 is the PGS Catalog accession for Khera 2018 coronary artery disease
+(6,630,150 variants). ClawBio ships an 8-variant curated type 2 diabetes panel
+that historically answered to that accession. After #357 and #380 the alias
+still fired silently on every ``--pgs-id PGS000013`` run, because the pinned
+clawbio_bench revision drives eight scoring cases through exactly that path.
+
+These tests pin the resolution: the alias fires only when the caller sets
+``CLAWBIO_ALLOW_LEGACY_PGS_ALIAS=1``. The benchmark workflow sets it. Nothing
+else does, so an ordinary user asking for PGS000013 is told what the accession
+really is and pointed at ``--panel-id CLAWBIO-T2D-8`` for the panel.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+import yaml
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+PROJECT_ROOT = SKILL_DIR.parent.parent
+OPT_IN = "CLAWBIO_ALLOW_LEGACY_PGS_ALIAS"
+
+# A proxy nothing listens on. requests honours HTTPS_PROXY, so any attempt to
+# reach the PGS Catalog fails immediately and deterministically instead of
+# fetching a 6.6M-variant score in the middle of a unit test.
+OFFLINE = {"HTTPS_PROXY": "http://127.0.0.1:9", "HTTP_PROXY": "http://127.0.0.1:9",
+           "NO_PROXY": ""}
+
+
+def _load_engine():
+    spec = spec_from_file_location("gwas_prs_alias_opt_in", SKILL_DIR / "gwas_prs.py")
+    module = module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ENGINE = _load_engine()
+
+
+def _run(tmp_path: Path, *args: str, env: dict | None = None) -> subprocess.CompletedProcess[str]:
+    merged = {k: v for k, v in os.environ.items() if k != OPT_IN}
+    merged.update(OFFLINE)
+    merged.update(env or {})
+    return subprocess.run(
+        [sys.executable, str(SKILL_DIR / "gwas_prs.py"),
+         "--input", str(SKILL_DIR / "demo_patient_prs.txt"),
+         "--output", str(tmp_path), *args],
+        capture_output=True, text=True, timeout=120, env=merged,
+    )
+
+
+class TestOptInSwitch:
+    def test_disabled_when_unset(self):
+        assert ENGINE.legacy_alias_enabled({}) is False
+
+    def test_enabled_only_by_an_explicit_true_value(self):
+        for value in ("1", "true", "TRUE", "yes", "on"):
+            assert ENGINE.legacy_alias_enabled({OPT_IN: value}) is True, value
+        for value in ("", "0", "false", "no", "off", "PGS000013"):
+            assert ENGINE.legacy_alias_enabled({OPT_IN: value}) is False, value
+
+    def test_env_var_name_is_the_documented_one(self):
+        assert ENGINE.LEGACY_ALIAS_ENV == OPT_IN
+
+
+class TestRefusalWithoutOptIn:
+    def test_pgs000013_is_not_substituted(self, tmp_path):
+        proc = _run(tmp_path, "--pgs-id", "PGS000013")
+        combined = proc.stdout + proc.stderr
+        assert "benchmark compatibility" not in combined.lower()
+        assert "Traceback" not in proc.stderr
+        # Offline, the genuine Catalog fetch cannot succeed, so the run fails
+        # rather than quietly scoring the wrong panel.
+        assert proc.returncode != 0
+        assert "--panel-id CLAWBIO-T2D-8" in combined
+        assert "PGS Catalog accession" in combined
+        results = tmp_path / "prs_results.json"
+        if results.exists():
+            for row in json.loads(results.read_text()):
+                assert row.get("legacy_pgs_compatibility") is not True
+
+    def test_refusal_names_what_the_accession_really_is(self, tmp_path):
+        proc = _run(tmp_path, "--pgs-id", "PGS000013")
+        combined = (proc.stdout + proc.stderr).lower()
+        assert "coronary artery disease" in combined
+        assert "khera" in combined
+
+    def test_a_false_value_does_not_enable_the_alias(self, tmp_path):
+        proc = _run(tmp_path, "--pgs-id", "PGS000013", env={OPT_IN: "0"})
+        assert "benchmark compatibility" not in (proc.stdout + proc.stderr).lower()
+        assert proc.returncode != 0
+
+
+class TestAliasWithOptIn:
+    def test_benchmark_path_still_works_when_opted_in(self, tmp_path):
+        proc = _run(tmp_path, "--pgs-id", "PGS000013", env={OPT_IN: "1"})
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert "benchmark compatibility" in (proc.stdout + proc.stderr).lower()
+        result = json.loads((tmp_path / "prs_results.json").read_text())[0]
+        assert result["score_id"] == "CLAWBIO-T2D-8"
+        assert result["pgs_id"] == "PGS000013"
+        assert result["legacy_pgs_compatibility"] is True
+
+    def test_opt_in_does_not_widen_the_alias_table(self):
+        assert ENGINE.LEGACY_PGS_PANEL_COMPAT == {"PGS000013": "CLAWBIO-T2D-8"}
+
+
+class TestTheBenchmarkWorkflowOptsIn:
+    """The refusal is only safe to ship if the pinned benchmark keeps working.
+    That depends on one line of workflow YAML, so pin it."""
+
+    def test_smoke_run_step_sets_the_opt_in(self):
+        wf = yaml.safe_load(
+            (PROJECT_ROOT / ".github" / "workflows" / "bench-leaderboard.yml").read_text()
+        )
+        steps = wf["jobs"]["bench"]["steps"]
+        smoke = [s for s in steps if "uv run clawbio-bench" in str(s.get("run", ""))]
+        assert len(smoke) == 1, "expected exactly one step that runs clawbio-bench"
+        env = smoke[0].get("env") or {}
+        assert str(env.get(OPT_IN)) == "1"
+
+
+class TestDocsAgreeWithCode:
+    def test_skill_md_documents_the_opt_in(self):
+        text = (SKILL_DIR / "SKILL.md").read_text()
+        assert OPT_IN in text
+        assert "--panel-id CLAWBIO-T2D-8" in text

--- a/skills/gwas-prs/tests/test_legacy_alias_opt_in.py
+++ b/skills/gwas-prs/tests/test_legacy_alias_opt_in.py
@@ -21,6 +21,7 @@ import sys
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
+import pytest
 import yaml
 
 SKILL_DIR = Path(__file__).resolve().parent.parent
@@ -48,6 +49,11 @@ ENGINE = _load_engine()
 def _run(tmp_path: Path, *args: str, env: dict | None = None) -> subprocess.CompletedProcess[str]:
     merged = {k: v for k, v in os.environ.items() if k != OPT_IN}
     merged.update(OFFLINE)
+    # The PGS Catalog client caches metadata under ~/.clawbio/pgs_cache for 24h.
+    # A developer who ran --pgs-id PGS000013 by hand would otherwise make these
+    # tests pass or fail depending on what their home directory remembers.
+    merged["HOME"] = str(tmp_path / "home")
+    (tmp_path / "home").mkdir(exist_ok=True)
     merged.update(env or {})
     return subprocess.run(
         [sys.executable, str(SKILL_DIR / "gwas_prs.py"),
@@ -113,19 +119,28 @@ class TestAliasWithOptIn:
         assert ENGINE.LEGACY_PGS_PANEL_COMPAT == {"PGS000013": "CLAWBIO-T2D-8"}
 
 
-class TestTheBenchmarkWorkflowOptsIn:
+class TestTheBenchmarkWorkflowsOptIn:
     """The refusal is only safe to ship if the pinned benchmark keeps working.
-    That depends on one line of workflow YAML, so pin it."""
+    Two workflows run it (the weekly leaderboard and the CI scientific audit,
+    whose baseline comparison is a gate), and each depends on one line of YAML."""
 
-    def test_smoke_run_step_sets_the_opt_in(self):
-        wf = yaml.safe_load(
-            (PROJECT_ROOT / ".github" / "workflows" / "bench-leaderboard.yml").read_text()
-        )
-        steps = wf["jobs"]["bench"]["steps"]
-        smoke = [s for s in steps if "uv run clawbio-bench" in str(s.get("run", ""))]
-        assert len(smoke) == 1, "expected exactly one step that runs clawbio-bench"
+    WORKFLOWS = ("bench-leaderboard.yml", "ci.yml")
+
+    def _smoke_steps(self, workflow: str) -> list[dict]:
+        wf = yaml.safe_load((PROJECT_ROOT / ".github" / "workflows" / workflow).read_text())
+        return [
+            step
+            for job in wf["jobs"].values()
+            for step in job.get("steps", [])
+            if "clawbio-bench --smoke" in str(step.get("run", ""))
+        ]
+
+    @pytest.mark.parametrize("workflow", WORKFLOWS)
+    def test_every_smoke_run_sets_the_opt_in(self, workflow):
+        smoke = self._smoke_steps(workflow)
+        assert len(smoke) == 1, f"{workflow}: expected exactly one clawbio-bench --smoke step"
         env = smoke[0].get("env") or {}
-        assert str(env.get(OPT_IN)) == "1"
+        assert str(env.get(OPT_IN)) == "1", f"{workflow}: smoke step does not opt in"
 
 
 class TestDocsAgreeWithCode:

--- a/skills/gwas-prs/tests/test_score_provenance.py
+++ b/skills/gwas-prs/tests/test_score_provenance.py
@@ -202,6 +202,7 @@ class TestCuratedPanelsNeverShadowARealScore:
 # call sites, and a behavioural change with no test. These pin all four.
 # ---------------------------------------------------------------------------
 
+import os
 import subprocess
 import sys
 
@@ -262,12 +263,17 @@ class TestBothCallSitesAreGuarded:
 class TestTheMitigationActuallyRuns:
     """Deleting the warning block used to leave all 78 tests green."""
 
+    # These tests exercise the benchmark compatibility alias, which is opt-in
+    # since #356's refusal landed. See test_legacy_alias_opt_in.py for the
+    # default (refusing) behaviour.
+    _ALIAS_ENV = {**os.environ, "CLAWBIO_ALLOW_LEGACY_PGS_ALIAS": "1"}
+
     def _run(self, tmp_path, *args):
         return subprocess.run(
             [sys.executable, str(SKILL_DIR / "gwas_prs.py"),
              "--input", str(SKILL_DIR / "demo_patient_prs.txt"),
              "--output", str(tmp_path), *args],
-            capture_output=True, text=True, timeout=120,
+            capture_output=True, text=True, timeout=120, env=self._ALIAS_ENV,
         )
 
     def test_pgs_id_path_warns_on_stdout(self, tmp_path):

--- a/tests/test_data_handling_doc.py
+++ b/tests/test_data_handling_doc.py
@@ -1,0 +1,112 @@
+"""docs/data-handling.md must name every skill that can send data off the machine.
+
+A prose promise that "networked skills are individually labelled" governs
+nothing. This test scans every skill for outbound-call code, or for a declared
+remote endpoint, or for use of the hosted Genomic Intelligence client, and
+fails if any such skill is missing from the data-handling page. Add a row to
+the page when you add a network call; the page is the contract institutions
+read.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILLS = ROOT / "skills"
+DOC = ROOT / "docs" / "data-handling.md"
+
+CALL = re.compile(
+    r"requests\.(get|post|put|delete|request|Session)\(|urllib\.request\.urlopen\(|urlopen\(|"
+    r"httpx\.|aiohttp|\bsubprocess\.[a-z_]+\([^)]*\b(curl|wget|nextflow)\b|download\.file\(|"
+    r"httr::|bioblend|BioBlend|AsyncOpenAI\(|OpenAI\(|from clawbio\.gi|import clawbio\.gi|"
+    r"session\.(get|post)\(|voyageai|google\.cloud\.bigquery|huggingface_hub|hf_hub_download|"
+    r"from_pretrained\(|(import|from) labstep|synapseclient|[\"']uvx[\"']|[\"']nextflow[\"']\s*,\s*[\"']run[\"']"
+)
+SOURCE_SUFFIXES = (".py", ".R", ".r", ".sh")
+
+
+def skills_that_reach_the_network() -> set[str]:
+    found: set[str] = set()
+    for skill_dir in sorted(p for p in SKILLS.iterdir() if p.is_dir()):
+        name = skill_dir.name
+        for path in skill_dir.rglob("*"):
+            if not path.is_file() or path.suffix not in SOURCE_SUFFIXES:
+                continue
+            if "tests" in path.parts or "node_modules" in path.parts:
+                continue
+            text = path.read_text(errors="ignore")
+            if CALL.search(text):
+                found.add(name)
+                break
+        skill_md = skill_dir / "SKILL.md"
+        if skill_md.exists():
+            match = re.match(r"^---\n(.*?)\n---", skill_md.read_text(errors="ignore"), re.S)
+            try:
+                front = yaml.safe_load(match.group(1)) if match else {}
+            except yaml.YAMLError:
+                front = {}
+            endpoints = ((front or {}).get("metadata") or {}).get("endpoints")
+            if isinstance(endpoints, (list, dict)):
+                values = endpoints if isinstance(endpoints, list) else endpoints.values()
+                if any(isinstance(v, str) and v.startswith("http") for v in values):
+                    found.add(name)
+    return found
+
+
+def documented_skills() -> set[str]:
+    text = DOC.read_text()
+    return set(re.findall(r"`([a-z0-9][a-z0-9-]*)`", text))
+
+
+def test_data_handling_page_exists():
+    assert DOC.exists(), "docs/data-handling.md is missing"
+
+
+def test_every_networked_skill_is_documented():
+    networked = skills_that_reach_the_network()
+    assert networked, "scanner found nothing, which means the scanner is broken"
+    missing = sorted(networked - documented_skills())
+    assert not missing, (
+        "skills that reach the network but are absent from docs/data-handling.md: "
+        + ", ".join(missing)
+    )
+
+
+def documented_rows() -> set[str]:
+    """Skill names in the first cell of every table row (several rows list more than one)."""
+    names: set[str] = set()
+    for line in DOC.read_text().splitlines():
+        if line.startswith("| `"):
+            first_cell = line.split("|")[1]
+            names.update(re.findall(r"`([a-z0-9][a-z0-9-]*)`", first_cell))
+    return names
+
+
+def test_documented_skills_exist():
+    """A row for a skill that no longer exists is a stale claim."""
+    existing = {p.name for p in SKILLS.iterdir() if p.is_dir()}
+    stale = sorted(documented_rows() - existing)
+    assert not stale, f"docs/data-handling.md has rows for skills that do not exist: {stale}"
+
+
+def test_rows_cover_every_scanned_skill_or_the_checked_list():
+    """Every scanned skill must have a table row, except those the page explicitly
+    lists as checked and clean, which must still be named."""
+    networked = skills_that_reach_the_network()
+    rows = documented_rows()
+    text = DOC.read_text()
+    checked_section = text.split("## Checked and found to make no outbound call", 1)[-1]
+    checked = set(re.findall(r"`([a-z0-9][a-z0-9-]*)`", checked_section.split("## ", 1)[0]))
+    unaccounted = sorted(networked - rows - checked)
+    assert not unaccounted, f"scanned skills with neither a row nor a checked entry: {unaccounted}"
+
+
+def test_scanner_still_fires_on_a_known_networked_skill():
+    """If the regex rots, the page silently stops being enforced."""
+    networked = skills_that_reach_the_network()
+    for known in ("vcf-annotator", "clinical-variant-reporter", "gi-annotation", "pathway-enricher"):
+        assert known in networked, f"scanner no longer detects {known}"


### PR DESCRIPTION
## Summary

- `--pgs-id PGS000013` no longer scores the curated 8-variant T2D panel. It now fetches the real accession (Khera 2018, coronary artery disease, 6,630,150 variants) from the PGS Catalog like any other, and when it cannot, fails with a message that says what the accession is and how to request the panel (`--panel-id CLAWBIO-T2D-8`).
- The benchmark compatibility alias still exists but is opt-in: `CLAWBIO_ALLOW_LEGACY_PGS_ALIAS=1`. Only the two workflow steps that run the pinned `clawbio_bench` smoke suite set it: the weekly leaderboard in `bench-leaderboard.yml` and the `scientific-audit` job in `ci.yml`, whose baseline comparison would otherwise drop the gwas-prs harness from 62.5% to 0% on every PR. Drop both lines once the bench requests `--panel-id CLAWBIO-T2D-8`.
- Network failures on the `--pgs-id` path now report cleanly (`requests.RequestException`) instead of raising a traceback.

Closes #356 (the refusal half; the accession rename landed in #380).

## Skill affected

gwas-prs. No change to any artefact produced under `--panel-id`, `--trait` or `--demo`.

## Checklist

- [x] SKILL.md is present and updated (documents the opt-in and the refusal)
- [x] Tests included and passing: 167 in `skills/gwas-prs/tests/`, 11 new
- [x] Demo data included for reviewers to test (unchanged)
- [x] No patient/sensitive data committed
- [x] Follows CONTRIBUTING.md conventions

## Verification

- New tests run offline through a dead proxy (`HTTPS_PROXY=http://127.0.0.1:9`) with a throwaway `HOME`, so no test can pull a 6.6M-variant score or pass through a developer's `~/.clawbio/pgs_cache`.
- Deleting the gate (`and legacy_alias_enabled()`) makes `test_pgs000013_is_not_substituted` fail; the guard is measured, not assumed.
- A test parses both workflow files and fails if any `clawbio-bench --smoke` step stops opting in.
- Live run without the opt-in against the real Catalog:

```
GWAS-PRS: PGS000013 is a PGS Catalog accession (Khera AV et al. 2018, coronary artery disease, 6,630,150 variants), not the curated panel CLAWBIO-T2D-8.
  ClawBio does not substitute the panel for the accession.
  For the curated panel use --panel-id CLAWBIO-T2D-8.
  See ClawBio issue #356.

GWAS-PRS: fetching score PGS000013
  Fetching metadata for PGS000013...
  Trait: coronary artery disorder
  Variants: 6630150
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default gwas-prs behavior for `--pgs-id PGS000013` changes in a clinically sensitive area; benchmark compatibility depends on CI env vars staying set until clawbio_bench is updated.
> 
> **Overview**
> **gwas-prs** no longer silently maps `--pgs-id PGS000013` to the curated T2D panel `CLAWBIO-T2D-8`. Without opt-in, that accession is treated as the real PGS Catalog score (Khera 2018 CAD); failures explain the mismatch and point users to `--panel-id CLAWBIO-T2D-8`. The legacy benchmark alias remains behind **`CLAWBIO_ALLOW_LEGACY_PGS_ALIAS=1`**, set only on the two **`clawbio-bench --smoke`** steps in CI and the weekly leaderboard workflow; outputs under the alias are flagged **`legacy_pgs_compatibility: true`**. Catalog fetch errors on the `--pgs-id` path now surface as clean **`requests.RequestException`** messages instead of tracebacks.
> 
> The PR also adds **`SECURITY.md`** (private disclosure, scope, supported versions) and **`docs/data-handling.md`** (per-skill egress inventory), with **`tests/test_data_handling_doc.py`** enforcing that every networked skill appears on that page. **README**, **`docs/architecture.md`**, **`CHANGELOG`**, and **`llms.txt`** drop overstated “no network” claims, link the new docs, and bump the stated release to **v0.7.0**. New and updated **gwas-prs** tests cover opt-in/refusal behavior and workflow YAML wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 907467e3b3cb5ebe193151f50b65ce7b71a07993. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->