### PR TITLE
ci: publish to PyPI with an API token until Trusted Publishing is registered

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,5 +64,20 @@ jobs:
           name: dist
           path: dist/
 
+      # Trusted Publishing (OIDC) is the intended mechanism and needs no secret,
+      # but it has never succeeded: every tagged run so far failed with
+      # `invalid-publisher`, because no publisher matching this repository,
+      # workflow and environment is registered on PyPI. Until that registration
+      # exists, publish with an API token held as an environment secret.
+      #
+      # The secret lives on the `pypi` environment, not on the repository, and
+      # that environment accepts `v*` tags only, so no branch build and no pull
+      # request can reach it.
+      #
+      # To return to Trusted Publishing: register the publisher on PyPI
+      # (owner ClawBio, repository ClawBio, workflow publish.yml, environment
+      # pypi), then delete the `password` line below and the secret.
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -70,7 +70,22 @@ To cut a release:
    sdist + wheel, runs `twine check`, and publishes to PyPI. Watch it under the
    repo's Actions tab.
 
-### One-time PyPI Trusted Publisher setup (required before the first automated run)
+### Current state: API token, not Trusted Publishing
+
+Trusted Publishing has never worked on this project. Every tagged run failed
+with `invalid-publisher`, because no publisher matching this repository is
+registered on PyPI, so 0.5.2, 0.6.1 and 0.7.0 were all uploaded by hand.
+
+Since 2026-09-05 the workflow authenticates with an API token instead, held as
+the `PYPI_API_TOKEN` secret on the `pypi` **environment** (not on the
+repository), and that environment accepts `v*` tags only. A pull request or a
+branch build therefore cannot read it.
+
+The token is account-scoped, so it can publish any of the owner's PyPI
+projects. Replacing it with a token scoped to `clawbio` alone is the obvious
+improvement, and returning to Trusted Publishing removes the secret entirely.
+
+### Returning to Trusted Publishing (removes the secret)
 
 On PyPI, open the `clawbio` project -> **Manage** -> **Publishing**, then under
 **Add a new publisher** choose GitHub and enter exactly:


### PR DESCRIPTION
## Summary

Tagged releases have never published themselves. Every run of `publish.yml` failed with `invalid-publisher`, and 0.5.2, 0.6.1 and 0.7.0 were uploaded by hand.

The workflow was not the problem. GitHub sends exactly the claims `packaging/README.md` documents:

```
sub:              repo:ClawBio/ClawBio:environment:pypi
job_workflow_ref: ClawBio/ClawBio/.github/workflows/publish.yml@refs/tags/v0.7.0
```

No publisher matching them is registered on PyPI, and there is no API to register one, so this switches to an API token until that is done in the web UI.

## Blast radius

- The token is an **environment** secret on `pypi`, not a repository secret, so only this job can read it.
- The `pypi` environment now accepts **`v*` tags only**, so no branch build and no contributor pull request can reach it.
- The token is account-scoped. That is recorded in the docs as the known weakness; a `clawbio`-scoped token would be strictly better.

## Reverting to Trusted Publishing

Register the publisher on PyPI (owner `ClawBio`, repository `ClawBio`, workflow `publish.yml`, environment `pypi`), then delete the `password` line and the secret. The workflow needs no other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a long-lived PyPI credential in CI; exposure is limited by the tag-only `pypi` environment, but the token is account-scoped rather than project-scoped.
> 
> **Overview**
> **Tagged PyPI releases can succeed in CI again** by authenticating `publish.yml` with `PYPI_API_TOKEN` on the `pypi` GitHub environment instead of relying on OIDC Trusted Publishing, which has been failing with `invalid-publisher` because no matching publisher is registered on PyPI.
> 
> The publish step now passes `password: ${{ secrets.PYPI_API_TOKEN }}` to `pypa/gh-action-pypi-publish`, with inline workflow comments documenting why, where the secret lives (environment-only, `v*` tags), and how to revert once a GitHub trusted publisher is configured.
> 
> **`packaging/README.md`** replaces the one-time Trusted Publisher setup section with the current API-token approach, notes that recent versions were uploaded manually, calls out the account-scoped token as a known limitation, and keeps step-by-step instructions for re-enabling Trusted Publishing later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0773b539117299fca48a89bcef1acc2b2a07162. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->