### PR TITLE
ci: let scientific-audit start without waiting for test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,7 +429,6 @@ jobs:
 
   scientific-audit:
     runs-on: ubuntu-latest
-    needs: test
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:


### PR DESCRIPTION
## Summary

- Remove `needs: test` from the `scientific-audit` job so it starts immediately instead of queuing behind `test`.
- Takes CI wall clock from roughly 9 minutes to roughly 6.5, with no change to what any job does.

`scientific-audit` is the longest job in every run. It checks out, installs its own toolchain and `clawbio-bench`, runs the smoke bench and writes its own `results/`. It reads no artifact and no output from `test`, so the dependency was ordering only.

Measured against run `34035644836`:

| Job | Duration |
|---|---|
| `scientific-audit` | 394s |
| `test (3.12)` | 140s |
| `test (3.13)` | 124s |
| `test (3.11)` | 118s |
| `skill-lint` | 26s |
| `benchmark` | 18s |

Sum of job time was 14.2 min; wall clock was ~9 min, essentially `test` then `scientific-audit` back to back.

The trade-off, stated plainly: the bench now also runs on pushes whose tests fail, where the edge previously skipped it. That costs some runner minutes. Wall clock looks like the scarcer resource here, and the baseline-regression gate at the end of the job does not depend on `test` having passed. Happy to restore the edge if you'd rather keep the minutes.

## Skill affected

None. CI configuration only.

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology) — n/a, no skill changed
- [x] Tests included and passing (`pytest -v`) — n/a, no test or skill code changed
- [x] Demo data included for reviewers to test — n/a
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

One-line workflow change; the check is that it parses and that the job graph is what we intend.

```
$ python3 -c "import yaml;yaml.safe_load(open('.github/workflows/ci.yml'))"
parses OK

$ git diff --stat
 .github/workflows/ci.yml | 1 -
```

This PR's own CI run is the real verification — `scientific-audit` should now start alongside `test` rather than after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
