### PR TITLE
ci: unblock publishing, the action's twine rejects Metadata-Version 2.5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,7 +77,15 @@ jobs:
       # To return to Trusted Publishing: register the publisher on PyPI
       # (owner ClawBio, repository ClawBio, workflow publish.yml, environment
       # pypi), then delete the `password` line below and the secret.
+      # `verify-metadata: false` because the twine bundled in the action's
+      # container rejects Metadata-Version 2.5, which current hatchling emits:
+      # the v0.7.1 run failed with `InvalidDistribution: '2.5' is not a valid
+      # metadata version` after authenticating successfully. The metadata is
+      # fine, and PyPI itself accepts it; only the container's older twine does
+      # not. The build job above already runs `uvx twine check` on the same
+      # artefacts with a current twine, so nothing goes unchecked.
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+          verify-metadata: false


### PR DESCRIPTION
The `v0.7.1` run authenticated successfully and then failed:

```
Checking dist/clawbio-0.7.1-py3-none-any.whl:
ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Current hatchling emits `Metadata-Version: 2.5`; the twine bundled in the action's container predates it. PyPI itself accepts the metadata, and the build job already runs `uvx twine check` on the same artefacts with a current twine, so disabling the redundant in-container check leaves nothing unverified.

This was a **second blocker hidden behind the trusted-publisher one**, and it would have broken the first successful release regardless of how it authenticated.

Nothing was published: `0.7.1` is still unused on PyPI, so the version number is not burned.

- Action bumped `v1.14.0` to `v1.14.2`, re-pinned by commit SHA.
- `verify-metadata: false` with the reason recorded inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only publish workflow change; metadata checks remain in the build job, and PyPI still receives the same distributions.
> 
> **Overview**
> Fixes release publishing failing **after** PyPI auth when the publish action’s bundled **twine** rejects **Metadata-Version 2.5** from current **hatchling** builds (as on the `v0.7.1` run).
> 
> Bumps **`pypa/gh-action-pypi-publish`** from **v1.14.0** to **v1.14.2** (commit-pinned) and sets **`verify-metadata: false`** on the publish step, with inline comments documenting why. Metadata is still validated in the **build** job via **`uvx twine check`** on the same artifacts before upload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 299c0ab54f7ceedbb0886b1ed038a7a288646da6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->