### PR TITLE
Align Luma calendar copy with GBrain project voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 <p align="center">
   <strong>📅 <a href="https://luma.com/clawbio">Follow the official ClawBio Events Calendar</a></strong><br>
-  <sub>Hackathons · workshops · meetups · community events — follow once on Luma to hear about every new event.</sub>
+  <sub>ClawBio is building a general-purpose agentic utility layer for bioinformatics. Follow the calendar for hackathons, workshops, meetups and community events where contributors build, test and extend the platform.</sub>
 </p>
 
 ---

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
       <li><a href="https://github.com/ClawBio/ClawBio" target="_blank">GitHub</a></li>
     </ul>
   </nav>
-  <a href="https://luma.com/clawbio" target="_blank" rel="noopener noreferrer" aria-label="Follow the ClawBio events calendar on Luma" style="display:block;background:linear-gradient(90deg,#7c3aed,#2563eb);color:#fff;text-align:center;padding:0.8rem 1rem;font-size:0.98rem;font-weight:700;text-decoration:none;">📅 Follow the ClawBio Calendar — hackathons, workshops &amp; community events · get every new event &rarr;</a>
+  <a href="https://luma.com/clawbio" target="_blank" rel="noopener noreferrer" aria-label="Follow the ClawBio events calendar on Luma" style="display:block;background:linear-gradient(90deg,#7c3aed,#2563eb);color:#fff;text-align:center;padding:0.8rem 1rem;font-size:0.98rem;font-weight:700;text-decoration:none;">📅 Join the ClawBio community: follow the official calendar for hackathons, workshops, meetups and new events &rarr;</a>
   <section class="hero">
     <div class="hero-badge">📊 Publicly benchmarked · 1,129 stars · 97 skills · 50 contributors · 4,723 tests</div>
     <h1>The first <em>bioinformatics-native</em><br>AI agent skill library</h1>
@@ -144,8 +144,8 @@
   <section id="events" style="padding:2.6rem 2rem;text-align:center;background:var(--bg2);border-top:1px solid var(--border);border-bottom:1px solid var(--border);">
     <div style="max-width:760px;margin:0 auto;">
       <div class="section-label">ClawBio Community</div>
-      <h2 style="font-size:clamp(1.5rem,3vw,2rem);margin-bottom:0.75rem;">Never miss a ClawBio event</h2>
-      <p style="color:var(--text-muted);font-size:1.02rem;margin:0 auto 1.4rem;max-width:650px;">Follow the official Luma calendar once to get ClawBio hackathons, workshops, meetups and community events as they are announced.</p>
+      <h2 style="font-size:clamp(1.5rem,3vw,2rem);margin-bottom:0.75rem;">Build agentic bioinformatics with us</h2>
+      <p style="color:var(--text-muted);font-size:1.02rem;margin:0 auto 1.4rem;max-width:650px;">ClawBio is building a general-purpose agentic utility layer for bioinformatics. Follow the official calendar to join hackathons, workshops and meetups where the community builds, tests and extends the platform.</p>
       <a class="btn btn-primary" href="https://luma.com/clawbio" target="_blank" rel="noopener noreferrer" style="background:var(--accent2);color:#0d1117;">📅 Follow ClawBio on Luma</a>
     </div>
   </section>


### PR DESCRIPTION
## Summary

- remove em dash usage introduced in the calendar promotion copy
- align website and README wording with canonical SOUL.md language
- connect the Luma calendar CTA to ClawBio community building and the general-purpose agentic utility layer mission

## Grounding

- SOUL.md: ClawBio should become the general-purpose agentic utility layer for the bioinformatics industry
- SOUL.md: talks and collaborators increase adoption; community strengthens ClawBio and ClawBench
- CLAUDE.md: never use em dashes or en dashes
- LUMA-COMMUNITY README/session notes: the calendar is the shared community surface across events

## Validation

- git diff --check passes
- zero em dash or en dash characters in the calendar copy touched by this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and marketing copy only on README and index.html; no runtime or API changes.
> 
> **Overview**
> Updates **README** and **index.html** Luma calendar messaging so it matches project voice (SOUL.md) instead of generic “never miss an event” promotion.
> 
> The README calendar blurb now states the **general-purpose agentic utility layer** mission and frames the calendar as where contributors **build, test and extend** the platform at hackathons, workshops and meetups. On the site, the top banner CTA shifts from “follow for every new event” to **join the community** via the official calendar, and the **#events** block retitles from “Never miss a ClawBio event” to **“Build agentic bioinformatics with us”** with the same mission-aligned body copy. Wording avoids em/en dashes in the touched strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72af5f8097055594d073ce34ec059a03153ffdee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->