### PR TITLE
docs(bot): require --group bot on uv run for the messaging adapters

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -130,15 +130,21 @@ CLAWBIO_MODEL=local-model
 
 ```bash
 # Telegram bot
-uv run python bot/roboterri.py
+uv run --group bot python bot/roboterri.py
 
 # Discord bot
-uv run python bot/roboterri_discord.py
+uv run --group bot python bot/roboterri_discord.py
 
 # Both at the same time (separate terminals)
-uv run python bot/roboterri.py &
-uv run python bot/roboterri_discord.py &
+uv run --group bot python bot/roboterri.py &
+uv run --group bot python bot/roboterri_discord.py &
 ```
+
+> **Note**: pass `--group bot` on every `uv run`, not just the initial `uv sync`.
+> The `bot` group is not a default group, so any later plain `uv sync` (or any
+> tool that runs one) prunes it from `.venv`, and a bare `uv run` will not put it
+> back — the bot then fails with `ModuleNotFoundError: No module named 'dotenv'`.
+> Passing the flag on the run command reinstalls the group if it went missing.
 
 If you want a direct browser chat instead of a messenger adapter, see [../docs/custom-domain-webchat.md](../docs/custom-domain-webchat.md) for the self-hosted OpenClaw gateway setup.
 


### PR DESCRIPTION
## Summary

- Document the messaging adapters' run commands as `uv run --group bot python bot/roboterri.py` (and the Discord equivalent) instead of a bare `uv run`.
- Add a note explaining that `bot` is not a default dependency group, so any later plain `uv sync` prunes it from `.venv` and a bare `uv run` does not put it back — the adapters then fail with `ModuleNotFoundError: No module named 'dotenv'`.
- Docs only. No code, no skill logic, no dependency changes.

## Skill affected

None — this touches `bot/README.md` only (the Telegram/Discord adapter layer, not a catalogued skill).

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology) — n/a, no skill added or modified
- [x] Tests included and passing (`pytest -v`) — no new tests; docs-only change, existing `bot/tests` suite re-run below
- [x] Demo data included for reviewers to test — n/a, no code paths changed
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

Existing bot suite, unaffected but re-run:

```
$ uv run --group bot pytest -q bot/tests
.......                                                                  [100%]
7 passed in 0.08s
```

Reproduction of the documented failure, and the fix. A plain `uv sync` prunes the `bot` group:

```
$ uv sync
 - python-dotenv==1.2.2
 - python-telegram-bot==22.7
 ...
$ uv run python -c "import dotenv"      # the command the README used to give
ModuleNotFoundError: No module named 'dotenv'
```

With the flag this PR documents, the group is reinstalled and the bot starts:

```
$ uv run --group bot python bot/roboterri.py
Installed 17 packages in 20ms
[roboterri] INFO: Starting RoboTerri ClawBio bot (model: gemini-2.5-flash-lite)
[roboterri] INFO: Admin chat ID: not set (public mode)
[roboterri] INFO: Rate limit: 10 msgs/hour per user (0=unlimited)
[telegram.ext.Application] INFO: Application started
```

This was hit for real while starting the Telegram adapter from the README as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
