### PR TITLE
fix(wgs-prs): embed the gwas-prs report in bridge output

### DIFF
--- a/skills/wgs-prs/SKILL.md
+++ b/skills/wgs-prs/SKILL.md
@@ -80,7 +80,7 @@ metadata:
     description: Ti/Tv ratio, Het/Hom ratio, variant counts, pass/fail
   - name: vcf_qc/canonical_pass.vcf.gz
     description: Normalised, filtered canonical VCF ready for PRS scoring
-  - name: prs_output/report.md
+  - name: prs_output/prs_report.md
     description: PRS narrative report from gwas-prs
   - name: prs_output/tables/scores.csv
     description: Per-trait PRS scores, percentiles, and risk categories

--- a/skills/wgs-prs/tests/test_wgs_prs.py
+++ b/skills/wgs-prs/tests/test_wgs_prs.py
@@ -18,7 +18,7 @@ SKILL_DIR = Path(__file__).resolve().parent.parent
 if str(SKILL_DIR) not in sys.path:
     sys.path.insert(0, str(SKILL_DIR))
 
-from wgs_prs import BridgeConfig, WgsToPrsBridge
+from wgs_prs import BridgeConfig, BridgeReport, WgsToPrsBridge
 from clawbio.common.sarek import SarekConfig
 from clawbio.common.vcf_qc import QcConfig
 
@@ -121,6 +121,27 @@ class TestBridgeVcfEntry:
 
         assert report.qc_metrics is not None
         assert "metrics" in report.qc_metrics
+
+
+class TestBridgeReport:
+    def test_markdown_report_embeds_gwas_prs_output(self, tmp_path):
+        """The bridge reads the report filename written by gwas-prs."""
+        output_dir = tmp_path / "out"
+        prs_output = output_dir / "prs_output"
+        prs_output.mkdir(parents=True)
+        (prs_output / "prs_report.md").write_text("# PRS result\n\nType 2 diabetes")
+
+        bridge = WgsToPrsBridge(BridgeConfig(output_dir=str(output_dir)))
+        report = BridgeReport(
+            sample_id="TEST",
+            timestamp="2026-09-08T00:00:00+00:00",
+            output_dir=output_dir,
+        )
+
+        markdown = bridge._write_markdown_report(report).read_text()
+
+        assert "PRS report available" in markdown
+        assert "# PRS result" in markdown
 
 
 # ---------------------------------------------------------------------------

--- a/skills/wgs-prs/wgs_prs.py
+++ b/skills/wgs-prs/wgs_prs.py
@@ -446,7 +446,7 @@ class WgsToPrsBridge:
         # PRS section
         lines += ["", "---", "", "## Polygenic Risk Scores", ""]
         prs_output = self._output_dir / "prs_output"
-        prs_report = prs_output / "report.md"
+        prs_report = prs_output / "prs_report.md"
         if prs_report.exists():
             lines.append(f"PRS report available at: `{prs_report}`")
             lines.append("")


### PR DESCRIPTION
## Summary
- read the `prs_report.md` artifact that `gwas-prs` actually writes
- add a regression test that exercises the WGS-to-PRS report handoff
- correct the documented WGS-PRS output path

## Why
The WGS-PRS bridge starts `gwas-prs` with `--output <bridge>/prs_output`. `gwas-prs` writes `<bridge>/prs_output/prs_report.md`, but the bridge report only looked for `report.md`. A successful scoring run could therefore be presented as unavailable in the aggregate medical-AI report.

## Validation
- `uv run --with pytest python -m pytest -q skills/wgs-prs/tests/` (37 passed)
- `python -m compileall -q skills/wgs-prs/wgs_prs.py`
- `uvx --from 'skills-ref>=0.1.1,<1' agentskills validate skills/wgs-prs`
- `git diff --check`

## Scope
This only aligns an existing local file handoff and its declared output name. It does not change PRS calculation, clinical interpretation, QC thresholds, or patient-data handling.