### PR TITLE
fix(omics): checksum every advertised output artifact

### DIFF
--- a/skills/omics-target-evidence-mapper/omics_target_evidence_mapper.py
+++ b/skills/omics-target-evidence-mapper/omics_target_evidence_mapper.py
@@ -360,14 +360,13 @@ def main() -> None:
     write_json(evidence_path, evidence)
     write_text(report_path, report)
     write_json(metadata_path, metadata)
-    write_checksums([evidence_path, report_path, metadata_path], output_dir, anchor=output_dir)
-    write_environment_yml(
+    environment_path = write_environment_yml(
         output_dir,
         env_name="clawbio-omics-target-evidence-mapper",
         pip_deps=["requests", "rocrate"],
         python_version="3.11",
     )
-    write_ro_crate(
+    ro_crate_path = write_ro_crate(
         output_dir,
         skill_name="omics-target-evidence-mapper",
         skill_version="0.1.0",
@@ -380,6 +379,11 @@ def main() -> None:
             "max_trials": args.max_trials,
             "demo": args.demo,
         },
+    )
+    write_checksums(
+        [evidence_path, report_path, metadata_path, environment_path, ro_crate_path],
+        output_dir,
+        anchor=output_dir,
     )
 
     print(f"Done. Output written to: {output_dir}")

--- a/skills/omics-target-evidence-mapper/tests/test_omics_target_evidence_mapper.py
+++ b/skills/omics-target-evidence-mapper/tests/test_omics_target_evidence_mapper.py
@@ -1,2 +1,64 @@
-def test_omics_target_evidence_mapper_placeholder():
-    assert True
+import argparse
+import hashlib
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parents[1] / "omics_target_evidence_mapper.py"
+SPEC = importlib.util.spec_from_file_location("omics_target_evidence_mapper", MODULE_PATH)
+mapper = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(mapper)
+
+
+def test_checksum_manifest_covers_every_advertised_output(tmp_path, monkeypatch) -> None:
+    output_dir = tmp_path / "output"
+    monkeypatch.setattr(
+        mapper,
+        "parse_args",
+        lambda: argparse.Namespace(
+            demo=True,
+            gene=None,
+            disease=None,
+            output=str(output_dir),
+            max_papers=5,
+            max_trials=5,
+        ),
+    )
+    monkeypatch.setattr(
+        mapper,
+        "build_evidence",
+        lambda _args: {
+            "query": {"gene": "IL6R", "disease": "coronary artery disease", "demo_mode": True},
+            "provenance": {"sources": ["UniProt"], "version": "0.1.0"},
+            "literature": [],
+            "trials": [],
+            "target_summary": {"status": "no_result"},
+            "disease_association": {"status": "skipped"},
+            "limitations": [],
+        },
+    )
+    monkeypatch.setattr(mapper, "build_report", lambda _evidence: "# Report\n")
+
+    def write_ro_crate(output_dir, **_kwargs):
+        path = Path(output_dir) / "ro-crate-metadata.json"
+        path.write_text("{}\n", encoding="utf-8")
+        return path
+
+    monkeypatch.setattr(mapper, "write_ro_crate", write_ro_crate)
+
+    mapper.main()
+
+    manifest = output_dir / "reproducibility" / "checksums.sha256"
+    entries = dict(line.split("  ", 1) for line in manifest.read_text().splitlines())
+    expected = {
+        "evidence.json",
+        "report.md",
+        "metadata.json",
+        "reproducibility/environment.yml",
+        "ro-crate-metadata.json",
+    }
+    assert set(entries.values()) == expected
+    for relative_path in expected:
+        content = (output_dir / relative_path).read_bytes()
+        assert entries[hashlib.sha256(content).hexdigest()] == relative_path
+    assert "reproducibility/checksums.sha256" not in entries.values()


### PR DESCRIPTION
## Summary

Write the environment and RO-Crate artifacts before the checksum manifest, so the five files already advertised by the omics evidence mapper are actually covered. Previously the manifest was generated while the final two files did not exist. The checksum manifest intentionally does not hash itself.

## Skill affected

`omics-target-evidence-mapper`.

## Checklist

- [x] Existing SKILL.md output contract is preserved and now fulfilled.
- [x] Regression included; the complete skill suite passes (2 tests).
- [x] Deterministic synthetic output fixture included.
- [x] No patient/sensitive data committed.
- [x] Uses the existing shared reproducibility helpers and focused contribution conventions.

## Test output

- Regression independently recomputes each SHA-256 and requires exactly: `evidence.json`, `report.md`, `metadata.json`, `reproducibility/environment.yml`, and `ro-crate-metadata.json`.
- `uv run --with pytest python -m pytest -q skills/omics-target-evidence-mapper/tests`: 2 passed.
- Python compile and `git diff --check`: passed.
- The regression uses a deterministic RO-Crate writer stub to isolate the checksum contract; it does not assert third-party RO-Crate serialization behavior. No full repository test pass is claimed.
