### PR TITLE
feat(skill-builder): write reproducibility bundles via clawbio.common

### DIFF
--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -146,7 +146,7 @@ Full spec with all optional fields:
 3. **Fill defaults**: domain → "bioinformatics", version → "0.1.0", capabilities/triggers → generic placeholders
 4. **Render SKILL.md**: Fill YAML frontmatter + all 13 required body sections from template
 5. **Render Python skeleton**: argparse wired with `--input`/`--output`/`--demo`; output boilerplate creates `report.md`, `result.json`, reproducibility bundle
-6. **Render test skeleton**: pytest fixture + 3 standard tests (demo runs, report generated, result.json valid)
+6. **Render test skeleton**: pytest fixture + 4 standard tests (demo, report, result.json, reproducibility bundle)
 7. **Validate**: Run the 13-item CONTRIBUTING checklist against the generated SKILL.md before writing
 8. **Register**: Append catalog entry; patch `clawbio.py` SKILLS dict via targeted string replacement
 
@@ -164,7 +164,9 @@ output_directory/
 ├── report.md                   # Summary of what was generated
 ├── result.json                 # Machine-readable scaffold manifest
 └── reproducibility/
-    └── commands.sh             # Exact command to reproduce the scaffold
+    ├── commands.sh             # Exact command to reproduce the scaffold
+    ├── environment.yml         # Environment snapshot
+    └── checksums.sha256        # SHA-256 of report.md and result.json
 
 Generated skill at skills/<name>/:
 ├── SKILL.md                    # Complete skill definition
@@ -188,7 +190,7 @@ Generated skill at skills/<name>/:
 - **Local-first**: No network calls; all generation is offline
 - **Non-destructive**: Never overwrites existing files without `--force`; prompts or errors if destination exists
 - **No hallucinated science**: All generated SKILL.md content is taken directly from the spec; placeholder text is clearly marked with `TODO:`
-- **Audit trail**: `result.json` and `commands.sh` record exactly what was generated and when
+- **Audit trail**: `result.json` and the reproducibility bundle record exactly what was generated and when
 
 ## Integration with Bio Orchestrator
 

--- a/skills/skill-builder/demo_spec.json
+++ b/skills/skill-builder/demo_spec.json
@@ -18,7 +18,7 @@
     "Accept a list of sample IDs from a plain-text file (one per line)",
     "Produce a formatted markdown report greeting each sample",
     "Write a machine-readable result.json with sample count and IDs",
-    "Provide a full reproducibility bundle (commands.sh + environment.yml)"
+    "Provide a full reproducibility bundle (commands.sh, environment.yml, checksums.sha256)"
   ],
   "input_formats": [
     {

--- a/skills/skill-builder/skill_builder.py
+++ b/skills/skill-builder/skill_builder.py
@@ -56,6 +56,32 @@ DEMO_SPEC_PATH = SCRIPT_DIR / "demo_spec.json"
 # Sentinel file that marks the ClawBio repo root
 REPO_SENTINEL = "clawbio.py"
 
+
+def _repro_helpers():
+    """Load clawbio.common.reproducibility without importing it at module load.
+
+    A top-level import pulls in ``clawbio.common.__init__`` (OpenTelemetry),
+    which would make ``--validate-only`` and ``--help`` depend on extras that
+    this skill's SKILL.md still lists as stdlib-only.
+    """
+    root = SCRIPT_DIR.parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    from clawbio.common.reproducibility import (  # noqa: E402
+        ReproCommand,
+        ReproPath,
+        write_checksums,
+        write_environment_yml,
+        write_portable_commands_sh,
+    )
+    return (
+        ReproCommand,
+        ReproPath,
+        write_checksums,
+        write_environment_yml,
+        write_portable_commands_sh,
+    )
+
 # Sections required in every SKILL.md body (from CONTRIBUTING.md checklist)
 REQUIRED_SECTIONS = [
     ("YAML frontmatter",             r"^---"),
@@ -525,9 +551,14 @@ def validate_spec(spec: dict) -> list[str]:
 # ---------------------------------------------------------------------------
 
 def _yaml_list(items: list[str], indent: int = 6) -> str:
-    """Render a YAML block list with given indent."""
+    """Render a YAML block list with given indent.
+
+    Never emit a flow sequence such as ``[]``: skills-ref/strictyaml rejects it.
+    """
     pad = " " * indent
-    return "\n".join(f"{pad}- {item}" for item in items) if items else f"{' ' * indent}[]"
+    if not items:
+        return f"{pad}- TODO"
+    return "\n".join(f"{pad}- {item}" for item in items)
 
 
 def _md_input_table(formats: list) -> str:
@@ -596,12 +627,6 @@ def _md_deps(deps: dict) -> str:
     return "\n".join(lines)
 
 
-def _yaml_inline_list(items: list[str]) -> str:
-    if not items:
-        return "[]"
-    return "[" + ", ".join(items) + "]"
-
-
 def generate_skill_md(spec: dict) -> str:
     """Generate a complete SKILL.md from a skill spec dict."""
     name         = spec["name"]
@@ -625,39 +650,40 @@ def generate_skill_md(spec: dict) -> str:
         f"{i+1}. **Capability {i+1}**: {cap}" for i, cap in enumerate(capabilities)
     )
 
-    install_section: str
     req_pkgs = deps.get("required", [])
     if req_pkgs:
         install_lines = "\n".join(
-            f"      - kind: pip\n        package: {p.split()[0]}\n        bins: []"
+            f"      - kind: pip\n        package: {p.split()[0]}"
             for p in req_pkgs
         )
-        install_section = f"    install:\n{install_lines}"
+        install_block = f"    install:\n{install_lines}\n"
     else:
-        install_section = "    install: []"
+        # Empty `install: []` is a flow sequence; skills-ref/strictyaml rejects it.
+        install_block = ""
+
+    tags_section = f"  tags:\n{_yaml_list(tags, indent=4)}\n" if tags else ""
 
     return f"""\
 ---
 name: {name}
 description: >-
   {description}
-version: {version}
-author: {author}
 license: {license_}
-tags: {_yaml_inline_list(tags)}
 metadata:
-  openclaw:
+  version: "{version}"
+  author: "{author}"
+  domain: {domain}
+{tags_section}  openclaw:
     requires:
       bins:
         - python3
-      env: []
-      config: []
     always: false
     emoji: "{emoji}"
     homepage: https://github.com/ClawBio/ClawBio
-    os: [darwin, linux]
-{install_section}
-    trigger_keywords:
+    os:
+      - darwin
+      - linux
+{install_block}    trigger_keywords:
 {_yaml_list(trigger_kws, indent=8)}
 ---
 
@@ -739,8 +765,12 @@ output_directory/
 │   └── results.csv        # Tabular data
 └── reproducibility/
     ├── commands.sh        # Exact commands to reproduce
-    └── environment.yml    # Conda/pip environment snapshot
+    ├── environment.yml    # Conda/pip environment snapshot
+    └── checksums.sha256   # SHA-256 of outputs, relative to output_directory
 ```
+
+Verify the run with
+`cd <output_directory> && sha256sum -c reproducibility/checksums.sha256`.
 
 ## Dependencies
 
@@ -785,6 +815,7 @@ def generate_skill_py(spec: dict) -> str:
         "\n".join(f"# import {p.split()[0].split('=')[0].split('>')[0].strip()}" for p in req_pkgs)
         if req_pkgs else "# No external dependencies required"
     )
+    pip_deps_repr = "[" + ", ".join(repr(p) for p in req_pkgs) + "]"
 
     return textwrap.dedent(f'''\
         #!/usr/bin/env python3
@@ -811,9 +842,55 @@ def generate_skill_py(spec: dict) -> str:
 
         {import_hint}
 
+        SKILL_DIR = Path(__file__).resolve().parent
+        _PROJECT_ROOT = SKILL_DIR.parents[1]
+        if str(_PROJECT_ROOT) not in sys.path:
+            sys.path.insert(0, str(_PROJECT_ROOT))
+
+        from clawbio.common.reproducibility import (  # noqa: E402
+            write_checksums,
+            write_commands_sh,
+            write_environment_yml,
+        )
+
         # ---------------------------------------------------------------------------
         # Core logic
         # ---------------------------------------------------------------------------
+
+        def write_reproducibility_bundle(output_dir: Path, invocation: str) -> None:
+            """Write commands.sh, environment.yml and checksums.sha256 via clawbio.common.
+
+            Do not hand-roll these writers: the shared helpers keep line endings,
+            the checksum format and the bundle layout identical across skills.
+            """
+            write_commands_sh(
+                output_dir,
+                "# {title} - reproducibility\\n"
+                "set -euo pipefail\\n"
+                "\\n"
+                "# 1. Recreate the environment\\n"
+                "conda env create -f environment.yml\\n"
+                "conda activate {name}\\n"
+                "\\n"
+                "# 2. Re-run the analysis\\n"
+                f"python {script_name}.py {{invocation}}\\n"
+                "\\n"
+                "# 3. Verify output checksums (labels are relative to the output directory)\\n"
+                '( cd "$(dirname "$0")/.." && sha256sum -c reproducibility/checksums.sha256 )',
+            )
+            write_environment_yml(
+                output_dir,
+                env_name="{name}",
+                python_version="3.11",
+                pip_deps={pip_deps_repr},
+                conda_deps=[],
+            )
+            write_checksums(
+                [output_dir / "report.md", output_dir / "result.json"],
+                output_dir,
+                anchor=output_dir,
+            )
+
 
         def run(input_path: Path, output_dir: Path) -> dict:
             """
@@ -829,8 +906,6 @@ def generate_skill_py(spec: dict) -> str:
             output_dir.mkdir(parents=True, exist_ok=True)
             (output_dir / "figures").mkdir(exist_ok=True)
             (output_dir / "tables").mkdir(exist_ok=True)
-            repro_dir = output_dir / "reproducibility"
-            repro_dir.mkdir(exist_ok=True)
 
             # ------------------------------------------------------------------
             # TODO: Implement your skill logic here.
@@ -872,18 +947,9 @@ def generate_skill_py(spec: dict) -> str:
                 json.dumps(results, indent=2, default=str), encoding="utf-8"
             )
 
-            # --- Write reproducibility bundle ---
-            cmd = (
-                f"python skills/{name}/{script_name}.py "
-                f"--input {{input_path}} --output {{output_dir}}"
-            )
-            (repro_dir / "commands.sh").write_text(
-                f"#!/bin/bash\\n# Reproduced: {{datetime.now().isoformat()}}\\n{{cmd}}\\n",
-                encoding="utf-8",
-            )
-            (repro_dir / "environment.yml").write_text(
-                "name: {name}\\nchannels:\\n  - conda-forge\\ndependencies:\\n  - python=3.11\\n",
-                encoding="utf-8",
+            write_reproducibility_bundle(
+                output_dir,
+                f"--input {{input_path}} --output {{output_dir}}",
             )
 
             return results
@@ -1027,11 +1093,12 @@ def generate_test_py(spec: dict) -> str:
 
 
         def test_reproducibility_bundle(tmp_output: Path) -> None:
-            """Reproducibility bundle (commands.sh + environment.yml) should be present."""
+            """Reproducibility bundle must include commands, environment, and checksums."""
             run_demo(tmp_output)
             repro = tmp_output / "reproducibility"
             assert (repro / "commands.sh").exists(), "commands.sh missing"
             assert (repro / "environment.yml").exists(), "environment.yml missing"
+            assert (repro / "checksums.sha256").exists(), "checksums.sha256 missing"
 
 
         # ---------------------------------------------------------------------------
@@ -1548,11 +1615,9 @@ def write_skill_builder_report(
     spec: dict,
     repo_root: Path | None,
 ) -> None:
-    """Write the skill-builder's own report.md + result.json to output_dir."""
-    name      = spec["name"]
-    cli_alias = spec.get("cli_alias") or name.split("-")[0]
-    repro_dir = output_dir / "reproducibility"
-    repro_dir.mkdir(parents=True, exist_ok=True)
+    """Write the skill-builder's own report.md, result.json, and repro bundle."""
+    name = spec["name"]
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     # report.md — numbered fresh after deciding which conditional steps apply
     steps: list[str] = []
@@ -1620,11 +1685,39 @@ def write_skill_builder_report(
     (output_dir / "report.md").write_text("\n".join(report_lines), encoding="utf-8")
     (output_dir / "result.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
 
-    cmd_input = spec.get("_source_path", "spec.json")
-    (repro_dir / "commands.sh").write_text(
-        f"#!/bin/bash\n# Reproduced: {manifest['generated_at']}\n"
-        f"python skills/skill-builder/skill_builder.py --input {cmd_input}\n",
-        encoding="utf-8",
+    spec_path = Path(spec.get("_source_path", "spec.json"))
+    (
+        ReproCommand,
+        ReproPath,
+        write_checksums,
+        write_environment_yml,
+        write_portable_commands_sh,
+    ) = _repro_helpers()
+    write_portable_commands_sh(
+        output_dir,
+        ReproCommand(
+            script_path=Path("skills/skill-builder/skill_builder.py"),
+            args=[
+                "--input",
+                ReproPath(spec_path, anchor="auto"),
+                "--output",
+                ReproPath(output_dir, anchor="output_dir"),
+            ],
+            comment=f"Reproduced: {manifest['generated_at']}",
+        ),
+        repo_root=repo_root,
+    )
+    write_environment_yml(
+        output_dir,
+        env_name="clawbio-skill-builder",
+        python_version="3.11",
+        pip_deps=[],
+        conda_deps=[],
+    )
+    write_checksums(
+        [output_dir / "report.md", output_dir / "result.json"],
+        output_dir,
+        anchor=output_dir,
     )
 
 

--- a/skills/skill-builder/tests/test_skill_builder.py
+++ b/skills/skill-builder/tests/test_skill_builder.py
@@ -10,9 +10,12 @@ or via ClawBio runner:
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
 
 import pytest
 
@@ -167,17 +170,36 @@ class TestGenerateSkillMd:
         assert "result.json" in md
         assert "commands.sh" in md
         assert "environment.yml" in md
+        assert "checksums.sha256" in md
+
+    def test_frontmatter_nests_under_metadata(self, spec: dict) -> None:
+        """Match templates/SKILL-TEMPLATE.md: version/author/tags live under metadata."""
+        md = generate_skill_md(spec)
+        front = md.split("---", 2)[1]
+        assert "\nversion:" not in front.split("metadata:", 1)[0]
+        assert "version:" in front.split("metadata:", 1)[1]
+        assert "author:" in front.split("metadata:", 1)[1]
 
     def test_os_values_use_process_platform_names(self, spec: dict) -> None:
         """
         ``agentskills validate`` (run in CI) rejects ``macos``/``windows`` and
-        requires Node's ``process.platform`` names. Ensure the generator emits
-        values that pass validation so no scaffolded skill is DOA.
+        requires Node's ``process.platform`` names. Flow-style lists such as
+        ``os: [darwin, linux]`` are also rejected (strictyaml: "ugly disallowed
+        JSONesque flow mapping"), so emit a block list.
         """
         md = generate_skill_md(spec)
-        assert "os: [darwin" in md, "os field must use 'darwin' (not 'macos')"
-        assert "macos" not in md.split("os:")[1].split("\n")[0]
-        assert "windows" not in md.split("os:")[1].split("\n")[0]
+        front = md.split("---", 2)[1]
+        assert "- darwin" in front, "os field must use 'darwin' (not 'macos')"
+        assert "- linux" in front
+        assert "os: [" not in front
+        assert "macos" not in front
+        assert "windows" not in front
+
+    def test_frontmatter_has_no_flow_style_lists(self, spec: dict) -> None:
+        """skills-ref 0.1.x rejects JSON-style flow sequences in SKILL.md YAML."""
+        md = generate_skill_md(spec)
+        front = md.split("---", 2)[1]
+        assert "[" not in front, f"flow-style list in frontmatter:\n{front}"
 
 
 # ---------------------------------------------------------------------------
@@ -225,6 +247,38 @@ class TestGenerateSkillPy:
         assert "result.json" in py
         assert "commands.sh" in py
         assert "environment.yml" in py
+        assert "checksums.sha256" in py
+        assert "clawbio.common.reproducibility" in py
+        for helper in ("write_commands_sh", "write_environment_yml", "write_checksums"):
+            assert helper in py, f"generated skill does not call {helper}"
+        bundle_fn = py.split("def write_reproducibility_bundle", 1)[1].split("def run(", 1)[0]
+        assert ".write_text(" not in bundle_fn
+
+    def test_generated_skill_demo_writes_shared_bundle(self, spec: dict, tmp_path: Path) -> None:
+        """A scaffolded skill must actually emit the bundle, not just mention it."""
+        skill_dir = tmp_path / spec["name"]
+        skill_dir.mkdir()
+        script_name = spec["name"].replace("-", "_")
+        script = skill_dir / f"{script_name}.py"
+        script.write_text(generate_skill_py(spec), encoding="utf-8")
+        out = tmp_path / "out"
+        env = dict(os.environ, PYTHONPATH=str(REPO_ROOT))
+        result = subprocess.run(
+            [sys.executable, str(script), "--demo", "--output", str(out)],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            env=env,
+        )
+        assert result.returncode == 0, result.stderr
+        repro = out / "reproducibility"
+        for artefact in ("commands.sh", "environment.yml", "checksums.sha256"):
+            assert (repro / artefact).exists(), f"missing {artefact}"
+        lines = (repro / "checksums.sha256").read_text().strip().splitlines()
+        assert lines, "checksum manifest is empty"
+        for line in lines:
+            _, label = line.split("  ", 1)
+            assert (out / label).exists(), f"label {label!r} does not resolve from output_dir"
 
 
 # ---------------------------------------------------------------------------
@@ -657,7 +711,15 @@ class TestRunDemo:
     def test_demo_creates_reproducibility_bundle(self, tmp_output: Path) -> None:
         run_demo(tmp_output, dry_run=False)
         repro = tmp_output / "reproducibility"
-        assert (repro / "commands.sh").exists()
+        for artefact in ("commands.sh", "environment.yml", "checksums.sha256"):
+            assert (repro / artefact).exists(), f"missing {artefact}"
+        src = (tmp_output / json.loads(DEMO_SPEC_PATH.read_text())["name"] / "hello_bioinformatics.py").read_text()
+        assert "clawbio.common.reproducibility" in src
+        lines = (repro / "checksums.sha256").read_text().strip().splitlines()
+        assert lines, "checksum manifest is empty"
+        for line in lines:
+            _, label = line.split("  ", 1)
+            assert (tmp_output / label).exists(), f"label {label!r} does not resolve from output_dir"
 
     def test_demo_dry_run_no_files(self, tmp_output: Path) -> None:
         run_demo(tmp_output, dry_run=True)


### PR DESCRIPTION
Addresses #372 (the remaining skill-builder scaffolder item after #374).

## Summary

- `skill-builder` no longer hand-rolls `commands.sh` / `environment.yml` with `write_text`. Its own report bundle and the generated skill skeleton both go through `clawbio.common.reproducibility`, including `checksums.sha256` with `anchor=output_dir`.
- Generated `SKILL.md` frontmatter now matches `templates/SKILL-TEMPLATE.md`: top-level `name` / `description` / `license`, everything else under `metadata:`, block lists instead of `os: [darwin, linux]` and `tags: [demo]`. Those flow-style lists fail `agentskills validate` even though PyYAML accepts them (same class as #367).
- Tests pin the shared-layer import, the checksum labels, a real `--demo` run of a generated skill, and the absence of flow-style lists in frontmatter.

## Skill affected

`skill-builder`

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology)
- [x] Tests included and passing (`pytest -v`)
- [x] Demo data included for reviewers to test
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

```text
$ python -m pytest skills/skill-builder/tests/test_skill_builder.py -q
122 passed in 13.50s

$ python -m pytest tests/test_scaffold_skill.py -q
6 passed in 0.96s

$ python skills/skill-builder/skill_builder.py --demo --output /tmp/skill_builder_repro_demo
# Demo complete. Checksums verify:
report.md: OK
result.json: OK

$ uvx --from 'skills-ref>=0.1.1,<1' agentskills validate /tmp/skill_builder_repro_demo/hello-bioinformatics
Valid skill: /tmp/skill_builder_repro_demo/hello-bioinformatics
```

This does not migrate the remaining bundle-less compute skills listed in #372. Those stay one-skill-per-PR as the issue asked.