### PR TITLE
fix(profile-report): respect PRS evidence and research-only scope

### DIFF
--- a/skills/profile-report/SKILL.md
+++ b/skills/profile-report/SKILL.md
@@ -119,3 +119,12 @@ output_directory/
 **Chaining partners**:
 - `full-profile pipeline`: Run `python clawbio.py run full-profile` first (pharmgx → nutrigx → prs → compare), then profile-report
 - `Individual skills`: Run any combination of pharmgx, nutrigx, prs, compare, then profile-report to unify
+
+## PRS evidence scope
+
+Preserve `gwas-prs` evidence assessments in unified reports. Research percentiles
+are not individual disease-risk categories. Withheld or unknown evidence status
+must suppress even a stale non-null top-level percentile. Explicit synthetic
+demo results remain illustrative. Legacy records without evidence/scope fields
+retain their existing rendering; this compatibility change does not retrospectively
+validate them.

--- a/skills/profile-report/profile_report.py
+++ b/skills/profile-report/profile_report.py
@@ -105,7 +105,30 @@ def _get_prs_scores(results: dict) -> list[dict]:
     scores = prs_data.get("scores")
     if scores is None:
         scores = prs_data.get("results")
-    return scores if isinstance(scores, list) else []
+    if not isinstance(scores, list):
+        return []
+    normalised = []
+    for score in scores:
+        row = dict(score)
+        scope = row.get("interpretation_scope")
+        assessment = row.get("evidence_assessment")
+        if scope == "synthetic_demo_only":
+            row["_evidence_scope"] = "illustrative"
+            row["risk_category"] = "Illustrative only"
+        elif scope is not None or assessment is not None:
+            # Never revive stale top-level percentiles after an evidence refusal.
+            row["_evidence_scope"] = "withheld"
+            row["percentile"] = None
+            row["risk_category"] = "Withheld"
+            if isinstance(assessment, dict) and scope == "research_percentile":
+                pct = assessment.get("percentile")
+                if (assessment.get("status") == "supported"
+                        and type(pct) in (int, float) and 0 <= pct <= 100):
+                    row["_evidence_scope"] = "research"
+                    row["percentile"] = pct
+                    row["risk_category"] = "Research only"
+        normalised.append(row)
+    return normalised
 
 
 # ---------------------------------------------------------------------------
@@ -141,10 +164,17 @@ def render_executive_summary(profile: dict) -> str:
             trait = score.get("trait", "Unknown")
             percentile = score.get("percentile")
             category = score.get("risk_category", "")
-            if percentile is not None:
-                trait_summaries.append(f"{category} {trait} risk ({percentile:.0f}th percentile)")
+            scope = score.get("_evidence_scope")
+            if scope == "withheld":
+                trait_summaries.append(f"{trait}: interpretation withheld")
+            elif percentile is not None:
+                if scope in ("research", "illustrative"):
+                    trait_summaries.append(f"{trait}: {scope} percentile ({percentile:.0f}th)")
+                else:
+                    trait_summaries.append(f"{category} {trait} risk ({percentile:.0f}th percentile)")
         if trait_summaries:
-            lines.append(f"- **Disease Risk**: {' · '.join(trait_summaries[:3])}")
+            label = "Polygenic Scores" if any(s.get("_evidence_scope") for s in scores) else "Disease Risk"
+            lines.append(f"- **{label}**: {' · '.join(trait_summaries[:3])}")
             if len(trait_summaries) > 3:
                 lines.append(f"  _(+{len(trait_summaries) - 3} more traits assessed)_")
         else:
@@ -355,6 +385,19 @@ def render_prs_section(profile: dict) -> str:
 
         # Per-trait detail
         for score in scores:
+            scope = score.get("_evidence_scope")
+            if scope:
+                label = {"withheld": "Interpretation withheld", "research": "Research percentile only",
+                         "illustrative": "Illustrative synthetic result"}[scope]
+                lines.append(f"> **{label}**: {score.get('trait', 'Unknown')}. No individual disease-risk conclusion.")
+                assessment = score.get("evidence_assessment")
+                if scope == "withheld" and isinstance(assessment, dict):
+                    codes = [str(reason.get("code", "")) for reason in assessment.get("reasons", [])
+                             if isinstance(reason, dict)]
+                    if codes:
+                        lines.append("> Evidence reasons: " + ", ".join(codes))
+                lines.append("")
+                continue
             percentile = score.get("percentile")
             if percentile is not None and percentile >= 90:
                 trait = score.get("trait", "Unknown")

--- a/skills/profile-report/tests/test_profile_report.py
+++ b/skills/profile-report/tests/test_profile_report.py
@@ -336,3 +336,36 @@ class TestDemoMode:
         # Should have at least PRS and compare from synthetic data
         skills = profile.get("skill_results", {})
         assert "prs" in skills or "pharmgx" in skills
+
+
+@pytest.mark.parametrize("status", ["supported", "not_established", "incompatible", "unknown"])
+def test_prs_evidence_is_not_promoted_to_disease_risk(full_profile, status):
+    score = {
+        "score_id": "SYNTHETIC", "trait": "Synthetic trait", "raw_score": 0.2,
+        "percentile": 99, "risk_category": "High",
+        "interpretation_scope": "research_percentile",
+        "evidence_assessment": {"status": status, "percentile": 98,
+                                "reasons": [{"code": "SYNTHETIC_REASON"}]},
+    }
+    full_profile["skill_results"]["prs"]["data"]["data"] = {"results": [score]}
+    section = pr.render_prs_section(full_profile)
+    summary = pr.render_executive_summary(full_profile)
+    assert "**Elevated risk**" not in section
+    assert "High Synthetic trait risk" not in summary
+    if status == "supported":
+        assert "98th" in section
+        assert "research percentile" in summary.lower()
+    else:
+        assert "98th" not in section and "99th" not in section
+        assert "withheld" in section.lower()
+    assert score["percentile"] == 99  # rendering must not mutate source data
+
+
+def test_new_synthetic_demo_scope_is_illustrative(full_profile):
+    scores = full_profile["skill_results"]["prs"]["data"]["data"]["scores"]
+    for score in scores:
+        score["interpretation_scope"] = "synthetic_demo_only"
+        score["evidence_assessment"] = None
+    section = pr.render_prs_section(full_profile)
+    assert "**Elevated risk**" not in section
+    assert "illustrative" in section.lower()


### PR DESCRIPTION
## Summary

Unified profile reports currently interpret every high PRS percentile as elevated disease risk. That would override the research-only scope introduced by #399.

- Respect PRS evidence status and interpretation scope before rendering summaries and tables.
- Preserve supported research percentiles without disease-risk language; suppress stale percentiles for withheld or unknown evidence status.
- Keep explicitly synthetic results illustrative. Legacy records without evidence/scope metadata retain their existing rendering.

## Skill affected

profile-report only. Backward-compatible consumer preparation for #399; merge this companion before enabling the new PRS workflow in unified profiles.

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology)
- [x] Tests included and passing (focused skill suite)
- [x] Demo data included for reviewers to test (existing synthetic profile fixtures extended in tests)
- [x] No patient/sensitive data committed
- [x] Follows CONTRIBUTING.md conventions

## Test output

Baseline: 18 tests passed. Five new cases failed before implementation.

Final: 23 passed on each of Python 3.10, 3.11 and 3.12.
Skill validation and git diff --check passed.

Synthetic fixture outcomes:
- supported: research percentile retained; no elevated-risk statement
- not_established, incompatible, unknown: stale percentiles suppressed
- synthetic_demo_only: illustrative label; no elevated-risk statement

Rendering does not mutate the source profile. This change consumes evidence decisions; it does not independently validate the evidence or certify older records.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how polygenic results are presented in unified reports; incorrect scope handling could mislead users about clinical vs research interpretation, but logic is conservative (withhold by default when evidence metadata is present).
> 
> **Overview**
> Unified profile reports no longer treat every high PRS percentile as **elevated disease risk**. PRS rows are normalized in `_get_prs_scores` using `interpretation_scope` and `evidence_assessment` from `gwas-prs`-style envelopes before the executive summary and PRS section render.
> 
> **Supported research percentiles** show as research-only (not clinical risk). **Withheld or non-supported evidence** clears stale top-level percentiles and uses withheld wording, including evidence reason codes in detail blocks. **`synthetic_demo_only`** is labeled illustrative and skips elevated-risk callouts. **Legacy scores** without scope/evidence fields keep the previous disease-risk presentation.
> 
> `SKILL.md` documents this PRS evidence policy. New tests cover evidence statuses, illustrative demo scope, and non-mutation of source profile data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96c3172215ef9b6c189237b3d344ce9440a4d74c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->