### PR TITLE
release: 0.7.1

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -62,5 +62,5 @@
     }
   ],
   "notes": "Winner of UK AI Agent Hackathon 2026 (Europe's largest AI hackathon). Bioinformatics Application Note submitted to Oxford University Press. Nature feature interview (Nicola Jones, April 2026).",
-  "version": "0.5.0"
+  "version": "0.7.1"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-09-05
+
+### Fixed
+- **Tagged releases publish themselves again.** Every previous run of
+  `publish.yml` failed with `invalid-publisher`, so 0.5.2, 0.6.1 and 0.7.0 were
+  uploaded by hand. The workflow was correct: the OIDC claims GitHub sends match
+  what `packaging/README.md` documents, and no matching publisher is registered
+  on PyPI. Until it is, the job authenticates with an API token held as an
+  environment secret on `pypi`, an environment that accepts `v*` tags only.
+
 ### Added
 - **`SECURITY.md`**: a private disclosure path (GitHub private vulnerability reporting,
   now enabled on the repository, with an email fallback), response commitments, what is

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: "If you use ClawBio, please cite it using the metadata from this file."
 type: software
 title: "ClawBio: Bioinformatics-Native AI Agent Skill Library"
-version: 0.7.0
-date-released: "2026-09-03"
+version: 0.7.1
+date-released: "2026-09-05"
 doi: "10.5281/zenodo.19420648"
 url: "https://clawbio.ai"
 repository-code: "https://github.com/ClawBio/ClawBio"

--- a/clawbio/__init__.py
+++ b/clawbio/__init__.py
@@ -1,6 +1,6 @@
 """ClawBio: Bioinformatics AI Agent shared library."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 from .runner import list_skills, run_skill, upload_profile
 


### PR DESCRIPTION
Cuts the accumulated `Unreleased` work into a patch release, and is the first release intended to publish itself.

## Contents

Yesterday's merged work: `SECURITY.md`, `docs/data-handling.md` with its CI scanner, the soul2dna retirement (#111), the gwas-prs PGS000013 refusal (#356), and the publish fix (#394).

## Version bumped in

| File | From | To |
|---|---|---|
| `clawbio/__init__.py` | 0.7.0 | 0.7.1 |
| `CITATION.cff` | 0.7.0 | 0.7.1 |
| `.zenodo.json` | **0.5.0** | 0.7.1 |

`.zenodo.json` was three releases stale.

## Verified locally before tagging

A PyPI version number can never be reused, so the workflow's own steps were run by hand first:

```
tag=0.7.1 pkg=0.7.1  MATCH
Successfully built dist/clawbio-0.7.1-py3-none-any.whl
Checking dist/clawbio-0.7.1.tar.gz: PASSED
```

The tag is pushed only after this merges and CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and changelog-only release prep; no application logic changes in the diff.
> 
> **Overview**
> **Cuts the accumulated `Unreleased` notes into patch release 0.7.1** and aligns release metadata so tagging can ship a self-publishing PyPI build.
> 
> Version **0.7.0 → 0.7.1** is applied in `clawbio/__init__.py`, `CITATION.cff` (release date **2026-09-05**), and `.zenodo.json`, where Zenodo had been stuck at **0.5.0**. `CHANGELOG.md` adds a **[0.7.1] - 2026-09-05** section documenting the **publish workflow fix** (OIDC `invalid-publisher` until PyPI trusted publishing is registered; `publish.yml` now uses a `pypi` environment API token for `v*` tags) and the shipped **SECURITY.md** / **`docs/data-handling.md`** (+ CI enforcement) work from prior merges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45456db462f5d77304bd949c1d51c1e2ca145173. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->