### PR TITLE
feat(gwas-prs): validate evidence before percentile interpretation

### DIFF
--- a/clawbio/cli.py
+++ b/clawbio/cli.py
@@ -449,7 +449,7 @@ SKILLS = {
         "description": "GWAS Polygenic Risk Score calculator (PGS Catalog, 3000+ scores)",
         "allowed_extra_flags": {
             "--trait", "--pgs-id", "--panel-id", "--min-overlap",
-            "--max-variants", "--build",
+            "--max-variants", "--build", "--evidence-json",
         },
         "accepts_genotypes": True,
     },

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -2265,7 +2265,7 @@
       "name": "gwas-prs",
       "cli_alias": "prs",
       "description": "Calculate polygenic risk scores from DTC genetic data using the PGS Catalog",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "status": "mvp",
       "maturity_tier": "ci-validated",
       "maturity_evidence": {

--- a/skills/gwas-prs/SKILL.md
+++ b/skills/gwas-prs/SKILL.md
@@ -3,7 +3,7 @@ name: gwas-prs
 description: Calculate polygenic risk scores from DTC genetic data using the PGS Catalog
 license: MIT
 metadata:
-  version: 0.2.0
+  version: 0.3.0
   openclaw:
     requires:
       bins:
@@ -22,6 +22,29 @@ metadata:
 # Polygenic Risk Score Calculator (GWAS-PRS)
 
 You are **GWAS-PRS**, a specialised ClawBio agent for polygenic risk score calculation. Your role is to compute polygenic risk scores (PRS) from direct-to-consumer (DTC) genetic data using published scoring files from the PGS Catalog, and to contextualise those scores against reference population distributions.
+
+## Evidence-gated interpretation (v0.3.0)
+
+Real-input runs require a local `--evidence-json` manifest before reporting a
+research percentile. Without sufficient evidence, percentile, z-score and risk
+category are null; the raw sum is retained for audit. The built-in synthetic
+`--demo` retains illustrative estimates and is labelled `synthetic_demo_only`.
+Supplying evidence also gates the demo. Curated panels cannot qualify.
+
+Read [the evidence policy and manifest schema](references/prs-evidence.md) when
+preparing evidence or explaining a withheld result. It specifies exact input/
+score hashes, build/strand declarations, allele compatibility, complete coverage,
+independent validation and target-context reference requirements. Population
+resemblance or representation metrics alone never establish portability.
+Heritability and causal evidence remain separate from predictive performance.
+A supported percentile does not establish clinical utility; risk category is
+always null in evidence-gated runs.
+
+The percentile instructions below describe the legacy illustrative demo.
+For real data, the evidence policy supersedes those estimation and risk-label
+steps. Existing additive score calculation is unchanged.
+
+Offline evidence-policy demo: `python skills/gwas-prs/benchmark_evidence.py --demo --output /tmp/prs-evidence-demo`. Its fixtures are synthetic software checks, not published-score validation.
 
 ## Core Capabilities
 
@@ -142,6 +165,8 @@ The report includes:
 
 | Column | Description |
 |---|---|
+| evidence_assessment | Versioned evidence decision, reasons, provenance and separated evidence types; null in ungated synthetic demo |
+| interpretation_scope | research_percentile or synthetic_demo_only |
 | score_id | Canonical score identity: `CLAWBIO-*` for curated panels or `PGS*` for Catalog scores |
 | pgs_id | PGS Catalog identifier; null for normal curated-panel runs |
 | curated_panel_id | Canonical panel id when `curated_demo_panel` is true |
@@ -250,3 +275,7 @@ It can be chained with:
 - **nutrigx**: Combine PRS for metabolic traits (T2D, BMI) with nutrigenomic recommendations.
 - **claw-ancestry-pca**: Ancestry estimation helps validate whether the PRS reference population is appropriate for the individual.
 - **clinpgx**: Cross-reference gene-drug interactions for conditions flagged as elevated risk by PRS.
+
+Replay requires `PRS_REPLAY_OUTPUT` naming a fresh output directory, preserving
+the original run for comparison. When evidence was supplied, also set
+`PRS_EVIDENCE_FILE` to the original manifest.

--- a/skills/gwas-prs/benchmark_evidence.py
+++ b/skills/gwas-prs/benchmark_evidence.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Offline synthetic evidence-policy contract benchmark; not clinical validation."""
+from __future__ import annotations
+
+import argparse
+import copy
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+
+SKILL = Path(__file__).resolve().parent
+spec = importlib.util.spec_from_file_location("prs_evidence", SKILL / "prs_evidence.py")
+policy = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(policy)
+
+DISCLAIMER = ("ClawBio is a research and educational tool. It is not a medical device "
+              "and does not provide clinical diagnoses. Consult a healthcare "
+              "professional before making any medical decisions.")
+
+
+def run_benchmark():
+    """Deliberately fabricated evidence exercises policy mechanics only."""
+    with tempfile.TemporaryDirectory(prefix="prs-evidence-") as tmp:
+        root = Path(tmp)
+        score = root / "score.txt"
+        inp = root / "input.txt"
+        score.write_text("rsID\teffect_allele\tother_allele\teffect_weight\nrs1\tA\tG\t0.2\n")
+        inp.write_text("# synthetic only\nrs1\t1\t1\tAG\n")
+        context = {"population": "synthetic-population", "context": "synthetic-adults"}
+        base = {
+            "score_id": "SYNTHETIC", "scoring_path": score, "input_path": inp,
+            "build": "GRCh37", "raw_score": 0.2, "genotypes": {"rs1": "AG"},
+            "variants": [{"rsid": "rs1", "effect_allele": "A", "other_allele": "G", "effect_weight": 0.2}],
+            "evidence": {
+                "schema_version": 1,
+                "input": dict(context, sha256=policy.digest(inp), build="GRCh37",
+                              strand="forward", source="synthetic manifest"),
+                "scores": {"SYNTHETIC": {
+                    "sha256": policy.digest(score), "build": "GRCh37", "version": "1",
+                    "source": "synthetic score", "variant_count": 1,
+                    "validation": dict(context, independent=True, n=1000,
+                        source="fabricated validation", metric="r2", estimate=0.03, ci_lower=0.01, ci_upper=0.05),
+                    "reference": dict(context, n=1000, source="fabricated reference",
+                        mean=0.2, sd=0.1, distribution="normal", missingness="complete_only"),
+                }},
+            },
+        }
+        cases = [
+            ("synthetic_personality_supported", (), None, "supported"),
+            ("synthetic_metabolic_supported", ("evidence", "scores", "SYNTHETIC", "trait"), "metabolic", "supported"),
+            ("missing_evidence", ("evidence",), None, "not_established"),
+            ("missing_score", ("evidence", "scores"), {}, "not_established"),
+            ("different_population", ("evidence", "input", "population"), "another", "not_established"),
+            ("different_context", ("evidence", "input", "context"), "children", "not_established"),
+            ("no_independent_validation", ("evidence", "scores", "SYNTHETIC", "validation", "independent"), False, "not_established"),
+            ("missing_reference", ("evidence", "scores", "SYNTHETIC", "reference"), None, "not_established"),
+            ("different_weights", ("evidence", "scores", "SYNTHETIC", "sha256"), "0"*64, "incompatible"),
+            ("different_build", ("evidence", "input", "build"), "GRCh38", "incompatible"),
+            ("missing_variant", ("genotypes",), {}, "not_established"),
+            ("invalid_genotype", ("genotypes", "rs1"), "00", "incompatible"),
+            ("wrong_sum", ("raw_score",), 999, "incompatible"),
+            ("unknown_strand", ("evidence", "input", "strand"), None, "not_established"),
+        ]
+        rows = []
+        for name, path, value, expected in cases:
+            args = copy.deepcopy(base)
+            if path:
+                obj = args
+                for key in path[:-1]:
+                    obj = obj[key]
+                obj[path[-1]] = value
+            result = policy.assess(**args)
+            rows.append({"case": name, "expected": expected, "observed": result["status"],
+                         "percentile": result["percentile"],
+                         "reasons": [r["code"] for r in result["reasons"]],
+                         "passed": result["status"] == expected
+                         and (result["percentile"] == 50 if expected == "supported"
+                              else result["percentile"] is None)})
+    return {
+        "evidence_type": "synthetic_software_contract", "policy_version": policy.POLICY_VERSION,
+        "all_passed": all(row["passed"] for row in rows),
+        "supported_cases": sum(row["expected"] == "supported" for row in rows),
+        "withheld_cases": sum(row["expected"] != "supported" for row in rows),
+        "false_supported": sum(row["expected"] != "supported" and row["observed"] == "supported" for row in rows),
+        "false_withheld": sum(row["expected"] == "supported" and row["observed"] != "supported" for row in rows),
+        "cases": rows,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--demo", action="store_true", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    if args.output.exists() and any(args.output.iterdir()):
+        parser.error("Choose a new or empty output directory.")
+    result = run_benchmark()
+    args.output.mkdir(parents=True, exist_ok=True)
+    (args.output / "result.json").write_text(json.dumps(result, indent=2) + "\n")
+    lines = ["# PRS evidence policy: synthetic software benchmark", "",
+             "Fabricated evidence and weights. Not a reproduction of the Nature paper,",
+             "an independently adjudicated benchmark, or evidence of clinical validity.", "",
+             "| Case | Expected | Observed | Percentile |", "|---|---|---|---|"]
+    for row in result["cases"]:
+        lines.append(f"| {row['case']} | {row['expected']} | {row['observed']} | {row['percentile']} |")
+    lines += ["", DISCLAIMER, ""]
+    (args.output / "report.md").write_text("\n".join(lines))
+    print(json.dumps({k: v for k, v in result.items() if k != "cases"}, indent=2))
+    return 0 if result["all_passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/gwas-prs/gwas_prs.py
+++ b/skills/gwas-prs/gwas_prs.py
@@ -38,6 +38,7 @@ for _import_path in (_PROJECT_ROOT, _SKILL_DIR):
     if str(_import_path) not in sys.path:
         sys.path.insert(0, str(_import_path))
 
+from prs_evidence import assess as assess_evidence  # noqa: E402
 from repro_bundle import create_reproducibility_bundle  # noqa: E402
 
 from clawbio.common.checksums import sha256_hex  # noqa: E402
@@ -52,7 +53,7 @@ from clawbio.common.report import write_result_json  # noqa: E402
 PGS_API_BASE = "https://www.pgscatalog.org/rest"
 RATE_LIMIT_INTERVAL = 0.55  # seconds between requests (stay under 2 req/sec)
 CACHE_TTL = 86400  # 24 hours
-USER_AGENT = "ClawBio-GWAS-PRS/0.2.0"
+USER_AGENT = "ClawBio-GWAS-PRS/0.3.0"
 
 DISCLAIMER = _SHARED_DISCLAIMER
 
@@ -962,6 +963,13 @@ def generate_report(
             f"| **Overlap** | {prs['overlap_fraction'] * 100:.1f}% |"
         )
         lines.append(f"| **Raw PRS** | {prs['raw_score']:.6f} |")
+        assessment = r.get("evidence_assessment")
+        if assessment:
+            lines.append(f"| **Evidence assessment** | {assessment['status']} |")
+            for reason in assessment["reasons"]:
+                lines.append(f"| {reason['code']} | {reason['action']} |")
+            lines.append("| **Interpretation** | Research percentile only; no individual disease-risk or causal claim |")
+
         if pct_info["percentile"] is not None:
             lines.append(
                 f"| **Percentile** | {pct_info['percentile']:.1f}% |"
@@ -981,7 +989,7 @@ def generate_report(
                     f"{pct_info['reference_population']} |"
                 )
         else:
-            lines.append("| **Percentile** | N/A (no reference available) |")
+            lines.append("| **Percentile** | Withheld (see evidence assessment or reference availability) |")
         lines.append("")
 
         # Variant breakdown (show scored variants, limit to top contributors)
@@ -1070,6 +1078,18 @@ def generate_report(
     lines.append("")
     lines.append("**Genome build**: " + args.build)
     lines.append("")
+
+    if any(r.get("evidence_assessment") for r in results):
+        lines.append(
+            "**Evidence policy 1.0.0**: Research percentiles require caller-supplied, "
+            "hash-bound evidence for the exact score and input, complete compatible "
+            "variants, independent validation and a normal reference distribution "
+            "for the target population/context. Earlier percentile methods above "
+            "apply only to the synthetic demo. Evidence is not independently "
+            "verified; a supported percentile does not establish clinical utility "
+            "or causality. Unsupported raw sums are retained for audit only."
+        )
+        lines.append("")
 
     # ----- Limitations -----
     lines.append("## Limitations")
@@ -1165,7 +1185,26 @@ def main():
         help="Cache directory (default: ~/.clawbio/pgs_cache/)",
     )
 
+    parser.add_argument(
+        "--evidence-json",
+        help="Local hash-bound score/input evidence manifest for research percentiles",
+    )
     args = parser.parse_args()
+    evidence = None
+    if args.evidence_json:
+        try:
+            evidence = json.loads(Path(args.evidence_json).read_text())
+            if (not isinstance(evidence, dict) or evidence.get("schema_version") != 1
+                    or not isinstance(evidence.get("input"), dict)
+                    or not isinstance(evidence.get("scores"), dict)):
+                raise ValueError("expected schema_version 1 with input and scores objects")
+        except (OSError, ValueError) as exc:
+            parser.error(f"Invalid --evidence-json: {exc}")
+    evidence_gate = not args.demo or bool(args.evidence_json)
+    if args.output and any((Path(args.output) / name).exists() for name in (
+            "prs_report.md", "prs_results.json", "prs_variants.csv", "result.json", "reproducibility")):
+        parser.error("Output artifacts already exist; choose a new directory.")
+
 
     selectors = [args.demo, args.trait, args.pgs_id, args.panel_id]
     if sum(bool(value) for value in selectors) > 1:
@@ -1553,7 +1592,7 @@ def main():
         )
 
         # Check minimum overlap
-        if prs["overlap_fraction"] < args.min_overlap:
+        if prs["overlap_fraction"] < args.min_overlap and not evidence_gate:
             print(
                 f"  Skipping: overlap {prs['overlap_fraction'] * 100:.1f}% "
                 f"below --min-overlap {args.min_overlap * 100:.0f}%"
@@ -1562,10 +1601,26 @@ def main():
 
         print(f"  Raw PRS: {prs['raw_score']:.6f}")
 
-        # Estimate percentile
-        pct_info = estimate_percentile(
-            prs["raw_score"], score_id, scoring_variants
-        )
+        # Real inputs always require explicit evidence. Only the built-in
+        # synthetic demo retains illustrative legacy percentile estimates.
+        evidence_assessment = None
+        if evidence_gate:
+            evidence_assessment = assess_evidence(
+                score_id=score_id, scoring_path=filepath, input_path=input_path,
+                build=args.build, variants=scoring_variants,
+                genotypes=genotype_dict, raw_score=prs["raw_score"],
+                evidence=evidence, curated=is_curated_demo_panel(filepath),
+            )
+            pct_info = {key: evidence_assessment[key] for key in (
+                "percentile", "z_score", "risk_category", "method", "reference_population"
+            )}
+            print("  Evidence assessment: " + evidence_assessment["status"])
+            for reason in evidence_assessment["reasons"]:
+                print("    " + reason["code"] + ": " + reason["action"])
+        else:
+            pct_info = estimate_percentile(
+                prs["raw_score"], score_id, scoring_variants
+            )
         if pct_info["percentile"] is not None:
             print(
                 f"  Percentile: {pct_info['percentile']:.1f}% "
@@ -1587,6 +1642,8 @@ def main():
             "trait": trait,
             "prs": prs,
             "percentile_info": pct_info,
+            "evidence_assessment": evidence_assessment,
+            "interpretation_scope": "research_percentile" if evidence_gate else "synthetic_demo_only",
             "metadata": metadata,
             "scoring_variants": scoring_variants,
             "scoring_file_path": Path(filepath),
@@ -1639,6 +1696,8 @@ def main():
                 "variants_used": r["prs"]["variants_used"],
                 "variants_total": r["prs"]["variants_total"],
                 "overlap_fraction": r["prs"]["overlap_fraction"],
+                "evidence_assessment": r.get("evidence_assessment"),
+                "interpretation_scope": r.get("interpretation_scope"),
                 "percentile": r["percentile_info"]["percentile"],
                 "risk_category": r["percentile_info"]["risk_category"],
                 "z_score": r["percentile_info"]["z_score"],
@@ -1676,7 +1735,7 @@ def main():
         result_json_path = write_result_json(
             output_dir=output_dir,
             skill="gwas-prs",
-            version="0.2.0",
+            version="0.3.0",
             summary={
                 "scores_calculated": len(all_results),
                 "trait": first.get("trait", ""),
@@ -1693,6 +1752,8 @@ def main():
                 ),
                 "pgs_catalog_id": first.get("pgs_catalog_id"),
                 "raw_score": first.get("prs", {}).get("raw_score"),
+                "evidence_assessment": first.get("evidence_assessment"),
+                "interpretation_scope": first.get("interpretation_scope"),
                 "percentile": first_pct.get("percentile"),
                 "risk_category": first_pct.get("risk_category"),
                 "overlap_fraction": first.get("prs", {}).get("overlap_fraction"),

--- a/skills/gwas-prs/prs_evidence.py
+++ b/skills/gwas-prs/prs_evidence.py
@@ -1,0 +1,161 @@
+"""Deterministic research-percentile gate for exact scoring files.
+
+Evidence is caller-curated and hash-bound, not independently verified scientific
+truth. No network, ancestry inference, clinical classification or causal inference.
+"""
+from __future__ import annotations
+
+import hashlib
+import math
+from pathlib import Path
+
+POLICY_VERSION = "1.0.0"
+
+
+def digest(path):
+    h = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _text(value):
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _number(value):
+    return type(value) in (int, float) and math.isfinite(value)
+
+
+def _positive_int(value):
+    return type(value) is int and value > 0
+
+
+def _mapping(value):
+    return value if isinstance(value, dict) else {}
+
+
+def assess(*, score_id, scoring_path, input_path, build, variants, genotypes,
+           raw_score, evidence=None, curated=False):
+    """Return a stable decision; absent/incomplete evidence withholds interpretation.
+
+    Supported means the declared evidence satisfies this policy for a *research
+    percentile*. It does not certify external evidence or individual disease risk.
+    """
+    reasons = []
+    def flag(code, action, incompatible=False):
+        reasons.append({"code": code, "action": action, "incompatible": incompatible})
+
+    result = {
+        "policy_version": POLICY_VERSION, "status": "not_established",
+        "scope": "research_percentile", "evidence_basis": "caller_supplied",
+        "score_id": score_id, "scoring_sha256": digest(scoring_path),
+        "input_sha256": digest(input_path), "reasons": reasons,
+        "percentile": None, "z_score": None, "risk_category": None,
+        "method": "withheld_evidence", "reference_population": None,
+        "predictive_performance": None, "heritability": None,
+        "causal_evidence": None, "causal_claim_supported": False,
+    }
+    if curated:
+        flag("ILLUSTRATIVE_PANEL", "Use an exact published score with validated weights.")
+    if evidence is None:
+        flag("EVIDENCE_MISSING", "Supply a hash-bound evidence JSON; ancestry resemblance is insufficient.")
+        return result
+    if (not isinstance(evidence, dict) or type(evidence.get("schema_version")) is not int
+            or evidence["schema_version"] != 1
+            or not isinstance(evidence.get("input"), dict)
+            or not isinstance(evidence.get("scores"), dict)):
+        flag("EVIDENCE_SCHEMA_INVALID", "Use evidence schema version 1 with input and scores objects.")
+        return result
+    inp = evidence["input"]
+    card = _mapping(evidence["scores"].get(score_id))
+    if not card:
+        flag("SCORE_EVIDENCE_MISSING", "Provide evidence for this exact score identifier.")
+        return result
+    result["score_version"] = card.get("version")
+    result["score_source"] = card.get("source")
+    if card.get("sha256") != result["scoring_sha256"]:
+        flag("SCORE_IDENTITY_MISMATCH", "Verify the scoring-file hash against the cited score version.", True)
+    if inp.get("sha256") != result["input_sha256"]:
+        flag("INPUT_IDENTITY_MISMATCH", "Provide an input manifest for the exact genotype file.", True)
+    if not all(_text(card.get(k)) for k in ("version", "source")):
+        flag("SCORE_PROVENANCE_INCOMPLETE", "Record the score version and source.")
+    if not all(_text(inp.get(k)) for k in ("population", "context", "source")):
+        flag("TARGET_CONTEXT_MISSING", "Document target population, validation context and input source.")
+    if inp.get("build") not in ("GRCh37", "GRCh38") or card.get("build") not in ("GRCh37", "GRCh38"):
+        flag("BUILD_UNKNOWN", "Document the input and score genome builds.")
+    elif not inp["build"] == card["build"] == build:
+        flag("BUILD_MISMATCH", "Harmonise builds using a validated upstream workflow.", True)
+
+    if inp.get("strand") != "forward":
+        flag("STRAND_UNKNOWN", "Supply a source-backed forward-strand input declaration.")
+
+    ids = [v.get("rsid") for v in variants]
+    if len(ids) != len(set(ids)):
+        flag("DUPLICATE_VARIANTS", "Resolve duplicate scoring variants upstream.", True)
+    if not _positive_int(card.get("variant_count")) or card["variant_count"] != len(variants):
+        flag("VARIANT_COUNT_MISMATCH", "Reconcile parsed variants with the exact published score.", True)
+    if not variants or any(v.get("rsid") not in genotypes for v in variants):
+        flag("INCOMPLETE_VARIANTS", "This policy requires the complete score; partial sums cannot use its reference.")
+    bad_alleles = False
+    for v in variants:
+        ea, oa = v.get("effect_allele"), v.get("other_allele")
+        gt = genotypes.get(v.get("rsid"))
+        # v1 deliberately supports diploid biallelic SNVs only, with explicit
+        # other alleles. It does not guess strand flips or impute missing calls.
+        if (ea not in ("A", "C", "G", "T") or oa not in ("A", "C", "G", "T") or ea == oa
+                or (gt is not None and (not isinstance(gt, str) or len(gt) != 2
+                                       or not set(gt).issubset({ea, oa})))):
+            bad_alleles = True
+    if bad_alleles:
+        flag("ALLELE_INCOMPATIBLE", "Supply harmonised diploid SNVs with explicit effect/other alleles and valid calls.", True)
+    if not _number(raw_score) or any(not _number(v.get("effect_weight")) for v in variants):
+        flag("NONFINITE_SCORE", "Resolve non-finite weights or raw score.", True)
+
+    if (not bad_alleles and all(v.get("rsid") in genotypes for v in variants)
+            and _number(raw_score) and all(_number(v.get("effect_weight")) for v in variants)):
+        expected = sum(genotypes[v["rsid"]].count(v["effect_allele"]) * v["effect_weight"]
+                       for v in variants)
+        if not math.isclose(raw_score, expected, rel_tol=1e-12, abs_tol=1e-12):
+            flag("RAW_SCORE_MISMATCH", "Recalculate the raw sum from these exact compatible dosages.", True)
+
+    validation = _mapping(card.get("validation"))
+    ref = _mapping(card.get("reference"))
+    result["predictive_performance"] = validation or None
+    # These fields are deliberately never substituted for prediction evidence.
+    result["heritability"] = card.get("heritability")
+    result["causal_evidence"] = card.get("causal_evidence")
+    metric = validation.get("metric")
+    lo, est, hi = (validation.get(k) for k in ("ci_lower", "estimate", "ci_upper"))
+    valid_metric = (metric in ("r2", "auc", "correlation")
+                    and all(_number(x) for x in (lo, est, hi)))
+    if valid_metric:
+        lower_bound = -1 if metric == "correlation" else 0
+        valid_metric = lower_bound <= lo <= est <= hi <= 1
+    if (validation.get("independent") is not True or not _positive_int(validation.get("n"))
+            or not _text(validation.get("source")) or not valid_metric):
+        flag("VALIDATION_INCOMPLETE", "Provide independent validation, sample size, source, metric and ordered confidence interval.")
+    if (not all(_text(validation.get(k)) for k in ("population", "context"))
+            or any(validation.get(k) != inp.get(k) for k in ("population", "context"))):
+        flag("VALIDATION_CONTEXT_MISMATCH", "Obtain validation for the specified target population and context.")
+    if (not _text(ref.get("source")) or not _positive_int(ref.get("n"))
+            or not _number(ref.get("mean")) or not _number(ref.get("sd")) or ref.get("sd", 0) <= 0
+            or ref.get("distribution") != "normal" or ref.get("missingness") != "complete_only"):
+        flag("REFERENCE_INCOMPLETE", "Provide a documented normal reference distribution for the complete score.")
+    if (not all(_text(ref.get(k)) for k in ("population", "context"))
+            or any(ref.get(k) != inp.get(k) for k in ("population", "context"))):
+        flag("REFERENCE_CONTEXT_MISMATCH", "Provide a reference distribution for this population and context.")
+
+    if reasons:
+        result["status"] = "incompatible" if any(r["incompatible"] for r in reasons) else "not_established"
+    else:
+        z = (raw_score - ref["mean"]) / ref["sd"]
+        if not math.isfinite(z):
+            flag("REFERENCE_NUMERIC_OVERFLOW", "Check raw score and reference scale.", True)
+            result["status"] = "incompatible"
+            return result
+        result.update(status="supported", z_score=z,
+                      percentile=50 * (1 + math.erf(z / math.sqrt(2))),
+                      method="evidence_normal_reference", reference_population=ref["population"])
+    return result

--- a/skills/gwas-prs/references/prs-evidence.md
+++ b/skills/gwas-prs/references/prs-evidence.md
@@ -1,0 +1,111 @@
+# PRS evidence policy 1.0.0
+
+This gate assesses **research percentile eligibility**, not clinical utility.
+It implements deterministic checks against a caller-curated evidence manifest.
+It does not verify publications, infer ancestry, measure equity from population
+labels, or convert heritability/Mendelian randomisation into predictive accuracy.
+
+## Invocation and migration
+
+Real-input runs now withhold percentile, z-score and risk category unless a
+complete manifest is supplied with `--evidence-json manifest.json`.
+Raw sums remain available for audit, including partial scores previously skipped
+by `--min-overlap`. They must not be interpreted when the assessment is withheld.
+The built-in `--demo` remains explicitly `synthetic_demo_only`; providing
+`--evidence-json` also gates that demo, and illustrative panels cannot qualify.
+
+The public CLI accepts the flag:
+`python clawbio.py run prs --input genotypes.txt --pgs-id PGS... --evidence-json manifest.json --output new-directory`.
+Use the registered alias printed by `clawbio.py list` if it differs in your release.
+No new dependency, remote API, patient upload or separate skill is introduced.
+
+## Manifest schema
+
+All hashes are lowercase SHA-256 of exact file bytes, including compression.
+Schema version is the integer 1. The root has `input` and `scores` objects.
+Unknown fields are ignored; missing evidence withholds interpretation.
+
+| Object | Required fields |
+|---|---|
+| input | sha256, build (GRCh37/GRCh38), strand (forward), population, context, source |
+| scores[exact score_id] | sha256, version, source, build, variant_count, validation, reference |
+| validation | population, context, independent (boolean true), n (positive integer), source, metric, estimate, ci_lower, ci_upper |
+| reference | population, context, source, n (positive integer), mean, sd, distribution (normal), missingness (complete_only) |
+
+Metric is `r2`, `auc` or `correlation`. Confidence limits must contain the
+estimate and fall within the metric's domain. All numbers must be finite;
+booleans are not numbers. AUC/R2 use [0,1], correlation [-1,1].
+No minimum performance threshold is invented: a percentile is a position in a
+reference distribution, not a claim of useful disease prediction.
+
+The validation and reference apply to the enclosing exact score version/hash.
+Both must match the declared target population **and context**. These are
+explicit cohort/context identifiers chosen by the evidence curator, not inferred
+identity labels. Record age range, ascertainment and relevant assay/phenotype
+conditions in the cited context source. String equality checks the declaration;
+it does not scientifically establish applicability.
+
+Input build and forward strand are external declarations bound to the input
+hash. The gate checks their consistency with the requested/declared score build;
+it does not independently infer build or resolve strand. Only complete,
+diploid, biallelic SNV scores with explicit effect and other alleles qualify in
+v1. Missing calls, incompatible alleles, unsupported variant types, duplicate
+rsIDs, mismatched declared counts, or non-finite weights withhold interpretation.
+No strand guessing, lift-over, imputation or missingness extrapolation is done.
+A variant count from a trusted score manifest guards against silently dropped
+parser rows. The curator must verify that count against the original score.
+
+Optional `heritability` and `causal_evidence` objects are retained separately.
+They never satisfy the validation requirement. `causal_claim_supported` is always
+false: causal assessment is outside this gate's scope.
+
+## Output
+
+Every real-input result contains `evidence_assessment`, with policy version,
+input/score hashes, evidence source/version, performance, separate heritability
+and causal evidence, status and machine-readable reasons with remediation.
+Statuses are `supported`, `not_established`, and `incompatible`.
+Supported means **eligible under supplied evidence**, not independently verified.
+A supported normal-reference percentile is 100 * Phi((score - mean)/sd).
+Risk category remains null even when the percentile is supported.
+
+Decisions propagate into Markdown, compact JSON and the standard result envelope.
+The evidence file hash is in replay provenance; the file itself is not copied.
+Replay requires `PRS_EVIDENCE_FILE` pointing to the original evidence JSON.
+Evidence and reports can contain sensitive context and should stay local.
+The CLI refuses to overwrite existing report artifacts; choose a new output path.
+
+## Scientific motivation and fixtures
+
+Schwaba et al., Nature (2026), DOI:
+https://doi.org/10.1038/s41586-026-10992-9
+motivates separating population association/heritability, independent prediction,
+familial confounding, and population portability. It does not supply this policy's
+software thresholds or validate an individual personality report.
+
+Tests include personality and metabolic contexts using **synthetic evidence,
+weights and reference distributions**. No published score or validation metric
+is fabricated or attributed to that paper. These fixtures establish software
+behaviour only; they are not a reproduced experiment, external expert review,
+or an independently adjudicated scientific benchmark.
+
+Run `python -m pytest skills/gwas-prs/tests/test_prs_evidence.py -q`.
+Before deployment, curate evidence for a real score, independently review it,
+and validate performance and refusal rates on relevant external cohorts.
+
+## Runnable offline demonstration
+
+Run from the repository root:
+
+```bash
+python skills/gwas-prs/benchmark_evidence.py --demo --output /tmp/prs-evidence-demo
+```
+
+This produces result.json and report.md for 14 fixed synthetic cases: two
+supported and twelve withheld. Expected decisions are manually specified
+software contracts; no external adjudication is claimed. The summary reports
+false-supported and false-withheld counts. Use a fresh output directory.
+
+Replay requires `PRS_REPLAY_OUTPUT` naming a fresh output directory, preserving
+the original run for comparison. When evidence was supplied, also set
+`PRS_EVIDENCE_FILE` to the original manifest.

--- a/skills/gwas-prs/repro_bundle.py
+++ b/skills/gwas-prs/repro_bundle.py
@@ -172,7 +172,9 @@ def _selection(args: Any) -> tuple[str, str | None]:
 
 def _repro_command(args: Any, output_dir: Path) -> ReproCommand:
     command_args: list[str | ReproPath] = []
-    preflight: list[str] = []
+    preflight: list[str] = [
+        'OUTPUT_DIR="${PRS_REPLAY_OUTPUT:?Set PRS_REPLAY_OUTPUT to a new output directory}"'
+    ]
     mode, value = _selection(args)
     if mode == "demo":
         command_args.append("--demo")
@@ -205,6 +207,11 @@ def _repro_command(args: Any, output_dir: Path) -> ReproCommand:
             '"${PGS_CACHE_DIR:-$HOME/.clawbio/pgs_cache}"',
         ]
     )
+    if getattr(args, "evidence_json", None):
+        preflight.append(
+            ': "${PRS_EVIDENCE_FILE:?Set PRS_EVIDENCE_FILE to the evidence JSON used for this run}"'
+        )
+        command_args.extend(["--evidence-json", '"${PRS_EVIDENCE_FILE}"'])
     if bool(args.no_cache):
         command_args.append("--no-cache")
     return ReproCommand(
@@ -233,6 +240,11 @@ def _safe_parameters(args: Any) -> dict[str, Any]:
         "min_overlap": float(args.min_overlap),
         "max_variants": int(args.max_variants),
         "cache_enabled": not bool(args.no_cache),
+        "evidence_policy": "1.0.0",
+        "evidence_sha256": (
+            sha256_file(Path(args.evidence_json))
+            if getattr(args, "evidence_json", None) else None
+        ),
     }
 
 

--- a/skills/gwas-prs/tests/test_prs_evidence.py
+++ b/skills/gwas-prs/tests/test_prs_evidence.py
@@ -1,0 +1,201 @@
+"""Offline contract tests. All positive evidence below is synthetic, not clinical validation."""
+import copy
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+SKILL = ROOT / "skills/gwas-prs"
+
+
+def validator():
+    spec = importlib.util.spec_from_file_location("prs_evidence", SKILL / "prs_evidence.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def case(tmp_path):
+    score = tmp_path / "score.txt"
+    score.write_text("rsID\teffect_allele\tother_allele\teffect_weight\nrs1\tA\tG\t0.2\n")
+    inp = tmp_path / "input.txt"
+    inp.write_text("# synthetic genotype\nrs1\t1\t1\tAG\n")
+    evidence = {
+        "schema_version": 1,
+        "input": {"sha256": hashlib.sha256(inp.read_bytes()).hexdigest(),
+                  "build": "GRCh37", "strand": "forward", "population": "synthetic-population",
+                  "context": "synthetic-adults", "source": "synthetic input manifest"},
+        "scores": {"TEST-SCORE": {
+            "sha256": hashlib.sha256(score.read_bytes()).hexdigest(),
+            "version": "1", "source": "synthetic score manifest", "build": "GRCh37",
+            "variant_count": 1,
+            "validation": {"population": "synthetic-population", "context": "synthetic-adults",
+                "independent": True, "n": 1000, "source": "synthetic validation",
+                "metric": "r2", "estimate": 0.03, "ci_lower": 0.01, "ci_upper": 0.05},
+            "reference": {"population": "synthetic-population", "context": "synthetic-adults",
+                "source": "synthetic reference", "n": 1000, "mean": 0.2, "sd": 0.1,
+                "distribution": "normal", "missingness": "complete_only"},
+            "heritability": {"estimate": 0.1, "source": "synthetic"},
+            "causal_evidence": {"method": "MR", "source": "synthetic"}
+        }}
+    }
+    return dict(score_id="TEST-SCORE", scoring_path=score, input_path=inp,
+                build="GRCh37", variants=[{"rsid": "rs1", "effect_allele": "A",
+                                          "other_allele": "G", "effect_weight": 0.2}],
+                genotypes={"rs1": "AG"}, raw_score=0.2, evidence=evidence, curated=False)
+
+
+def test_supported_percentile_is_not_disease_risk(case):
+    result = validator().assess(**case)
+    assert result["status"] == "supported"
+    assert result["percentile"] == pytest.approx(50)
+    assert result["risk_category"] is None
+    assert result["causal_claim_supported"] is False
+    assert result["predictive_performance"]["estimate"] == 0.03
+    assert result["heritability"]["estimate"] == 0.1
+
+
+@pytest.mark.parametrize("mutation,code", [
+    ("missing", "EVIDENCE_MISSING"), ("score_hash", "SCORE_IDENTITY_MISMATCH"),
+    ("input_hash", "INPUT_IDENTITY_MISMATCH"), ("build", "BUILD_MISMATCH"),
+    ("population", "VALIDATION_CONTEXT_MISMATCH"), ("context", "VALIDATION_CONTEXT_MISMATCH"),
+    ("independence", "VALIDATION_INCOMPLETE"), ("reference", "REFERENCE_INCOMPLETE"),
+    ("reference_population", "REFERENCE_CONTEXT_MISMATCH"),
+    ("nan", "REFERENCE_INCOMPLETE"), ("boolean", "REFERENCE_INCOMPLETE"),
+    ("ci", "VALIDATION_INCOMPLETE"), ("no_calls", "ALLELE_INCOMPATIBLE"),
+    ("allele", "ALLELE_INCOMPATIBLE"), ("missing_allele", "ALLELE_INCOMPATIBLE"),
+    ("missing_variant", "INCOMPLETE_VARIANTS"), ("duplicate", "DUPLICATE_VARIANTS"),
+    ("count", "VARIANT_COUNT_MISMATCH"), ("curated", "ILLUSTRATIVE_PANEL"),
+])
+def test_withholding_has_machine_readable_reasons(case, mutation, code):
+    card = case["evidence"]["scores"]["TEST-SCORE"]
+    if mutation == "missing": case["evidence"] = None
+    elif mutation == "score_hash": card["sha256"] = "0" * 64
+    elif mutation == "input_hash": case["evidence"]["input"]["sha256"] = "0" * 64
+    elif mutation == "build": case["evidence"]["input"]["build"] = "GRCh38"
+    elif mutation == "population": card["validation"]["population"] = "another population"
+    elif mutation == "context": card["validation"]["context"] = "children"
+    elif mutation == "independence": card["validation"]["independent"] = "true"
+    elif mutation == "reference": del card["reference"]
+    elif mutation == "reference_population": card["reference"]["population"] = "another population"
+    elif mutation == "nan": card["reference"]["sd"] = float("nan")
+    elif mutation == "boolean": card["reference"]["sd"] = True
+    elif mutation == "ci": card["validation"]["ci_lower"] = 0.5
+    elif mutation == "no_calls": case["genotypes"]["rs1"] = "00"
+    elif mutation == "allele": case["genotypes"]["rs1"] = "CC"
+    elif mutation == "missing_allele": del case["variants"][0]["other_allele"]
+    elif mutation == "missing_variant": case["genotypes"] = {}
+    elif mutation == "duplicate": case["variants"] *= 2
+    elif mutation == "count": card["variant_count"] = 2
+    elif mutation == "curated": case["curated"] = True
+    result = validator().assess(**case)
+    assert result["status"] != "supported"
+    assert code in [r["code"] for r in result["reasons"]]
+    assert result["percentile"] is None
+    assert result["z_score"] is None
+    assert result["risk_category"] is None
+
+
+def test_deterministic_and_does_not_mutate(case):
+    original = copy.deepcopy(case)
+    module = validator()
+    assert module.assess(**case) == module.assess(**case)
+    assert case == original
+
+
+@pytest.mark.parametrize("value", [[], "bad", {"schema_version": 2}, {"schema_version": 1, "scores": []}])
+def test_malformed_evidence_fails_closed(case, value):
+    case["evidence"] = value
+    assert validator().assess(**case)["status"] != "supported"
+
+
+def test_cli_evidence_survives_every_output_and_replay(tmp_path):
+    evidence = tmp_path / "evidence.json"
+    evidence.write_text('{"schema_version": 1, "input": {}, "scores": {}}')
+    out = tmp_path / "report"
+    run = subprocess.run([sys.executable, str(SKILL / "gwas_prs.py"), "--demo",
+                          "--evidence-json", str(evidence), "--output", str(out)],
+                         capture_output=True, text=True)
+    assert run.returncode == 0, run.stderr + run.stdout
+    rows = json.loads((out / "prs_results.json").read_text())
+    assert rows and all(r["percentile"] is None for r in rows)
+    assert all(r["evidence_assessment"]["status"] != "supported" for r in rows)
+    envelope = json.loads((out / "result.json").read_text())
+    assert envelope["summary"]["percentile"] is None
+    assert "Evidence assessment" in (out / "prs_report.md").read_text()
+    assert "--evidence-json" in (out / "reproducibility/commands.sh").read_text()
+    provenance = json.loads((out / "reproducibility/provenance.json").read_text())
+    assert provenance["parameters"]["evidence_sha256"] == hashlib.sha256(evidence.read_bytes()).hexdigest()
+    assert str(evidence) not in (out / "reproducibility/provenance.json").read_text()
+
+    replay_dir = tmp_path / "replayed"
+    env = dict(os.environ, CLAWBIO_ROOT=str(ROOT),
+               PRS_EVIDENCE_FILE=str(evidence), PRS_REPLAY_OUTPUT=str(replay_dir))
+    env["PATH"] = str(Path(sys.executable).parent) + os.pathsep + env.get("PATH", "")
+    replay = subprocess.run(["bash", str(out / "reproducibility/commands.sh")],
+                            env=env, capture_output=True, text=True)
+    assert replay.returncode == 0, replay.stdout + replay.stderr
+    assert (replay_dir / "prs_results.json").read_bytes() == (out / "prs_results.json").read_bytes()
+
+def test_raw_score_must_match_compatible_dosages(case):
+    case["raw_score"] = 999
+    result = validator().assess(**case)
+    assert "RAW_SCORE_MISMATCH" in [r["code"] for r in result["reasons"]]
+    assert result["percentile"] is None
+
+
+def test_strand_must_be_declared(case):
+    del case["evidence"]["input"]["strand"]
+    result = validator().assess(**case)
+    assert "STRAND_UNKNOWN" in [r["code"] for r in result["reasons"]]
+
+
+@pytest.mark.parametrize("trait", ["Synthetic personality trait", "Synthetic metabolic trait"])
+@pytest.mark.parametrize("provide_evidence", [True, False])
+def test_real_input_path_supported_or_withheld(case, monkeypatch, tmp_path, trait, provide_evidence):
+    sys.path.insert(0, str(SKILL))
+    import gwas_prs
+    score_id = "PGS999999"  # synthetic identifier; no API requests
+    (tmp_path / (score_id + "_hmPOS_GRCh37.txt")).write_bytes(case["scoring_path"].read_bytes())
+    inp = case["input_path"]
+    inp.write_text("# This data file generated by 23andMe\n# rsid\tchromosome\tposition\tgenotype\nrs1\t1\t1\tAG\n")
+    ev = case["evidence"]
+    ev["input"]["sha256"] = hashlib.sha256(inp.read_bytes()).hexdigest()
+    ev["scores"][score_id] = ev["scores"].pop("TEST-SCORE")
+    evfile = tmp_path / "manifest.json"
+    evfile.write_text(json.dumps(ev))
+    monkeypatch.setattr(gwas_prs, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(gwas_prs.PGSCatalogClient, "get_score_metadata",
+                        lambda *a, **kw: {"trait_reported": [trait], "variants_number": 1})
+    out = tmp_path / "result"
+    argv = ["gwas_prs.py", "--input", str(inp), "--pgs-id", score_id,
+            "--output", str(out), "--cache-dir", str(tmp_path / "cache")]
+    if provide_evidence:
+        argv += ["--evidence-json", str(evfile)]
+    monkeypatch.setattr(sys, "argv", argv)
+    gwas_prs.main()
+    rows = json.loads((out / "prs_results.json").read_text())
+    assert rows[0]["trait"] == trait
+    assert rows[0]["percentile"] == (50 if provide_evidence else None)
+    assert rows[0]["risk_category"] is None
+    assert rows[0]["evidence_assessment"]["status"] == ("supported" if provide_evidence else "not_established")
+
+def test_offline_benchmark_runs_both_traits_and_exercises_abstention(tmp_path):
+    run = subprocess.run([sys.executable, str(SKILL / "benchmark_evidence.py"),
+                          "--demo", "--output", str(tmp_path / "benchmark")],
+                         capture_output=True, text=True)
+    assert run.returncode == 0, run.stdout + run.stderr
+    result = json.loads((tmp_path / "benchmark/result.json").read_text())
+    assert result["all_passed"]
+    assert result["supported_cases"] >= 2
+    assert result["withheld_cases"] >= 8
+    assert result["false_supported"] == 0
+    assert result["false_withheld"] == 0
+    assert result["evidence_type"] == "synthetic_software_contract"

--- a/skills/gwas-prs/tests/test_repro_bundle.py
+++ b/skills/gwas-prs/tests/test_repro_bundle.py
@@ -424,6 +424,8 @@ def test_demo_cli_writes_the_documented_output_contract(tmp_path) -> None:
 
     results = json.loads((output_dir / "prs_results.json").read_text(encoding="utf-8"))
     assert set(results[0]) == {
+        "evidence_assessment",
+        "interpretation_scope",
         "score_id",
         "pgs_id",
         "curated_panel_id",


### PR DESCRIPTION
## Summary

Real-input GWAS-PRS reports could emit percentiles without evidence that the exact score, reference and target context support them. Add a deterministic evidence gate before interpretation.

- Require a local hash-bound evidence manifest for real-input research percentiles. Check score/input identity, declared build and strand, compatible complete variants, independent validation and a matching reference; withhold unsupported percentiles and risk labels with structured reasons.
- Preserve raw sums for audit, separate prediction from heritability/causal evidence, carry decisions into every report, and record evidence hashes and portable replay inputs.
- Add a 14-case offline synthetic benchmark and migration/schema documentation. Built-in demo estimates remain explicitly illustrative.

## Skill affected

gwas-prs (0.3.0), with its public CLI flag registration and generated catalogue entry.

Companion #400 preserves the research-only scope in unified reports. Merge #400 first. The actual PRS CLI result envelope was also passed through that consumer successfully: withheld interpretations remained withheld.

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology)
- [x] Tests included and passing (focused skill suite)
- [x] Demo data included for reviewers to test (deterministic synthetic fixtures)
- [x] No patient/sensitive data committed
- [x] Follows CONTRIBUTING.md conventions

## Test output

Test-first development: 167 existing tests passed; 26 initial new contract tests failed before implementation. Additional raw-sum, strand and replay tests also demonstrated failures before their fixes.

Final focused suite:
- Python 3.10: 200 passed
- Python 3.11: 200 passed
- Python 3.12: 200 passed

Public CLI smoke: `clawbio.py run prs --demo --evidence-json ...` completed successfully and withheld unsupported results. A real generated replay command produced byte-identical prs_results.json in a fresh directory. Skill validation and git diff --check passed.

Reviewer demonstration:

```bash
python skills/gwas-prs/benchmark_evidence.py --demo --output /tmp/prs-evidence-review
```

Output: 14/14 cases passed; 2 supported, 12 withheld; false_supported=0, false_withheld=0.

These are synthetic software contracts, not independent scientific validation or a reproduction of Schwaba et al. (Nature 2026; doi:10.1038/s41586-026-10992-9). That paper motivates keeping heritability, prediction and portability distinct.

## Behaviour and limits

Real-input percentiles now default to null without sufficient evidence. Even supported results provide a research percentile, never a clinical risk category. Complete biallelic diploid SNVs and a documented normal reference are required in policy v1; partial sums remain audit-only. Existing output artifacts are protected; replay requires PRS_REPLAY_OUTPUT and, when applicable, PRS_EVIDENCE_FILE.

Evidence is caller-curated: hash consistency and declarations do not independently verify publications, population applicability or clinical utility. There are no new dependencies, scientific algorithms or patient-data network calls.
