### PR TITLE
Promote ClawBio Luma calendar across website and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,15 @@
   <a href="#quick-start"><img src="https://img.shields.io/badge/python-3.11+-blue?logo=python&logoColor=white" alt="Python 3.11+"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="MIT License"></a>
   <a href="https://clawhub.ai"><img src="https://img.shields.io/badge/ClawHub-97_skills-orange" alt="ClawHub Skills"></a>
+  <a href="https://luma.com/clawbio"><img src="https://img.shields.io/badge/Events-Follow_on_Luma-7c3aed" alt="Follow ClawBio Events on Luma"></a>
   <a href="https://doi.org/10.5281/zenodo.19420648"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.19420648.svg" alt="DOI"></a>
   <a href="https://github.com/ClawBio/ClawBio/issues"><img src="https://img.shields.io/github/issues/ClawBio/ClawBio" alt="Open Issues"></a>
   <a href="https://clawbio.github.io/ClawBio/slides/"><img src="https://img.shields.io/badge/slides-London_Bioinformatics_Meetup-purple" alt="Slides"></a>
+</p>
+
+<p align="center">
+  <strong>📅 <a href="https://luma.com/clawbio">Follow the official ClawBio Events Calendar</a></strong><br>
+  <sub>Hackathons · workshops · meetups · community events — follow once on Luma to hear about every new event.</sub>
 </p>
 
 ---

--- a/index.html
+++ b/index.html
@@ -111,6 +111,7 @@
       <li><a href="#why">Why ClawBio</a></li>
       <li><a href="#showcase">Showcase</a></li>
       <li><a href="#community">Community</a></li>
+      <li><a href="https://luma.com/clawbio" target="_blank" rel="noopener noreferrer" style="color:var(--accent);font-weight:700;">📅 Events</a></li>
       <li><a href="/benchmarks.html" style="color:var(--accent);font-weight:600;">Benchmarks</a></li>
       <li><a href="#marketplace" style="color:var(--accent);font-weight:600;">Marketplace</a></li>
       <li><a href="https://docs.clawbio.ai" target="_blank" style="color:var(--accent2);font-weight:600;">Docs</a></li>
@@ -118,7 +119,7 @@
       <li><a href="https://github.com/ClawBio/ClawBio" target="_blank">GitHub</a></li>
     </ul>
   </nav>
-  <a href="/benchmarks.html" style="display:block;background:linear-gradient(90deg,#238636,#1f6feb);color:#fff;text-align:center;padding:0.7rem 1rem;font-size:0.95rem;font-weight:600;text-decoration:none;">📊 Public Benchmark Leaderboard | 161/182 passing (88.5%), 26 Jul 2026 | nutrigx-advisor regressed to 0/10 and is being investigated | Every failure documented &rarr;</a>
+  <a href="https://luma.com/clawbio" target="_blank" rel="noopener noreferrer" aria-label="Follow the ClawBio events calendar on Luma" style="display:block;background:linear-gradient(90deg,#7c3aed,#2563eb);color:#fff;text-align:center;padding:0.8rem 1rem;font-size:0.98rem;font-weight:700;text-decoration:none;">📅 Follow the ClawBio Calendar — hackathons, workshops &amp; community events · get every new event &rarr;</a>
   <section class="hero">
     <div class="hero-badge">📊 Publicly benchmarked · 1,129 stars · 97 skills · 50 contributors · 4,723 tests</div>
     <h1>The first <em>bioinformatics-native</em><br>AI agent skill library</h1>
@@ -130,6 +131,7 @@
       <p style="color:var(--text-muted);font-size:0.82rem;margin:0.6rem 0 0;">🚀 New in <a href="/releases/v0.7.0/" style="color:var(--accent);">v0.7.0</a>: the library installs as a <a href="#mcp" style="color:var(--accent);">Claude Code plugin or plain Agent Skills</a>, and the headline skills write SHA-256 reproducibility bundles.</p>
     </div>
     <div class="hero-ctas">
+      <a class="btn btn-primary" href="https://luma.com/clawbio" target="_blank" rel="noopener noreferrer" style="background:var(--accent2);color:#0d1117;">📅 Follow Event Calendar</a>
       <a class="btn btn-primary" href="https://github.com/ClawBio/ClawBio" target="_blank">⭐ View on GitHub</a>
       <a class="btn btn-primary" href="/benchmarks.html" style="background:var(--accent2);color:#0d1117;">📊 Leaderboard · 161/182</a>
       <a class="btn btn-secondary" href="https://github.com/ClawBio/ClawBio/blob/main/CONTRIBUTING.md" target="_blank">🧬 Submit a Skill</a>
@@ -137,6 +139,14 @@
     </div>
     <div class="hero-pills">
       <span class="pill">bioinformatics</span><span class="pill">genomics</span><span class="pill">reproducibility</span><span class="pill">population-genetics</span><span class="pill">equity</span><span class="pill">ai-agents</span><span class="pill">local-first</span><span class="pill">openclaw</span>
+    </div>
+  </section>
+  <section id="events" style="padding:2.6rem 2rem;text-align:center;background:var(--bg2);border-top:1px solid var(--border);border-bottom:1px solid var(--border);">
+    <div style="max-width:760px;margin:0 auto;">
+      <div class="section-label">ClawBio Community</div>
+      <h2 style="font-size:clamp(1.5rem,3vw,2rem);margin-bottom:0.75rem;">Never miss a ClawBio event</h2>
+      <p style="color:var(--text-muted);font-size:1.02rem;margin:0 auto 1.4rem;max-width:650px;">Follow the official Luma calendar once to get ClawBio hackathons, workshops, meetups and community events as they are announced.</p>
+      <a class="btn btn-primary" href="https://luma.com/clawbio" target="_blank" rel="noopener noreferrer" style="background:var(--accent2);color:#0d1117;">📅 Follow ClawBio on Luma</a>
     </div>
   </section>
   <section style="padding:3rem 2rem;text-align:center;">
@@ -519,6 +529,7 @@ clawbio run pharmgx --demo</pre>
         <span style="color:var(--accent2)">cp -r ClawBio/skills/pharmgx-reporter ~/.agents/skills/</span>
       </div>
       <div class="hero-ctas">
+        <a class="btn btn-primary" href="https://luma.com/clawbio" target="_blank" rel="noopener noreferrer" style="background:var(--accent2);color:#0d1117;">📅 Follow Event Calendar</a>
         <a class="btn btn-primary" href="https://github.com/ClawBio/ClawBio" target="_blank">⭐ Star on GitHub</a>
         <a class="btn btn-secondary" href="https://t.me/RoboTerri_bot" target="_blank">🤖 Try RoboTerri</a>
         <a class="btn btn-secondary" href="https://docs.clawbio.ai" target="_blank">📄 Documentation</a>
@@ -528,6 +539,7 @@ clawbio run pharmgx --demo</pre>
   <footer>
     <div class="footer-links">
       <a href="https://github.com/ClawBio/ClawBio" target="_blank">GitHub</a>
+      <a href="https://luma.com/clawbio" target="_blank" rel="noopener noreferrer">📅 Events Calendar</a>
       <a href="https://discord.gg/DHpmptyv" target="_blank">Discord</a>
       <a href="https://t.me/ClawBioContributors" target="_blank">Telegram</a>
       <a href="https://docs.clawbio.ai" target="_blank">Docs</a>


### PR DESCRIPTION
## Goal
Maximise followers/subscribers to the official ClawBio Luma calendar: https://luma.com/clawbio

## Changes
- make the calendar the top announcement CTA on clawbio.ai
- add an Events link to the main navigation
- add a prominent hero CTA
- add a dedicated "Never miss a ClawBio event" section immediately below the hero
- repeat the calendar CTA in the final get-started section and footer
- add a Luma badge and prominent calendar callout near the top of the GitHub README

## Validation
- HTML parses successfully with Python's HTML parser
- `git diff --check` passes
- all new calendar CTAs point to the official Luma calendar

The benchmark remains accessible through the nav, hero badge and leaderboard CTA; only the old top announcement bar is repurposed for calendar conversion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and static marketing HTML only; no application logic, auth, or data handling changes.
> 
> **Overview**
> **Promotes the official ClawBio Luma events calendar** (`https://luma.com/clawbio`) on the GitHub README and the `clawbio.ai` landing page (`index.html`).
> 
> On the site, the **full-width top announcement bar** no longer highlights the public benchmark leaderboard; it now drives calendar follows. Benchmark access is unchanged via nav, hero badge, leaderboard button, and in-page links. New or repeated touchpoints include a nav **Events** link, a hero **Follow Event Calendar** button, a **Never miss a ClawBio event** section under the hero, and matching CTAs in the bottom get-started block and footer.
> 
> The **README** adds a Luma events badge in the badge row and a centered callout above the quick-start section with the same calendar link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4861fafecea7ef0326552cd429998daa53a0474. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->