### PR TITLE
feat(benchmark): add offline atlas split preflight

### DIFF
--- a/docs/atlas-benchmark-preflight.md
+++ b/docs/atlas-benchmark-preflight.md
@@ -1,0 +1,136 @@
+# Atlas benchmark preflight
+
+Offline check of whether two **declared observation metadata exports** support
+a donor-disjoint, cell-disjoint benchmark split. This is a benchmark utility,
+not a new atlas connector, analysis skill, model benchmark or clinical tool.
+
+## Why this check exists
+
+The combined Tabula Sapiens 2.0 atlas incorporates earlier samples. A release
+called "v2" must not automatically be treated as an unseen test set for a model
+trained on v1. The [CZI benchmark data card](https://virtualcellmodels.cziscience.com/dataset/tabula-sapiens)
+explicitly describes removing v1 samples previously used in training. This
+utility checks the exported identities instead of trusting release names.
+
+The [official data registry](https://registry.opendata.aws/tabula-sapiens/)
+distinguishes processed data from controlled raw FASTQ access. This utility
+downloads neither. Do not submit donor clinical histories or raw reads to it.
+
+These are data-release claims, not a claim that the 2025 preprint and the final
+[2026 Cell article](https://doi.org/10.1016/j.cell.2026.08.010) contain identical
+analyses. Keep publication versions separate from dataset versions.
+
+## Run
+
+From the repository root, with Python 3.10 or later and no third-party runtime dependencies:
+
+```bash
+python tests/benchmark/atlas_preflight.py \
+  --input /path/to/manifest.json --output /path/to/new-report
+```
+
+Gate a downstream command on success with `&&`. This utility is **opt-in**; it
+does not silently change existing benchmark runners or the ClawBio skill CLI.
+Its regression tests are discovered by the existing `tests/benchmark` pytest path.
+
+```bash
+python tests/benchmark/atlas_preflight.py --input manifest.json --output new-report && \
+  python your_existing_benchmark.py
+```
+
+Exit statuses:
+
+| Exit | Result | Meaning |
+|---|---|---|
+| 0 | PASS | No donor/cell overlap in the declared metadata; warnings may remain |
+| 1 | FAIL | Overlapping donors/cells or duplicate cell IDs within a split |
+| 2 | ERROR | Missing, malformed, inconsistent or unpinned input, or output cannot be safely written |
+
+An existing output path is always refused, even when empty. Choose a new directory.
+
+## Input contract
+
+Copy the shape of `tests/benchmark/fixtures/atlas_preflight/demo_manifest.json`,
+but replace all **synthetic** provenance, identifiers, paths, hashes and counts.
+Never rename the toy fixture to suggest it is a real atlas benchmark.
+
+Each of the exactly two splits, `train` and `test`, declares:
+
+- `dataset_id`: source dataset identifier.
+- `dataset_version`: explicit release identifier, not `latest`, `stable`, `current`, `main`, `master` or `HEAD`.
+- `source_url`: source citation URL, recorded but never fetched.
+- `identity_namespace`: the **same stable study-level identity convention** in both splits.
+- `observations_path`: local JSONL path, relative to the manifest directory or absolute.
+- `observations_sha256`: SHA-256 of the exact JSONL bytes.
+- `expected_cells`: positive expected number of observation records.
+
+JSONL has one object per cell, with required string `cell_id` and `donor_id`.
+Optional `sex` and `ancestry` fields are donor metadata strings or null.
+Other fields are ignored. Empty lines are ignored for cell counting but remain
+included in the checksum. Duplicate JSON keys and non-finite JSON numbers are rejected.
+
+Use original globally unique cell identities preserved across releases. A bare
+10x barcode is **not** globally unique. An identity may need the original
+donor, library/sample and barcode. Do not prepend the release version or split
+name: doing so would hide overlapping cells. Donor IDs must also be harmonised
+across releases before this audit. Separate identifier namespaces are rejected,
+not treated as evidence of independence.
+
+Export all observations actually used by each pipeline from its AnnData `obs`
+metadata, preserving the originals. Verify the export count against the matrix
+before declaring `expected_cells`. Hash the export with `sha256sum` on Linux or
+`shasum -a 256` on macOS. The utility does not verify this export against H5AD;
+the caller remains responsible for completeness and faithful identity mapping.
+
+## Outputs and provenance
+
+- `report.md`: status, split counts, finding codes and interpretation limits.
+- `result.json`: structured findings, versions, source citations, observed checksums,
+  overlap counts and donor-level sex/ancestry coverage.
+- `reproducibility/manifest.json`: exact input snapshot, if the input was readable.
+- `reproducibility/environment.json`: Python/platform, utility version and script hash.
+- `reproducibility/commands.sh`: original shell-quoted invocation and working directory.
+- `reproducibility/checksums.sha256`: hashes of every generated bundle file except itself.
+
+Identity lists and expression values are not written to the report. The source
+JSONL files remain local and are not copied into the report. Source paths and
+demographic distributions may still be sensitive: review a report before sharing.
+No shell commands are executed by the utility and no network requests are made.
+
+Checksums bind the files to this run; they are not digital signatures proving
+the source declarations true. Retain the original input exports for replay.
+
+## What a PASS does not mean
+
+It does not establish that a model never saw the data, that releases are complete,
+that cell annotations are correct, that donors represent global populations, or
+that preprocessing and tuning were conducted without test-set leakage. It also
+does not perform similarity-based duplicate detection on expression matrices.
+
+Sex and ancestry summaries count **unique donors, not cells**. Missing ancestry
+remains unknown. Conflicting labels are flagged and excluded from distributions;
+no label is inferred. Warnings do not invalidate a disjoint split, but may limit
+the interpretation of downstream results. There is no invented "equity score".
+
+## Verification and bounded scope
+
+```bash
+python -m pytest tests/benchmark/test_atlas_preflight.py -q
+python tests/benchmark/atlas_preflight.py --demo --output fresh-demo-output
+```
+
+The demo deliberately returns **FAIL / exit 1**, with one overlapping donor and
+one overlapping cell. It is a successful negative-control check on toy data,
+not a failed scientific experiment. Positive-control and malformed-input cases
+are included in the regression tests. No real Tabula Sapiens benchmark has been
+run by this implementation.
+
+Design decision: extend the existing benchmark utilities, preserving existing
+single-cell analysis skills. A new atlas service, separate research programme,
+full million-cell download and LLM-based clinical-record interface were excluded.
+The immediate deliverable is reproducible evaluation protection, not a claim
+of adoption, agent superiority or time saved.
+
+ClawBio is a research and educational tool. It is not a medical device and does
+not provide clinical diagnoses. Consult a healthcare professional before making
+any medical decisions.

--- a/tests/benchmark/atlas_preflight.py
+++ b/tests/benchmark/atlas_preflight.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Offline donor/cell holdout audit of explicitly pinned observation metadata.
+
+This does not fetch an atlas, inspect expression matrices, run a model or certify
+unknown model-training data. PASS concerns the declared metadata only.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import re
+import shlex
+import sys
+from pathlib import Path
+
+VERSION = "0.1.0"
+UNKNOWN = {"", "unknown", "na", "n/a", "nan", "none", "null", "unassigned", "not reported"}
+FLOATING = {"latest", "stable", "current", "main", "master", "head"}
+DISCLAIMER = (
+    "ClawBio is a research and educational tool. It is not a medical device "
+    "and does not provide clinical diagnoses. Consult a healthcare professional "
+    "before making any medical decisions."
+)
+LIMITATIONS = [
+    "PASS means no donor/cell overlap found in the declared metadata, not a clean model-training history.",
+    "Identifiers must be stable and globally unique within the same study namespace across releases. Aliases are not resolved.",
+    "Metadata checksums pin the inspected bytes. Source release labels and expected cell counts are caller declarations.",
+    "Expression matrices, export completeness against H5AD, labels and upstream preprocessing leakage are not verified.",
+    "A combined atlas release may contain earlier samples. A newer version is not evidence of independent holdout data.",
+    "Donor metadata is descriptive. Missing ancestry is unknown, never evidence of representativeness or inferred ancestry.",
+]
+
+
+class InputError(ValueError):
+    def __init__(self, code, message):
+        super().__init__(message)
+        self.code = code
+
+
+def _pairs(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise InputError("INVALID_INPUT", "Duplicate JSON key is not permitted.")
+        result[key] = value
+    return result
+
+
+def _reject_constant(value):
+    raise InputError("INVALID_INPUT", "Non-finite JSON values are not permitted.")
+
+
+def _json(data):
+    return json.loads(data, object_pairs_hook=_pairs, parse_constant=_reject_constant)
+
+
+def _text(value, label):
+    if (not isinstance(value, str) or value != value.strip()
+            or value.casefold() in UNKNOWN or any(ord(c) < 32 for c in value)):
+        raise InputError("INVALID_INPUT", f"{label} must be a known, non-empty, whitespace-trimmed string.")
+    return value
+
+
+def _finding(findings, code, severity, message, split=None):
+    item = {"code": code, "severity": severity, "message": message}
+    if split:
+        item["split"] = split
+    findings.append(item)
+
+
+def _validate_spec(spec):
+    if not isinstance(spec, dict):
+        raise InputError("INVALID_INPUT", "Each split must be an object.")
+    for key in ("dataset_id", "dataset_version", "source_url", "identity_namespace",
+                "observations_path", "observations_sha256"):
+        _text(spec.get(key), key)
+    if spec["dataset_version"].casefold() in FLOATING:
+        raise InputError("INVALID_INPUT", "Pin a dataset release, not a floating version alias.")
+    if not re.fullmatch(r"https?://[^\s/]+(?:/[^\s]*)?", spec["source_url"]):
+        raise InputError("INVALID_INPUT", "source_url must be an HTTP(S) citation URL; it is never fetched.")
+    if "://" in spec["observations_path"]:
+        raise InputError("INVALID_INPUT", "observations_path must name a local JSONL file, not a URL.")
+    if not re.fullmatch(r"[0-9a-fA-F]{64}", spec["observations_sha256"]):
+        raise InputError("INVALID_INPUT", "observations_sha256 must be a SHA-256 hex digest.")
+    if type(spec.get("expected_cells")) is not int or spec["expected_cells"] <= 0:
+        raise InputError("INVALID_INPUT", "expected_cells must be a positive integer.")
+
+
+def _demographics(donors, records, field, findings, split):
+    distribution = {}
+    known = conflict = 0
+    for donor in donors:
+        values = records.get(donor, set())
+        if len(values) == 1:
+            known += 1
+            value = next(iter(values))
+            distribution[value] = distribution.get(value, 0) + 1
+        elif len(values) > 1:
+            conflict += 1
+    unknown = len(donors) - known - conflict
+    if unknown:
+        _finding(findings, f"{field.upper()}_COVERAGE_INCOMPLETE", "warning",
+                 f"{unknown} donors have no reported {field}; no values were inferred.", split)
+    if conflict:
+        _finding(findings, f"{field.upper()}_METADATA_CONFLICT", "warning",
+                 f"{conflict} donors have conflicting {field} values; excluded from the distribution.", split)
+    return {"known_donors": known, "unknown_donors": unknown,
+            "conflicting_donors": conflict, "distribution": dict(sorted(distribution.items()))}
+
+
+def _read_split(name, spec, parent, findings):
+    path = (parent / spec["observations_path"]).resolve()
+    digest = hashlib.sha256()
+    cells, donors = set(), set()
+    demographics = {"sex": {}, "ancestry": {}}
+    count = duplicates = 0
+    # Hash exactly the bytes parsed in this single read, avoiding a separate hash/read race.
+    with path.open("rb") as handle:
+        for line_number, line in enumerate(handle, 1):
+            digest.update(line)
+            if not line.strip():
+                continue
+            try:
+                row = _json(line)
+            except (ValueError, UnicodeError) as error:
+                raise InputError("INVALID_INPUT", f"Invalid JSONL in {name}, line {line_number}.") from error
+            if not isinstance(row, dict):
+                raise InputError("INVALID_INPUT", f"{name} line {line_number} must be an object.")
+            cell = _text(row.get("cell_id"), f"{name} cell_id at line {line_number}")
+            donor = _text(row.get("donor_id"), f"{name} donor_id at line {line_number}")
+            duplicates += int(cell in cells)
+            cells.add(cell)
+            donors.add(donor)
+            count += 1
+            for field, groups in demographics.items():
+                value = row.get(field)
+                if value is None:
+                    continue
+                if not isinstance(value, str):
+                    raise InputError("INVALID_INPUT", f"Optional {field} must be a string or null.")
+                value = value.strip()
+                if value.casefold() not in UNKNOWN:
+                    groups.setdefault(donor, set()).add(value)
+    actual_hash = digest.hexdigest()
+    if actual_hash != spec["observations_sha256"].lower():
+        raise InputError("CHECKSUM_MISMATCH", f"{name} observations do not match the declared SHA-256.")
+    if count != spec["expected_cells"]:
+        raise InputError("CELL_COUNT_MISMATCH", f"{name}: read {count} cells; expected {spec['expected_cells']}.")
+    if duplicates:
+        _finding(findings, "DUPLICATE_CELL_ID", "failure",
+                 f"{duplicates} repeated cell IDs within the split.", name)
+    summary = {
+        "dataset_id": spec["dataset_id"], "dataset_version": spec["dataset_version"],
+        "source_url": spec["source_url"], "identity_namespace": spec["identity_namespace"],
+        "observations_path": str(path), "observations_sha256": actual_hash,
+        "cells": count, "unique_cells": len(cells), "donors": len(donors),
+        "duplicate_cell_rows": duplicates,
+        "donor_metadata": {field: _demographics(donors, groups, field, findings, name)
+                           for field, groups in demographics.items()},
+    }
+    return summary, cells, donors
+
+
+def _audit(path, raw):
+    result = {
+        "tool": "atlas-benchmark-preflight", "tool_version": VERSION,
+        "status": "ERROR", "scope": "declared_observation_metadata_only",
+        "model_training_contamination": "not_assessed", "synthetic_demo": False,
+        "splits": {}, "overlap": None, "findings": [], "limitations": LIMITATIONS.copy(),
+        "provenance": {"manifest_path": str(path),
+                       "manifest_sha256": hashlib.sha256(raw).hexdigest()},
+    }
+    try:
+        manifest = _json(raw)
+        if not isinstance(manifest, dict) or type(manifest.get("schema_version")) is not int or manifest["schema_version"] != 1:
+            raise InputError("INVALID_INPUT", "Expected manifest schema_version 1.")
+        splits = manifest.get("splits")
+        if not isinstance(splits, dict) or set(splits) != {"train", "test"}:
+            raise InputError("INVALID_INPUT", "Exactly train and test splits are required.")
+        for spec in splits.values():
+            _validate_spec(spec)
+        result["synthetic_demo"] = manifest.get("synthetic_demo") is True
+        if splits["train"]["identity_namespace"] != splits["test"]["identity_namespace"]:
+            raise InputError("IDENTITY_NAMESPACE_MISMATCH", "Cannot compare IDs from different identity namespaces.")
+        identities = {}
+        for name in ("train", "test"):
+            summary, cells, donors = _read_split(name, splits[name], path.parent, result["findings"])
+            result["splits"][name] = summary
+            identities[name] = (cells, donors)
+        cell_overlap = len(identities["train"][0] & identities["test"][0])
+        donor_overlap = len(identities["train"][1] & identities["test"][1])
+        result["overlap"] = {"cells": cell_overlap, "donors": donor_overlap}
+        for count, code in ((cell_overlap, "CELL_OVERLAP"), (donor_overlap, "DONOR_OVERLAP")):
+            if count:
+                _finding(result["findings"], code, "failure",
+                         f"{count} shared {code.split('_')[0].lower()} identities between train and test.")
+        result["status"] = "FAIL" if any(f["severity"] == "failure" for f in result["findings"]) else "PASS"
+    except (InputError, ValueError, OSError, UnicodeError) as error:
+        _finding(result["findings"], getattr(error, "code", "INVALID_INPUT"), "error", str(error))
+    return result
+
+
+def audit_manifest(path):
+    """Audit pinned local JSONL observation exports; never use network or write files."""
+    path = Path(path).resolve()
+    try:
+        raw = path.read_bytes()
+    except OSError as error:
+        result = _audit(path, b"")
+        result["provenance"]["manifest_sha256"] = None
+        result["findings"] = [{"code": "INVALID_INPUT", "severity": "error", "message": str(error)}]
+        return result
+    return _audit(path, raw)
+
+
+def _write_bundle(out, result, raw, argv):
+    # Refuse existing directories, files and symlinks, including concurrent creation.
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.mkdir(exist_ok=False)
+    repro = out / "reproducibility"
+    repro.mkdir()
+    (out / "result.json").write_text(json.dumps(result, indent=2, allow_nan=False) + "\n", encoding="utf-8")
+    lines = ["# Atlas benchmark preflight", "", f"Status: **{result['status']}**", "",
+             "Scope: declared observation metadata only. Model-training contamination was not assessed.", ""]
+    if result["synthetic_demo"]:
+        lines += ["**SYNTHETIC DEMO: these are toy records, not Tabula Sapiens observations.**", ""]
+    lines += ["| Split | Cells | Unique donors |", "|---|---:|---:|"]
+    for name, split in result["splits"].items():
+        lines.append(f"| {name} | {split['cells']} | {split['donors']} |")
+    if result["overlap"] is not None:
+        lines += ["", f"Shared cells: {result['overlap']['cells']}. Shared donors: {result['overlap']['donors']}."]
+    lines += ["", "## Findings", ""]
+    lines.extend(f"- {f['severity'].upper()}: {f['code']}" + (f" ({f['split']})" if "split" in f else "")
+                 for f in result["findings"])
+    if not result["findings"]:
+        lines.append("No overlap or metadata warnings found within the declared scope.")
+    lines += ["", "See result.json for structured findings and donor-level metadata coverage.", "",
+              "## Interpretation boundaries", ""] + [f"- {line}" for line in LIMITATIONS]
+    lines += ["", DISCLAIMER, ""]
+    (out / "report.md").write_text("\n".join(lines), encoding="utf-8")
+    if raw is not None:
+        (repro / "manifest.json").write_bytes(raw)
+    script = Path(__file__).resolve()
+    (repro / "environment.json").write_text(json.dumps({
+        "python": platform.python_version(), "platform": platform.platform(),
+        "tool_version": VERSION, "script_sha256": hashlib.sha256(script.read_bytes()).hexdigest(),
+        "dependencies": "Python standard library only", "network_access": "none",
+        "working_directory": str(Path.cwd()),
+    }, indent=2) + "\n", encoding="utf-8")
+    (repro / "commands.sh").write_text(
+        "#!/usr/bin/env bash\n# Original invocation. Choose a fresh --output directory for a rerun.\n"
+        + "cd " + shlex.quote(str(Path.cwd())) + "\n"
+        + shlex.join([sys.executable, str(script), *argv]) + "\n", encoding="utf-8")
+    hashes = []
+    for path in sorted(out.rglob("*")):
+        if path.is_file():
+            hashes.append(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.relative_to(out).as_posix()}")
+    (repro / "checksums.sha256").write_text("\n".join(hashes) + "\n", encoding="utf-8")
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    parser = argparse.ArgumentParser(description=__doc__)
+    inputs = parser.add_mutually_exclusive_group(required=True)
+    inputs.add_argument("--input", type=Path, help="Pinned manifest for local JSONL metadata exports.")
+    inputs.add_argument("--demo", action="store_true", help="Synthetic leaking split, expected FAIL and exit 1.")
+    parser.add_argument("--output", type=Path, required=True, help="New output directory; existing paths are refused.")
+    args = parser.parse_args(argv)
+    path = (Path(__file__).parent / "fixtures" / "atlas_preflight" / "demo_manifest.json"
+            if args.demo else args.input).resolve()
+    try:
+        raw = path.read_bytes()
+        result = _audit(path, raw)
+    except OSError:
+        raw = None
+        result = audit_manifest(path)
+    try:
+        _write_bundle(args.output.absolute(), result, raw, argv)
+    except OSError as error:
+        print(f"Refusing to overwrite, or unable to write, output: {error}", file=sys.stderr)
+        return 2
+    print(json.dumps({"status": result["status"], "scope": result["scope"],
+                      "output": str(args.output.absolute()), "overlap": result["overlap"]}))
+    return {"PASS": 0, "FAIL": 1, "ERROR": 2}[result["status"]]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/fixtures/atlas_preflight/demo_manifest.json
+++ b/tests/benchmark/fixtures/atlas_preflight/demo_manifest.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "synthetic_demo": true,
+  "description": "Toy leaking split. Not real Tabula Sapiens data. Expected FAIL.",
+  "splits": {
+    "train": {
+      "dataset_id": "synthetic-atlas-example",
+      "dataset_version": "1.0",
+      "source_url": "https://example.org/synthetic-atlas",
+      "identity_namespace": "synthetic-atlas-stable-ids-v1",
+      "observations_path": "train.jsonl",
+      "observations_sha256": "2de772f327f6b4dd2f005c2e5e50b7b9235c46aa8c48f5c2b9e03ff5accfc4e3",
+      "expected_cells": 2
+    },
+    "test": {
+      "dataset_id": "synthetic-atlas-example",
+      "dataset_version": "2.0",
+      "source_url": "https://example.org/synthetic-atlas",
+      "identity_namespace": "synthetic-atlas-stable-ids-v1",
+      "observations_path": "test.jsonl",
+      "observations_sha256": "03ca9342bb6d9c2ac11beed01bad6eef1c36e91423325c0c0dfb8d46298deb05",
+      "expected_cells": 2
+    }
+  }
+}

--- a/tests/benchmark/fixtures/atlas_preflight/test.jsonl
+++ b/tests/benchmark/fixtures/atlas_preflight/test.jsonl
@@ -1,0 +1,2 @@
+{"cell_id":"SYNTHETIC-A:cell-1","donor_id":"SYNTHETIC-A","sex":"female","ancestry":null}
+{"cell_id":"SYNTHETIC-B:cell-1","donor_id":"SYNTHETIC-B","sex":"male","ancestry":null}

--- a/tests/benchmark/fixtures/atlas_preflight/train.jsonl
+++ b/tests/benchmark/fixtures/atlas_preflight/train.jsonl
@@ -1,0 +1,2 @@
+{"cell_id":"SYNTHETIC-A:cell-1","donor_id":"SYNTHETIC-A","sex":"female","ancestry":null}
+{"cell_id":"SYNTHETIC-A:cell-2","donor_id":"SYNTHETIC-A","sex":"female","ancestry":null}

--- a/tests/benchmark/test_atlas_preflight.py
+++ b/tests/benchmark/test_atlas_preflight.py
@@ -1,0 +1,233 @@
+"""Offline contract tests. All cell/donor records in this module are synthetic."""
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).with_name("atlas_preflight.py")
+SPEC = importlib.util.spec_from_file_location("atlas_preflight", SCRIPT)
+audit = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(audit)
+
+
+def save_json(path, value):
+    path.write_text(json.dumps(value), encoding="utf-8")
+    return path
+
+
+def make_manifest(tmp_path, train=None, test=None):
+    records = {
+        "train": train if train is not None else [
+            {"cell_id": "SYN-A:1", "donor_id": "SYN-A", "sex": "female"},
+            {"cell_id": "SYN-A:2", "donor_id": "SYN-A", "sex": "female"},
+        ],
+        "test": test if test is not None else [
+            {"cell_id": "SYN-B:1", "donor_id": "SYN-B", "sex": "male"},
+        ],
+    }
+    manifest = {"schema_version": 1, "splits": {}}
+    for name, rows in records.items():
+        path = tmp_path / (name + ".jsonl")
+        path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+        manifest["splits"][name] = {
+            "dataset_id": "synthetic-atlas",
+            "dataset_version": "1.0" if name == "train" else "2.0",
+            "source_url": "https://example.org/synthetic-atlas",
+            "identity_namespace": "synthetic-study-stable-ids-v1",
+            "observations_path": path.name,
+            "observations_sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+            "expected_cells": len(rows),
+        }
+    return save_json(tmp_path / "manifest.json", manifest)
+
+
+def change(path, edit):
+    value = json.loads(path.read_text())
+    edit(value)
+    save_json(path, value)
+
+
+def codes(result):
+    return {f["code"] for f in result["findings"]}
+
+
+def test_disjoint_declared_metadata_passes_but_does_not_prove_model_clean(tmp_path):
+    path = make_manifest(tmp_path)
+    result = audit.audit_manifest(path)
+    assert result["status"] == "PASS"
+    assert result["scope"] == "declared_observation_metadata_only"
+    assert result["model_training_contamination"] == "not_assessed"
+    assert result["splits"]["train"]["cells"] == 2
+    assert result["splits"]["train"]["donors"] == 1
+    assert result["overlap"] == {"cells": 0, "donors": 0}
+    assert "ANCESTRY_COVERAGE_INCOMPLETE" in codes(result)
+    assert result["provenance"]["manifest_sha256"] == hashlib.sha256(path.read_bytes()).hexdigest()
+    assert result == audit.audit_manifest(path)
+
+
+def test_cell_and_donor_overlap_block_combined_v2(tmp_path):
+    path = make_manifest(tmp_path, test=[{"cell_id": "SYN-A:1", "donor_id": "SYN-A"}])
+    result = audit.audit_manifest(path)
+    assert result["status"] == "FAIL"
+    assert {"CELL_OVERLAP", "DONOR_OVERLAP"} <= codes(result)
+    assert result["overlap"] == {"cells": 1, "donors": 1}
+
+
+def test_distinct_cells_from_same_donor_fail_donor_holdout(tmp_path):
+    path = make_manifest(tmp_path, test=[{"cell_id": "SYN-A:NEW", "donor_id": "SYN-A"}])
+    result = audit.audit_manifest(path)
+    assert result["status"] == "FAIL"
+    assert "DONOR_OVERLAP" in codes(result)
+    assert "CELL_OVERLAP" not in codes(result)
+
+
+@pytest.mark.parametrize("field", ["cell_id", "donor_id"])
+@pytest.mark.parametrize("value", [None, "", "unknown", "NA", "nan", 3, [], " A "])
+def test_invalid_or_unknown_identity_fails_closed(tmp_path, field, value):
+    row = {"cell_id": "SYN-B:1", "donor_id": "SYN-B", field: value}
+    result = audit.audit_manifest(make_manifest(tmp_path, test=[row]))
+    assert result["status"] == "ERROR"
+    assert "INVALID_INPUT" in codes(result)
+
+
+def test_absent_identity_rejected(tmp_path):
+    result = audit.audit_manifest(make_manifest(tmp_path, test=[{"cell_id": "SYN-B:1"}]))
+    assert result["status"] == "ERROR"
+
+
+def test_namespace_difference_is_unverifiable_not_disjoint(tmp_path):
+    path = make_manifest(tmp_path)
+    change(path, lambda m: m["splits"]["test"].update(identity_namespace="renamed-ids"))
+    result = audit.audit_manifest(path)
+    assert result["status"] == "ERROR"
+    assert "IDENTITY_NAMESPACE_MISMATCH" in codes(result)
+    assert result["overlap"] is None
+
+
+@pytest.mark.parametrize("version", ["latest", "stable", "main", "HEAD", "current", ""])
+def test_floating_or_empty_version_rejected(tmp_path, version):
+    path = make_manifest(tmp_path)
+    change(path, lambda m: m["splits"]["test"].update(dataset_version=version))
+    assert audit.audit_manifest(path)["status"] == "ERROR"
+
+
+def test_same_version_with_disjoint_ids_is_not_itself_leakage(tmp_path):
+    path = make_manifest(tmp_path)
+    change(path, lambda m: m["splits"]["test"].update(dataset_version="1.0"))
+    assert audit.audit_manifest(path)["status"] == "PASS"
+
+
+@pytest.mark.parametrize("field", ["expected_cells", "observations_sha256", "source_url", "dataset_id"])
+def test_missing_provenance_rejected(tmp_path, field):
+    path = make_manifest(tmp_path)
+    change(path, lambda m: m["splits"]["test"].pop(field))
+    assert audit.audit_manifest(path)["status"] == "ERROR"
+
+
+def test_tampered_bytes_fail_hash_check(tmp_path):
+    path = make_manifest(tmp_path)
+    with (tmp_path / "test.jsonl").open("a") as handle:
+        handle.write("\n")
+    result = audit.audit_manifest(path)
+    assert result["status"] == "ERROR"
+    assert "CHECKSUM_MISMATCH" in codes(result)
+
+
+def test_incomplete_export_fails_count_check(tmp_path):
+    path = make_manifest(tmp_path)
+    change(path, lambda m: m["splits"]["test"].update(expected_cells=100))
+    assert "CELL_COUNT_MISMATCH" in codes(audit.audit_manifest(path))
+
+
+def test_duplicate_cell_within_split_fails(tmp_path):
+    row = {"cell_id": "SYN-A:1", "donor_id": "SYN-A"}
+    result = audit.audit_manifest(make_manifest(tmp_path, train=[row, row]))
+    assert result["status"] == "FAIL"
+    assert "DUPLICATE_CELL_ID" in codes(result)
+
+
+def test_empty_split_fails(tmp_path):
+    assert audit.audit_manifest(make_manifest(tmp_path, test=[]))["status"] == "ERROR"
+
+
+def test_population_summary_counts_donors_not_cells(tmp_path):
+    path = make_manifest(tmp_path)
+    result = audit.audit_manifest(path)
+    coverage = result["splits"]["train"]["donor_metadata"]["sex"]
+    assert coverage == {"known_donors": 1, "unknown_donors": 0, "conflicting_donors": 0,
+                        "distribution": {"female": 1}}
+    assert result["splits"]["train"]["donor_metadata"]["ancestry"]["unknown_donors"] == 1
+
+
+def test_inconsistent_demographics_warn_and_do_not_invent_consensus(tmp_path):
+    rows = [{"cell_id": "SYN-A:1", "donor_id": "SYN-A", "sex": "female"},
+            {"cell_id": "SYN-A:2", "donor_id": "SYN-A", "sex": "male"}]
+    result = audit.audit_manifest(make_manifest(tmp_path, train=rows))
+    assert "SEX_METADATA_CONFLICT" in codes(result)
+    assert result["splits"]["train"]["donor_metadata"]["sex"]["distribution"] == {}
+
+
+@pytest.mark.parametrize("contents", ['{', '[]', '{"schema_version": 2}', '{"schema_version":1,"schema_version":1}'])
+def test_malformed_manifest_reports_error(tmp_path, contents):
+    path = tmp_path / "bad.json"
+    path.write_text(contents)
+    assert audit.audit_manifest(path)["status"] == "ERROR"
+
+
+def test_remote_observations_path_never_fetched(tmp_path):
+    path = make_manifest(tmp_path)
+    change(path, lambda m: m["splits"]["test"].update(observations_path="https://example.org/cells.jsonl"))
+    assert audit.audit_manifest(path)["status"] == "ERROR"
+
+
+def run_cli(*args):
+    return subprocess.run([sys.executable, str(SCRIPT), *map(str, args)], text=True, capture_output=True)
+
+
+@pytest.mark.parametrize("overlap,exit_code", [(False, 0), (True, 1)])
+def test_cli_writes_verifiable_bundle_and_respects_exit_status(tmp_path, overlap, exit_code):
+    rows = [{"cell_id": "SYN-A:1", "donor_id": "SYN-A"}] if overlap else None
+    path = make_manifest(tmp_path, test=rows)
+    out = tmp_path / "report with spaces"
+    completed = run_cli("--input", path, "--output", out)
+    assert completed.returncode == exit_code, completed.stderr
+    result = json.loads((out / "result.json").read_text())
+    assert result["status"] == ("FAIL" if overlap else "PASS")
+    assert "not a medical device" in (out / "report.md").read_text()
+    assert (out / "reproducibility" / "manifest.json").read_bytes() == path.read_bytes()
+    assert "'" in (out / "reproducibility" / "commands.sh").read_text()
+    for line in (out / "reproducibility" / "checksums.sha256").read_text().splitlines():
+        digest, relative = line.split("  ", 1)
+        assert hashlib.sha256((out / relative).read_bytes()).hexdigest() == digest
+    before = (out / "result.json").read_bytes()
+    assert run_cli("--input", path, "--output", out).returncode == 2
+    assert (out / "result.json").read_bytes() == before
+
+
+def test_cli_error_is_reported_and_nonzero(tmp_path):
+    path = make_manifest(tmp_path)
+    change(path, lambda m: m["splits"]["test"].update(expected_cells=999))
+    out = tmp_path / "error_report"
+    assert run_cli("--input", path, "--output", out).returncode == 2
+    assert json.loads((out / "result.json").read_text())["status"] == "ERROR"
+
+
+def test_demo_is_synthetic_and_deliberately_detects_leakage(tmp_path):
+    out = tmp_path / "demo"
+    result = run_cli("--demo", "--output", out)
+    assert result.returncode == 1, result.stderr
+    payload = json.loads((out / "result.json").read_text())
+    assert payload["status"] == "FAIL"
+    assert payload["synthetic_demo"] is True
+    assert payload["overlap"] == {"cells": 1, "donors": 1}
+
+
+def test_cli_requires_input_or_demo_and_never_both(tmp_path):
+    assert run_cli("--output", tmp_path / "no_input").returncode == 2
+    assert run_cli("--input", "x", "--demo", "--output", tmp_path / "both").returncode == 2


### PR DESCRIPTION
## Summary

The combined Tabula Sapiens 2.0 atlas includes earlier samples, so a newer release label alone does not establish an independent test set. [CZI's benchmark curation](https://virtualcellmodels.cziscience.com/dataset/tabula-sapiens) explicitly removes v1 samples previously used in training.

- Add an offline preflight for pinned train/test JSONL observation metadata. Detect shared donors and cells, duplicate cell IDs, incompatible identity namespaces, checksum mismatches and incomplete exports; reject floating release labels and missing identifiers.
- Generate JSON/Markdown reports and a reproducibility bundle. Summarise sex/ancestry coverage by unique donor, retaining missing and conflicting values explicitly.
- Add 48 regression tests, a clearly labelled synthetic negative-control demo and usage documentation. No new runtime dependencies or changes to existing skill interfaces.

## Skill affected

None. This extends `tests/benchmark` with an opt-in utility. The existing pytest configuration discovers its tests. No SKILL.md or catalogue changes are required.

## Checklist

- [x] SKILL.md applicability checked: not applicable, no skill added or modified.
- [x] Tests included and passing: 103 selected tests, including 48 new tests.
- [x] Demo data included for reviewers to test: synthetic, deliberately overlapping records.
- [x] No patient/sensitive data committed.
- [x] Follows applicable CONTRIBUTING.md conventions: local computation, focused scope, documentation, reproducibility and refusal to overwrite output.

## Test output

Red baseline: new tests failed collection because `atlas_preflight.py` did not yet exist. After implementation:

```text
python -m pytest tests/benchmark/test_atlas_preflight.py -q
48 passed in 1.56s

python -m pytest tests/benchmark/test_atlas_preflight.py tests/benchmark/test_finemapping_benchmark.py tests/benchmark/test_reference_genome.py -q
103 passed in 20.24s
```

These tests ran on Python 3.13.12. CLI negative-control smoke tests and output checksum verification also passed on Python 3.11.14 and 3.14.6. Python 3.10/3.12 syntax compatibility was checked; those runtime suites were not run locally. `git diff --check` passed.

Reviewer demo, from the repository root using a new output directory:

```bash
python tests/benchmark/atlas_preflight.py --demo --output /tmp/atlas-preflight-review
```

Expected result (exit **1**, deliberately):

```json
{"status": "FAIL", "scope": "declared_observation_metadata_only", "overlap": {"cells": 1, "donors": 1}}
```

The negative control succeeds by detecting the overlap. Exit codes are 0 for PASS, 1 for FAIL and 2 for malformed/unverifiable input or an output write error. Existing output paths are refused.

### Interpretation limits

A PASS concerns only declared observation metadata. It does not certify a model's training history, export completeness against H5AD, expression-level duplicates, annotation accuracy, or absence of preprocessing/tuning leakage. Identifiers must remain globally stable within a common study namespace across releases. Checksums bind inspected metadata bytes; source declarations still require verification by the caller. Missing ancestry is not imputed or converted into an equity score.

This is opt-in and does not automatically gate existing benchmark runners. No real Tabula Sapiens analysis or model benchmark was run. See `docs/atlas-benchmark-preflight.md` for the input contract and reproducibility details.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New isolated benchmark utility and tests only; no changes to production skills, auth, or data pipelines beyond reading caller-supplied local files.
> 
> **Overview**
> Adds an **opt-in, offline** preflight utility under `tests/benchmark` so train/test atlas benchmarks can be checked against **pinned local JSONL observation metadata** instead of trusting release labels (e.g. Tabula Sapiens v2 vs v1 holdout).
> 
> `atlas_preflight.py` validates a manifest with exactly `train` and `test` splits (pinned versions, SHA-256, cell counts, shared identity namespace), then flags **donor/cell overlap**, duplicate cell IDs within a split, checksum/count mismatches, and bad or floating provenance. It emits `report.md`, `result.json`, and a **reproducibility bundle**; summarizes sex/ancestry by **unique donor** with warnings only. **No network**, no third-party deps, and existing output directories are refused. CLI exit codes: 0 PASS, 1 FAIL, 2 ERROR.
> 
> Also adds `docs/atlas-benchmark-preflight.md`, synthetic demo fixtures (deliberate FAIL), and a large pytest contract suite. **Does not** wire into existing benchmark runners or ClawBio skills.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81a6487e23284f518ca80eb919ac650ece34fda7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->