### PR TITLE
ci: report dependency advisories on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,14 @@ jobs:
 
       - name: Audit locked dependencies
         id: audit
+        # Deliberately unflagged. setup-uv installs whichever uv is latest
+        # (no version input, no required-version), and this preview subcommand
+        # has already renamed things across versions: `--all-groups` does not
+        # exist on 0.12.9, and `--preview-features audit` became
+        # `audit-command`. Auditing every group is the default, so the bare
+        # command is the one form that works on both. The experimental warning
+        # is cosmetic and lands in the report.
+        #
         # `|| true` keeps findings from failing the build (this job is
         # report-only), but it would also hide the tool itself breaking. So
         # assert the report is a report: `uv audit` always prints a "Found N
@@ -81,7 +89,7 @@ jobs:
         # changed, was removed, or died -- which must fail loudly rather than
         # render an empty summary nobody reads.
         run: |
-          uv audit --all-groups --preview-features audit > audit.txt 2>&1 || true
+          uv audit > audit.txt 2>&1 || true
           if ! grep -qE '^Found [0-9]+ known vulnerabilit' audit.txt; then
             echo "::error::uv audit produced no recognisable report - the audit step is broken, not clean"
             cat audit.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,19 @@ jobs:
 
       - name: Audit locked dependencies
         id: audit
-        run: uv audit --all-groups --preview-features audit > audit.txt 2>&1 || true
+        # `|| true` keeps findings from failing the build (this job is
+        # report-only), but it would also hide the tool itself breaking. So
+        # assert the report is a report: `uv audit` always prints a "Found N
+        # known vulnerabilities" line, and if that is missing the subcommand
+        # changed, was removed, or died -- which must fail loudly rather than
+        # render an empty summary nobody reads.
+        run: |
+          uv audit --all-groups --preview-features audit > audit.txt 2>&1 || true
+          if ! grep -qE '^Found [0-9]+ known vulnerabilit' audit.txt; then
+            echo "::error::uv audit produced no recognisable report - the audit step is broken, not clean"
+            cat audit.txt
+            exit 1
+          fi
 
       - name: Post summary
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,53 @@ jobs:
       - name: Check lockfile is up to date
         run: uv lock --check
 
+  dependency-audit:
+    # Report-only, deliberately. Two reasons, both verified against uv 0.10.12:
+    #
+    #   1. `uv audit` exits 0 even when it reports findings, so gating would
+    #      mean parsing its output ourselves. Not worth it while there is a
+    #      backlog of nine affected packages to clear first -- a gate born red
+    #      is how the scientific-audit job below ended up carrying `|| true`
+    #      for months (#342).
+    #   2. The subcommand is still experimental and warns that it may change
+    #      without notice, so its exit codes and output are not a stable
+    #      contract to build a gate on yet.
+    #
+    # Promote to a gate once the backlog is cleared and the subcommand settles.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          enable-cache: true
+
+      - name: Audit locked dependencies
+        id: audit
+        run: uv audit --all-groups --preview-features audit > audit.txt 2>&1 || true
+
+      - name: Post summary
+        if: always()
+        run: |
+          echo "## Dependency Audit" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Report-only: this job never fails the build." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat audit.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload audit report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dependency-audit
+          path: audit.txt
+          retention-days: 30
+
   skill-lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Add a `dependency-audit` job to CI that runs `uv audit` against the lockfile on every push and PR, writing the report to the step summary and uploading it as an artifact.
- **Report-only**: findings never fail the build. But a *missing* report does — if `uv audit` stops producing a recognisable report, the job fails loudly rather than rendering an empty summary that reads as "clean".
- One tool, not two. `uv audit` reads `uv.lock` natively with no export step; pip-audit was evaluated and independently confirmed the identical set of affected packages, so running both would be duplicated cost for one signal.

## Skill affected

None — CI configuration only (`.github/workflows/ci.yml`).

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology) — n/a, no skill added or modified
- [x] Tests included and passing (`pytest -v`) — n/a, no Python changed; the job's guard clause was exercised directly (below)
- [x] Demo data included for reviewers to test — n/a
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Why this was missing

There was no dependency audit anywhere in CI — `scientific-audit` is the
correctness benchmark, not a security check — and no Dependabot config. So
advisories against locked dependencies went unnoticed until someone ran a scan
by hand. That is how pillow sat at 12.2.0 with ten July 2026 advisories against
it, while decoding images uploaded to the public RoboTerri bot (fixed
separately in #392).

## Why report-only rather than gating

Two reasons, both verified against uv 0.10.12 and recorded in a comment on the
job:

1. `uv audit` **exits 0 even when it reports findings**, so gating would mean
   parsing its output ourselves. Not worth doing while there is a backlog of
   affected packages to clear — and a gate born red is how the
   `scientific-audit` job below ended up carrying `|| true` for months (#342).
2. The subcommand is still **experimental** and warns that it may change
   without notice, so its exit codes and output are not a stable contract to
   build a gate on yet.

Promote to a gate once the backlog is cleared and the subcommand settles.

## Why the guard clause

`|| true` is what makes the job report-only, but on its own it would also mask
the tool breaking — a removed or renamed subcommand exits 0, the summary
renders empty, and the job still shows green. The step therefore greps for the
`Found N known vulnerabilities` line that `uv audit` always prints, and fails
if it is absent.

## Test output

The guard clause, exercised against real and broken outputs:

```
1. real audit output:        -> passes (real report)
2. subcommand removed:       -> FAILS (reports broken)
3. empty output:             -> FAILS (reports broken)
4. a genuinely clean report: -> passes (real report)
```

Case 4 is the one that matters for false alarms: `Found 0 known
vulnerabilities` passes rather than being mistaken for a broken tool.

Validated end to end with `act`, which caught a real bug before it reached CI:
`setup-uv` installs whichever uv is latest (0.12.9 today), and that version
rejects `--all-groups` outright.

```
[CI/dependency-audit] ❗ ::error::uv audit produced no recognisable report - the audit step is broken, not clean
[CI/dependency-audit]  | error: unexpected argument '--all-groups' found
[CI/dependency-audit] ❌ Failure - Main Audit locked dependencies
```

That is the guard clause working as intended: a broken step failed loudly
instead of rendering an empty summary that reads as clean. The command is now
unflagged, which is the only form valid on both uv versions in play (the
preview flag was also renamed, `audit` -> `audit-command`). Re-run under `act`:

```
[CI/dependency-audit]  | Successfully installed uv version 0.12.9
[CI/dependency-audit] ✅ Success - Main Audit locked dependencies
[CI/dependency-audit] ✅ Success - Main Post summary
```

The only remaining `act` failure is `Upload audit report`, which cannot run
locally: act's container has no Node for JS actions
(`exec: "node": executable file not found in $PATH`). GitHub's runners do.

The command the job runs, today, on this branch:

```
$ uv audit
Resolved 186 packages in 7ms
Found 107 known vulnerabilities and no adverse project statuses in 185 packages
```

(That count is against this branch's lockfile. With #392 merged it drops to 53;
note that `uv audit` lists GHSA and PYSEC records separately for the same
underlying issue, so the raw number roughly double-counts.)

YAML validated with `yaml.safe_load`; the job list parses as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)