### PR TITLE
fix(qc): enforce VCF missing-call limits on both execution paths

### DIFF
--- a/clawbio/common/vcf_qc.py
+++ b/clawbio/common/vcf_qc.py
@@ -305,7 +305,7 @@ class VcfQC:
             for line in fh:
                 if line.startswith("#"):
                     continue
-                parts = line.split("\t")
+                parts = line.rstrip("\r\n").split("\t")
                 if len(parts) < 10:
                     continue
                 ref, alt = parts[3], parts[4]
@@ -354,7 +354,7 @@ class VcfQC:
             for line in fh:
                 if line.startswith("#"):
                     continue
-                parts = line.rstrip("\n").split("\t")
+                parts = line.rstrip("\r\n").split("\t")
                 if len(parts) < 10:
                     continue
                 format_fields = parts[8].split(":")

--- a/clawbio/common/vcf_qc.py
+++ b/clawbio/common/vcf_qc.py
@@ -41,6 +41,11 @@ from typing import Optional
 log = logging.getLogger(__name__)
 
 
+def _is_complete_genotype(value: str) -> bool:
+    """Whether a GT contains one or more fully specified numeric alleles."""
+    return bool(re.fullmatch(r"\d+(?:[|/]\d+)*", value))
+
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -92,6 +97,7 @@ class QcResult:
     hom_alt_count: int = 0
     het_hom_ratio: Optional[float] = None
     filtered_out: int = 0
+    missing_genotype_rate: float | None = None
 
     def summary(self) -> str:
         lines = [
@@ -167,6 +173,7 @@ class VcfQC:
             stats = self._python_stats(input_vcf)
 
         self._populate_result(result, stats)
+        result.missing_genotype_rate = self._missing_genotype_rate(input_vcf)
         self._evaluate_pass_fail(result)
 
         metrics_path = output_dir / "qc_metrics.json"
@@ -302,8 +309,10 @@ class VcfQC:
                 if len(parts) < 10:
                     continue
                 ref, alt = parts[3], parts[4]
-                fmt_idx = parts[8].split(":").index("GT") if "GT" in parts[8] else -1
-                gt_raw = parts[9].split(":")[fmt_idx] if fmt_idx >= 0 else "."
+                format_fields = parts[8].split(":")
+                fmt_idx = format_fields.index("GT") if "GT" in format_fields else -1
+                sample_fields = parts[9].split(":")
+                gt_raw = sample_fields[fmt_idx] if 0 <= fmt_idx < len(sample_fields) else "."
 
                 # SNP vs indel
                 is_snp = len(ref) == 1 and len(alt) == 1 and alt != "."
@@ -318,8 +327,8 @@ class VcfQC:
                     metrics["number of indels:"] += 1
 
                 # Het / hom
-                gt = re.split(r"[|/]", gt_raw.replace(".", "0"))
-                if len(gt) == 2:
+                gt = re.split(r"[|/]", gt_raw)
+                if _is_complete_genotype(gt_raw) and len(gt) == 2:
                     if gt[0] != gt[1]:
                         metrics["number of heterozygous SNPs:"] += 1
                     elif gt[0] != "0":
@@ -327,8 +336,39 @@ class VcfQC:
 
         if tv_count > 0:
             metrics["titv_ratio"] = round(ti_count / tv_count, 4)
-
         return metrics
+
+    @staticmethod
+    def _missing_genotype_rate(vcf: Path) -> float | None:
+        """Return missing-call rate across every sample and variant in a VCF.
+
+        A missing allele (`./.`, `0/.`) and a sample without a readable GT
+        field are both missing calls. This scan deliberately runs regardless
+        of whether bcftools produced the other QC statistics, so the configured
+        missingness gate has identical semantics on both execution paths.
+        """
+        opener = gzip.open if str(vcf).endswith(".gz") else open
+        calls_seen = 0
+        missing_calls = 0
+        with opener(vcf, "rt") as fh:
+            for line in fh:
+                if line.startswith("#"):
+                    continue
+                parts = line.rstrip("\n").split("\t")
+                if len(parts) < 10:
+                    continue
+                format_fields = parts[8].split(":")
+                try:
+                    gt_index = format_fields.index("GT")
+                except ValueError:
+                    gt_index = -1
+                for sample in parts[9:]:
+                    calls_seen += 1
+                    sample_fields = sample.split(":")
+                    gt = sample_fields[gt_index] if 0 <= gt_index < len(sample_fields) else "."
+                    if not _is_complete_genotype(gt):
+                        missing_calls += 1
+        return missing_calls / calls_seen if calls_seen else None
 
     # ------------------------------------------------------------------
     # Step 4: Populate result and evaluate pass/fail
@@ -353,6 +393,11 @@ class VcfQC:
         if result.snp_count < cfg.min_snp_count:
             reasons.append(
                 f"Too few SNPs: {result.snp_count} < {cfg.min_snp_count}"
+            )
+
+        if result.missing_genotype_rate is not None and result.missing_genotype_rate > cfg.max_missing_rate:
+            reasons.append(
+                f"Missing genotype rate too high: {result.missing_genotype_rate:.3f} > {cfg.max_missing_rate:.3f}"
             )
 
         if result.titv_ratio is not None:
@@ -423,6 +468,7 @@ class VcfQC:
                 "hom_alt_count": result.hom_alt_count,
                 "het_hom_ratio": result.het_hom_ratio,
                 "filtered_out": result.filtered_out,
+                "missing_genotype_rate": result.missing_genotype_rate,
             },
         }
         path.write_text(json.dumps(metrics, indent=2))

--- a/skills/wgs-prs/SKILL.md
+++ b/skills/wgs-prs/SKILL.md
@@ -242,6 +242,7 @@ After WGS-PRS completes, the canonical VCF can be passed to:
 
 ## Gotchas
 
+- **Missing-call rate uses the raw input VCF, before filtering.** It counts sample calls across all input records; for a multi-sample VCF it is a cohort-wide rate, not a per-sample metric.
 - **Do not skip VCF QC even when the user provides their own VCF.** Users often pass unfiltered or unnormalised VCFs from external pipelines. Always run Stage 2 unless the user explicitly opts out with `--skip-qc`. Skipping QC silently produces unreliable PRS scores.
 - **Do not route to this skill when the user already has a VCF and wants PRS only.** The model will be tempted to use wgs-prs because it mentions PRS. If there is no FASTQ and the user has not asked for variant calling, route directly to `gwas-prs` to avoid unnecessary sarek overhead.
 - **Do not invent QC thresholds.** Ti/Tv and Het/Hom cut-offs are fixed at 1.8 to 2.5 and 1.0 to 3.0 respectively. Do not adjust these based on the user's wishes or apparent sample quality. If thresholds are debated, surface the metrics and let the user decide whether to continue with `--no-fail-fast`.

--- a/skills/wgs-prs/tests/test_vcf_qc.py
+++ b/skills/wgs-prs/tests/test_vcf_qc.py
@@ -84,6 +84,21 @@ class TestPythonStats:
         assert stats["number of heterozygous SNPs:"] >= 0
         assert stats["number of homozygous SNPs:"] >= 0
 
+    def test_gt_only_terminal_field_counts_het_and_hom_calls(self, tmp_path):
+        """The final GT field must not retain its trailing line ending."""
+        vcf = tmp_path / "gt_only.vcf"
+        vcf.write_text(
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE\n"
+            "1\t1\trs1\tA\tG\t50\tPASS\t.\tGT\t0/1\n"
+            "1\t2\trs2\tC\tT\t50\tPASS\t.\tGT\t1/1\n"
+            "1\t3\trs3\tG\tA\t50\tPASS\t.\tGT\t1/0\n"
+        )
+
+        stats = VcfQC.__new__(VcfQC)._python_stats(vcf)
+
+        assert stats["number of heterozygous SNPs:"] == 2
+        assert stats["number of homozygous SNPs:"] == 1
+
 
 # ---------------------------------------------------------------------------
 # Parse bcftools stats output

--- a/skills/wgs-prs/tests/test_vcf_qc.py
+++ b/skills/wgs-prs/tests/test_vcf_qc.py
@@ -176,6 +176,90 @@ class TestPassFail:
 # ---------------------------------------------------------------------------
 
 class TestFullRunNoBcftools:
+    def test_missing_calls_fail_the_configured_missingness_limit(self, tmp_path):
+        vcf = tmp_path / "missing.vcf"
+        vcf.write_text(
+            "##fileformat=VCFv4.2\n"
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE\n"
+            "1\t1\trs1\tA\tG\t50\tPASS\t.\tGT\t./.\n"
+            "1\t2\trs2\tC\tA\t50\tPASS\t.\tGT\t./.\n"
+            "1\t3\trs3\tG\tA\t50\tPASS\t.\tGT\t./.\n"
+            "1\t4\trs4\tT\tG\t50\tPASS\t.\tGT\t./.\n"
+        )
+        cfg = QcConfig(min_snp_count=1, max_missing_rate=0.1)
+        with patch("clawbio.common.vcf_qc.shutil.which", return_value=None):
+            result = VcfQC(cfg).run(vcf, tmp_path / "qc")
+
+        assert not result.passes_qc
+        assert any("Missing genotype rate" in reason for reason in result.fail_reasons)
+
+    @pytest.mark.parametrize(
+        "format_field, genotype",
+        [("GT:DP", "./.:30"), ("GT:DP", "0/.:30"), ("GT:DP", ".|1:30"),
+         ("DP", "30"), ("DP:GT", "30"), ("PGT", "0|1")],
+    )
+    def test_missing_or_unreadable_gt_is_counted(self, tmp_path, format_field, genotype):
+        vcf = tmp_path / "calls.vcf"
+        vcf.write_text(
+            "##fileformat=VCFv4.2\n"
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSAMPLE\n"
+            f"1\t1\trs1\tA\tG\t50\tPASS\t.\t{format_field}\t{genotype}\n"
+        )
+        assert VcfQC._missing_genotype_rate(vcf) == 1.0
+        assert VcfQC()._python_stats(vcf)["number of heterozygous SNPs:"] == 0
+
+    def test_haploid_and_polyploid_calls_are_present(self, tmp_path):
+        vcf = tmp_path / "ploidy.vcf"
+        vcf.write_text("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS\n1\t1\trs1\tA\tG\t50\tPASS\t.\tGT\t1\n1\t2\trs2\tA\tG\t50\tPASS\t.\tGT\t0/1/1\n")
+        assert VcfQC._missing_genotype_rate(vcf) == 0.0
+
+    def test_partial_gt_does_not_count_as_heterozygous(self, tmp_path):
+        vcf = tmp_path / "partial.vcf"
+        vcf.write_text("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS\n1\t1\trs1\tA\tG\t50\tPASS\t.\tGT\t1/.\n")
+        stats = VcfQC.__new__(VcfQC)._python_stats(vcf)
+        assert stats["number of heterozygous SNPs:"] == 0
+
+    def test_missingness_uses_all_samples_and_persists_threshold_equality(self, tmp_path):
+        vcf = tmp_path / "multi.vcf"
+        vcf.write_text(
+            "##fileformat=VCFv4.2\n"
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tA\tB\n"
+            "1\t1\trs1\tA\tG\t50\tPASS\t.\tGT\t0/1\t./.\n"
+        )
+        cfg = QcConfig(min_snp_count=1, max_missing_rate=0.5)
+        with patch("clawbio.common.vcf_qc.shutil.which", return_value=None):
+            result = VcfQC(cfg).run(vcf, tmp_path / "qc")
+        assert result.missing_genotype_rate == 0.5
+        assert not any("Missing genotype rate" in reason for reason in result.fail_reasons)
+        assert json.loads(result.metrics_json.read_text())["metrics"]["missing_genotype_rate"] == 0.5
+
+    def test_missingness_just_over_the_threshold_fails_on_bcftools_path(self, tmp_path):
+        vcf = tmp_path / "multi.vcf"
+        vcf.write_text(
+            "##fileformat=VCFv4.2\n"
+            "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tA\tB\tC\n"
+            "1\t1\trs1\tA\tG\t50\tPASS\t.\tGT\t0/1\t0/1\t./.\n"
+        )
+        cfg = QcConfig(min_snp_count=1, max_missing_rate=0.3)
+        qc = VcfQC(cfg)
+        qc._bcftools = "bcftools"
+        canonical = tmp_path / "canonical.vcf.gz"
+        canonical.write_text("placeholder\n")
+        with patch.object(qc, "_normalise", return_value=canonical), \
+             patch.object(qc, "_hard_filter", return_value=(canonical, 0)), \
+             patch.object(qc, "_compute_stats", return_value={
+                 "number of SNPs:": 1,
+                 "number of indels:": 0,
+                 "number of heterozygous SNPs:": 1,
+                 "number of homozygous SNPs:": 1,
+                 "titv_ratio": 2.0,
+             }):
+            result = qc.run(vcf, tmp_path / "qc")
+
+        assert result.missing_genotype_rate == pytest.approx(1 / 3)
+        assert not result.passes_qc
+        assert any("Missing genotype rate" in reason for reason in result.fail_reasons)
+
     def test_run_without_bcftools_uses_python_fallback(self, minimal_vcf, tmp_path):
         cfg = QcConfig(min_snp_count=1)   # low threshold so tiny VCF passes
         with patch("clawbio.common.vcf_qc.shutil.which", return_value=None):


### PR DESCRIPTION
## Summary
- Compute the configured missing-call rate after both bcftools and Python statistics paths, persisting the metric in JSON.
- Count unreadable and partial genotype calls as missing while preserving complete haploid and polyploid calls.
- Strip VCF record line endings before parsing terminal GT fields, with a regression asserting 2 heterozygous and 1 homozygous-alt calls. This addresses the GT-only fixture audit finding.
- Document that missingness is measured across sample calls in the raw input VCF before filtering, as requested in the non-blocking audit note.

## Skill affected

WGS-PRS VCF QC, through `clawbio/common/vcf_qc.py`.

## Checklist

- [x] Existing SKILL.md remains complete; this enforces its configured missing-call limit.
- [x] Regression tests included; the affected WGS-PRS suite passes (48 tests).
- [x] Synthetic GT-only fixture included in the regression test (2 het / 1 hom-alt).
- [x] No patient/sensitive data committed.
- [x] Focused change follows contribution conventions; local full-suite limitations are recorded below.

## Test output

- New GT-only regression before fix: failed, expected 2 heterozygous calls but got 0.
- `uv run --with pytest python -m pytest -q skills/wgs-prs/tests/test_vcf_qc.py`: 27 passed.
- `uv run --with pytest python -m pytest -q skills/wgs-prs/tests`: 48 passed.
- `uv run python clawbio.py list`, Python compile check, and `git diff --check`: passed.
- Broader WGS-PRS plus common tests: 170 passed, 1 failed (`test_generate_report_header_requires_skill_version`). The same failure reproduces on unchanged PR head `6a9ce97` (7 passed, 1 failed in that file).
- Full local collection also stops at an existing duplicate `tests.conftest` registration between eqtl-catalogue and gwas-catalog region-fetch tests. A passing full local suite is not claimed.

## Scope

This enforces an existing QC limit and corrects missing-call accounting; it does not alter filtering thresholds, PRS scoring, or clinical interpretation. The follow-up fixes valid GT-only VCF records without widening the QC change.
