### PR TITLE
Integrity and governance sweep (M1): public-claims gate, GOVERNANCE, MAINTAINERS, CODEOWNERS, Dependabot, CodeQL, pip-audit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "name": "clawbio",
   "metadata": {
     "description": "Bioinformatics-native AI agent skill library for Claude Code: 97 Agent Skills, local-first and reproducible.",
-    "version": "0.7.0"
+    "version": "0.7.1"
   },
   "owner": {
     "name": "Manuel Corpas",
@@ -12,8 +12,8 @@
   "plugins": [
     {
       "name": "clawbio",
-      "description": "97 bioinformatics Agent Skills: pharmacogenomics, clinical variant interpretation, GWAS and PRS, ancestry, RNA-seq and single-cell, metagenomics, proteomics, methylation clocks, nf-core pipeline wrappers. 50 run deterministically from the CLI with demo data and write a reproducibility bundle. Local-first, privacy-focused.",
-      "version": "0.7.0",
+      "description": "97 bioinformatics Agent Skills: pharmacogenomics, clinical variant interpretation, GWAS and PRS, ancestry, RNA-seq and single-cell, metagenomics, proteomics, methylation clocks, nf-core pipeline wrappers. 49 run deterministically from the CLI with demo data and write a reproducibility bundle. Local-first, privacy-focused.",
+      "version": "0.7.1",
       "author": {
         "name": "Manuel Corpas",
         "email": "mc@manuelcorpas.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clawbio",
-  "description": "Bioinformatics-native AI agent skill library: pharmacogenomics, clinical variant interpretation, GWAS and polygenic scores, ancestry, RNA-seq and single-cell, metagenomics, proteomics and nf-core pipeline wrappers. 97 Agent Skills, 50 with a deterministic CLI entry point and demo data, every runnable skill writing a SHA-256 reproducibility bundle. Local-first.",
-  "version": "0.7.0",
+  "description": "Bioinformatics-native AI agent skill library: pharmacogenomics, clinical variant interpretation, GWAS and polygenic scores, ancestry, RNA-seq and single-cell, metagenomics, proteomics and nf-core pipeline wrappers. 97 Agent Skills, 49 with a deterministic CLI entry point and demo data, every runnable skill writing a SHA-256 reproducibility bundle. Local-first.",
+  "version": "0.7.1",
   "author": {
     "name": "Manuel Corpas",
     "email": "mc@manuelcorpas.com"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# Review is required from the listed owner before a change to these paths
+# merges. Everything not listed (in particular skills/) is reviewed under the
+# process in GOVERNANCE.md and may be merged by any maintainer, or by the
+# daily PR agent when its published conditions are met.
+#
+# This file only binds once branch protection on main requires code-owner
+# review; see GOVERNANCE.md, "Repository settings".
+
+/clawbio/           @manuelcorpas
+/.github/           @manuelcorpas
+/scripts/           @manuelcorpas
+/pyproject.toml     @manuelcorpas
+/uv.lock            @manuelcorpas
+/GOVERNANCE.md      @manuelcorpas
+/MAINTAINERS.md     @manuelcorpas
+/SECURITY.md        @manuelcorpas

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Weekly dependency update proposals. Python is declared as the `uv`
+# ecosystem, not `pip`, because the project pins through uv.lock and CI runs
+# `uv lock --check`: a pip-ecosystem update would edit pyproject.toml, leave the
+# lockfile behind and fail that check on every PR it opened.
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-and-patch:
+        update-types: ["minor", "patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,60 @@ jobs:
           path: audit.txt
           retention-days: 30
 
+  pip-audit:
+    # Second opinion on the lockfile from pip-audit (PyPI advisory database and
+    # OSV), next to the `uv audit` job above. Report-only for the same reason
+    # that job is: on the day this was added the lockfile carried 55 findings
+    # across gitpython, pyasn1 and setuptools, and a gate born red is how the
+    # scientific-audit job came to carry `|| true` for months (#342). Dependabot
+    # (.github/dependabot.yml) drives the backlog down; promote this to a gate
+    # by removing `|| true` once `uvx pip-audit --strict` is clean on main.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+
+      - name: Export the lockfile
+        run: uv export --frozen --no-hashes --all-extras -o requirements-audit.txt
+
+      - name: Audit with pip-audit
+        # `|| true` keeps findings from failing the build, so assert the tool
+        # actually ran: pip-audit always prints either "No known
+        # vulnerabilities found" or "Found N known vulnerabilities". Neither
+        # line means the step broke, which must fail loudly.
+        run: |
+          uvx pip-audit -r requirements-audit.txt --no-deps > pip-audit.txt 2>&1 || true
+          if ! grep -qE 'No known vulnerabilities found|Found [0-9]+ known vulnerabilit' pip-audit.txt; then
+            echo "::error::pip-audit produced no recognisable report - the audit step is broken, not clean"
+            cat pip-audit.txt
+            exit 1
+          fi
+
+      - name: Post summary
+        if: always()
+        run: |
+          echo "## pip-audit" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Report-only: this job never fails the build on findings." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat pip-audit.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload audit report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pip-audit
+          path: pip-audit.txt
+          retention-days: 30
+
   skill-lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, so new query packs run against main even in a quiet week.
+    - cron: "17 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyse:
+    name: Analyse (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, actions]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialise CodeQL
+        uses: github/codeql-action/init@4bd7200e1f146b1c937cae12d258b50f41a53cf8 # v4.38.0
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Analyse
+        uses: github/codeql-action/analyze@4bd7200e1f146b1c937cae12d258b50f41a53cf8 # v4.38.0
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,11 +1,10 @@
 {
   "title": "ClawBio: Bioinformatics-Native AI Agent Skill Library",
-  "description": "ClawBio is where biological AI gets its skills: a curated, reproducible, open repository any agent can call. v0.5.0 introduces the platform's first systematic validation infrastructure including an Alzheimer's disease ground truth benchmark, mock API server for offline testing, swappable fine-mapping pipeline (ABF vs SuSiE), benchmark scorer with objective metrics, and red/green TDD mandate. 42 skills, 687 tests, 74 benchmark tests.",
+  "description": "ClawBio is where biological AI gets its skills: a curated, reproducible, open repository any agent can call. 97 skills covering pharmacogenomics, variant annotation, fine-mapping, polygenic risk scoring, single-cell RNA-seq, and more, with validation infrastructure (an Alzheimer's disease ground truth benchmark, a mock API server for offline testing, a swappable fine-mapping pipeline, a benchmark scorer with objective metrics) and 4,730 automated tests.",
   "upload_type": "software",
   "creators": [
     {
       "name": "Corpas, Manuel",
-      "affiliation": "University of Westminster",
       "orcid": "0000-0002-5765-9827"
     }
   ],

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,11 +10,11 @@ repository-code: "https://github.com/ClawBio/ClawBio"
 license: MIT
 abstract: >-
   ClawBio is where biological AI gets its skills: a curated, reproducible,
-  open repository any agent can call. 42 executable bioinformatics skills
-  covering pharmacogenomics, variant annotation, fine-mapping, polygenic
-  risk scoring, single-cell RNA-seq, and more. Includes validation
-  infrastructure with Alzheimer's disease ground truth benchmark, mock
-  API server, swappable fine-mapping pipeline, and 687 automated tests.
+  open repository any agent can call. 97 skills covering pharmacogenomics,
+  variant annotation, fine-mapping, polygenic risk scoring, single-cell
+  RNA-seq, and more. Includes validation infrastructure with an Alzheimer's
+  disease ground truth benchmark, mock API server, swappable fine-mapping
+  pipeline, and 4,730 automated tests.
 keywords:
   - bioinformatics
   - AI agents
@@ -29,4 +29,3 @@ authors:
   - family-names: Corpas
     given-names: Manuel
     orcid: "https://orcid.org/0000-0002-5765-9827"
-    affiliation: "University of Westminster"

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,139 @@
+# Governance
+
+This document says how ClawBio is run today. It describes the project at its
+actual size: one lead maintainer, a small number of people with repository
+rights, and community contributors. There is no steering committee, no
+foundation and no voting body. If the project grows to need one, this file
+changes first.
+
+The people holding each right are listed in [MAINTAINERS.md](MAINTAINERS.md),
+which is checked against the GitHub API rather than written from memory.
+
+## Roles
+
+**Lead maintainer.** Manuel Corpas. Holds final say on scope, releases,
+security response and this document. Owns the PyPI project, the clawbio.ai
+domain and the GitHub organisation.
+
+**Maintainer.** A person with `maintain` or `admin` permission on the
+repository. Reviews and merges community pull requests within the limits
+below, triages issues, and may cut a release when asked to by the lead
+maintainer.
+
+**Contributor.** Anyone who opens a pull request. Contributors keep copyright
+in their work and license it under MIT by contributing; see
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
+**The daily PR agent.** An unattended job, run from the lead maintainer's own
+machine, that audits community pull requests once a day. Its policy is fixed
+in code and tested; it is summarised under "Automated merges" below.
+
+## How decisions are made
+
+Most decisions are made in the pull request or issue where they arise, by the
+maintainer handling it. Anything that changes what ClawBio promises to users
+is decided by the lead maintainer and recorded where the change lands:
+
+- the public interface of the `clawbio` package and CLI, and any deprecation;
+- the SKILL.md contract, the catalogue schema and the maturity tiers;
+- what CI requires of a contribution;
+- release timing and version numbers;
+- security response, including whether to disclose and when;
+- this document, MAINTAINERS.md and CODEOWNERS.
+
+A decision of that kind is recorded in the CHANGELOG under `Unreleased` when
+it changes behaviour, or in the pull request that makes it otherwise. There is
+no separate RFC process. If you want to argue for a change, open an issue and
+make the case; the lead maintainer answers there.
+
+## Who merges what
+
+| Change | Who may merge | Conditions |
+|--------|---------------|------------|
+| A new or changed skill under `skills/` | Any maintainer, or the daily PR agent | CI green, audit verdict SAFE, a domain read of the science, no conflict with `main` |
+| `clawbio/`, `scripts/`, `.github/`, `pyproject.toml`, `uv.lock` | Lead maintainer | Review by the code owner named in `.github/CODEOWNERS` |
+| Documentation and site pages | Any maintainer | CI green |
+| A release tag `v*` | Lead maintainer | Tag ruleset: only repository admins can create or move one |
+| GOVERNANCE.md, MAINTAINERS.md, CODEOWNERS, SECURITY.md | Lead maintainer | Code-owner review |
+
+Nobody merges their own pull request into `clawbio/` or `.github/` without a
+second person's review, and the daily PR agent never acts on a pull request
+authored by the lead maintainer.
+
+### Automated merges
+
+The daily PR agent comments on, approves and merges a community pull request
+only when all of the following hold: the static audit and a domain read of the
+diff both return SAFE, CI is green (a run that never started is not green),
+GitHub reports the branch mergeable, and the diff contains no prompt-injection
+markers. Anything else is a comment or a request for changes, and anything the
+scanner flags but the domain read does not confirm is held for a person. It
+merges at most five pull requests per run. Its model cannot reach GitHub; the
+model returns a recommendation and a separate, tool-free step acts on it using
+state read from the API. A file named `DATA/DISABLED` on the machine that runs
+it stops all merging while auditing continues. Every rule has a test; the
+policy changes only by changing the code and its tests together.
+
+## Becoming a maintainer
+
+There is no application form. Someone becomes a maintainer when:
+
+1. they have had several pull requests merged over a few months, including at
+   least one review of somebody else's contribution that caught something real;
+2. the lead maintainer asks them, or they ask and the lead maintainer agrees;
+3. they accept in writing, in an issue or a pull request against
+   MAINTAINERS.md, which states what they are taking on (the expected load is
+   about two hours a week);
+4. the lead maintainer grants the repository permission and merges the
+   MAINTAINERS.md change.
+
+Maintainer status lapses after six months without activity on the repository.
+The person is told first; if they want to stay they say so and remain. It is
+withdrawn immediately for a breach of the [Code of Conduct](CONTRIBUTING.md)
+or of the security policy in [SECURITY.md](SECURITY.md).
+
+ClawBio is looking for a second maintainer. If the description above fits you,
+open an issue.
+
+## Resolving disputes
+
+1. Talk it through in the pull request or issue. Most disagreements are about
+   a missing fact, and the fact settles it.
+2. If two maintainers disagree, the lead maintainer decides and writes the
+   reason in the thread.
+3. If the disagreement is with the lead maintainer, say so plainly in the
+   thread; the decision stands but the objection is recorded with it, and the
+   question is reopened when new evidence arrives.
+4. Conduct complaints go to the address in SECURITY.md and are handled by the
+   lead maintainer, or by another maintainer if the complaint concerns the lead
+   maintainer.
+
+## If the lead maintainer is unavailable
+
+If the lead maintainer has not responded on the repository for thirty days,
+any repository admin listed in MAINTAINERS.md may: merge pull requests that
+meet the conditions above, cut a patch release for a security fix, and respond
+to security reports. They may not change this document, the licence, the
+package name or the organisation's membership. A second owner account for the
+GitHub organisation, controlled by the lead maintainer and protected by a
+hardware key, is planned so that loss of one account does not lock the
+project.
+
+## Repository settings
+
+The settings this document relies on, and their state on 11 September 2026:
+
+- `main` is not branch-protected. This document recommends protecting it with
+  required CI, required code-owner review for the paths in CODEOWNERS, and no
+  force pushes. The `scientific-audit` CI job is excluded from the required
+  set, because it runs an external audit suite pinned to a commit and is
+  informative rather than blocking.
+- Release tags `v*` are protected by a repository ruleset.
+- Dependency updates are proposed weekly by Dependabot; CodeQL runs on every
+  pull request and weekly on `main`; `uv audit` and `pip-audit` report on the
+  lockfile.
+
+## Changing this document
+
+By pull request, reviewed by the lead maintainer, with the reason for the
+change in the pull request body.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,48 @@
+# Maintainers
+
+Who holds which right on ClawBio, as of 11 September 2026. Every list below
+was read from the GitHub API on that date (`gh api
+repos/ClawBio/ClawBio/collaborators`, `gh api orgs/ClawBio/members`) rather
+than written from memory. When you change a permission, change this file in
+the same pull request. The roles are defined in [GOVERNANCE.md](GOVERNANCE.md).
+
+## Lead maintainer
+
+| Person | GitHub | ORCID |
+|--------|--------|-------|
+| Manuel Corpas | [@manuelcorpas](https://github.com/manuelcorpas) | [0000-0002-5765-9827](https://orcid.org/0000-0002-5765-9827) |
+
+## Repository permissions (ClawBio/ClawBio)
+
+| GitHub | Permission | Notes |
+|--------|------------|-------|
+| [@manuelcorpas](https://github.com/manuelcorpas) | admin | Lead maintainer |
+| [@jaymoore-research](https://github.com/jaymoore-research) | admin | Repository admin; backup for the thirty-day rule in GOVERNANCE.md |
+| [@camlloyd](https://github.com/camlloyd) | maintain (includes push) | Reviews and merges skill contributions within the limits in GOVERNANCE.md |
+| [@afonsoguerra](https://github.com/afonsoguerra) | read | Organisation member |
+
+## Organisation (github.com/ClawBio)
+
+| GitHub | Role |
+|--------|------|
+| [@manuelcorpas](https://github.com/manuelcorpas) | owner |
+| [@afonsoguerra](https://github.com/afonsoguerra) | member |
+
+A second owner account for the organisation, controlled by the lead maintainer
+and protected by a hardware key, is planned and not yet created.
+
+## Other controls
+
+| Control | Held by |
+|---------|---------|
+| PyPI project `clawbio` | Manuel Corpas |
+| Domain `clawbio.ai` (DNS) and GitHub Pages | Manuel Corpas |
+| Release tags `v*` | Repository admins only, by ruleset |
+| The daily PR agent | Runs from Manuel Corpas's machine; see GOVERNANCE.md |
+
+## Second maintainer wanted
+
+ClawBio has one lead maintainer and is seeking a second maintainer who can
+share review of community skill contributions and act as backup for security
+response. The expectations and the path are in GOVERNANCE.md, "Becoming a
+maintainer". If that is you, open an issue.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h3 align="center">ClawBio</h3>
 
 <p align="center">
-  <strong>The first bioinformatics-native AI agent skill library.</strong><br>
+  <strong>A bioinformatics-native AI agent skill library.</strong><br>
   Built on <a href="https://github.com/openclaw/openclaw">OpenClaw</a> (180k+ GitHub stars). Local-first. Privacy-focused. Reproducible.
 </p>
 
@@ -9,7 +9,6 @@
   <a href="https://github.com/ClawBio/ClawBio/actions/workflows/ci.yml"><img src="https://github.com/ClawBio/ClawBio/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="#quick-start"><img src="https://img.shields.io/badge/python-3.11+-blue?logo=python&logoColor=white" alt="Python 3.11+"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="MIT License"></a>
-  <a href="https://clawhub.ai"><img src="https://img.shields.io/badge/ClawHub-97_skills-orange" alt="ClawHub Skills"></a>
   <a href="https://luma.com/clawbio"><img src="https://img.shields.io/badge/Events-Follow_on_Luma-7c3aed" alt="Follow ClawBio Events on Luma"></a>
   <a href="https://doi.org/10.5281/zenodo.19420648"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.19420648.svg" alt="DOI"></a>
   <a href="https://github.com/ClawBio/ClawBio/issues"><img src="https://img.shields.io/github/issues/ClawBio/ClawBio" alt="Open Issues"></a>
@@ -69,7 +68,7 @@ uv run python clawbio.py run pharmgx --demo
 
 ## What ClawBio Does Today
 
-**97 skills (91 with runnable demo data) + 8,182 Galaxy tools + 4,723 tests + benchmark validation. Local-first by default. Reproducible. No guessing.**
+**97 skills (92 with runnable demo data) + 8,182 Galaxy tools + 4,730 tests + benchmark validation. Local-first by default. Reproducible. No guessing.**
 > **v0.5.0 released** (4 Apr 2026): Validation and Benchmark Infrastructure. AD ground truth benchmark, mock API server for offline testing, swappable fine-mapping pipeline (SuSiE vs ABF), 74 benchmark tests, red/green TDD mandate. [Release notes](https://github.com/ClawBio/ClawBio/releases/tag/v0.5.0). DOI: [10.5281/zenodo.19420648](https://doi.org/10.5281/zenodo.19420648).
 
 Snap a photo of a medication in Telegram. ClawBio identifies the drug from the packaging, queries your pharmacogenomic profile from [your own genome](docs/demo-genome.md), and returns a personalised dosage card — on your machine, in seconds:
@@ -686,7 +685,7 @@ See [Contributing a Skill](#contributing-a-skill) above for the submission proce
 
 ## Versioning
 
-ClawBio follows [Semantic Versioning](https://semver.org/). The current release is **v0.7.0**. See [CHANGELOG.md](CHANGELOG.md) for a full history of additions and breaking changes.
+ClawBio follows [Semantic Versioning](https://semver.org/). The current release is **v0.7.1**. See [CHANGELOG.md](CHANGELOG.md) for a full history of additions and breaking changes.
 
 ---
 
@@ -694,7 +693,7 @@ ClawBio follows [Semantic Versioning](https://semver.org/). The current release 
 
 ### What is ClawBio?
 
-ClawBio is the **first bioinformatics-native AI agent skill library**. Built on OpenClaw (180k+ GitHub stars), it provides 97 skills (91 with runnable demo data) for genomics analysis, pharmacogenomics, ancestry profiling, and more. Local-first, privacy-focused, and reproducible.
+ClawBio is a **bioinformatics-native AI agent skill library**. Built on OpenClaw (180k+ GitHub stars), it provides 97 skills (92 with runnable demo data) for genomics analysis, pharmacogenomics, ancestry profiling, and more. Local-first, privacy-focused, and reproducible.
 
 ### What are ClawBio skills?
 

--- a/llms.txt
+++ b/llms.txt
@@ -8,7 +8,7 @@
 - [CLAUDE.md](CLAUDE.md): Agent routing table, CLI reference, demo data, safety rules, script-first execution guidance
 - [AGENTS.md](AGENTS.md): Universal guide for AI coding agents working in this repo
 - [commands/](commands/): Reusable slash-command workflows for analysis, skill scaffolding, skill listing, and demos
-- [CHANGELOG.md](CHANGELOG.md): Release milestones through `v0.5.0`
+- [CHANGELOG.md](CHANGELOG.md): Release milestones through `v0.7.1`
 - [REMEDIATION-PLAN.md](REMEDIATION-PLAN.md): External audit findings and remediation roadmap
 - [docs/CLAWBIO-BRIEF.md](docs/CLAWBIO-BRIEF.md): Evergreen project brief for collaborators, investors, and agents
 - [docs/reference-genome.md](docs/reference-genome.md): Corpas 30x WGS reference genome used across demos, tutorials, and benchmarking
@@ -25,9 +25,9 @@
 
 ## Project State
 
-- Current public release: `v0.5.0`
-- Public framing in `README.md`: `95 skills + 8,182 Galaxy tools + 4,217 tests + benchmark validation`
-- Catalog status split: `29` MVP skills and `66` planned / legacy skills
+- Current public release: `v0.7.1`
+- Public framing in `README.md`: `97 skills + 8,182 Galaxy tools + 4,730 tests + benchmark validation`
+- Catalog status split: `29` MVP skills and `68` planned / legacy skills
 - Counts above are derived, not hand-written. Regenerate them before editing:
   - skills and Galaxy tools: `skill_count` / `galaxy_tool_count` in `skills/catalog.json`,
     itself produced by `python scripts/generate_catalog.py`
@@ -122,6 +122,6 @@ These skills are referenced in `CLAUDE.md`, `skills/catalog.json`, or executable
 
 ## Optional
 
-- [skills/catalog.json](skills/catalog.json): Machine-readable skill index; current catalog contains `55` entries
+- [skills/catalog.json](skills/catalog.json): Machine-readable skill index; current catalog contains `97` entries
 - [templates/SKILL-TEMPLATE.md](templates/SKILL-TEMPLATE.md): Template for new skills
 - [clawbio.py](clawbio.py): Main CLI runner and alias registry for `python clawbio.py run <alias>`

--- a/marketplace.html
+++ b/marketplace.html
@@ -595,7 +595,7 @@ tr.clickable:hover .col-repo a { color: var(--accent-cyan); }
 <!-- ClawBio -->
 <tr class="clickable" data-readiness="ready" data-search="clawbio genomics pharmacogenomics single-cell gwas prs equity nutrigenomics ancestry variant galaxy" data-skills="28" data-stars="342" data-forks="50" data-status="1" data-repo="ClawBio" data-origin="Imperial College London">
   <td><div class="col-repo"><span class="org">ClawBio</span><a href="https://github.com/ClawBio/ClawBio" target="_blank" onclick="event.stopPropagation()">ClawBio</a></div></td>
-  <td class="col-desc">First bioinformatics-native AI agent skill library. Local-first genomic analysis with reproducibility bundles. 78 skills + 8,000 Galaxy tools.</td>
+  <td class="col-desc">Bioinformatics-native AI agent skill library. Local-first genomic analysis with reproducibility bundles; the live catalogue is skills/catalog.json.</td>
   <td class="col-num" style="text-align:right">28</td>
   <td class="col-stars" style="text-align:right">&#9733; 342</td>
   <td class="col-forks" style="text-align:right">&#9741; 50</td>

--- a/packaging/bioconda/meta.yaml
+++ b/packaging/bioconda/meta.yaml
@@ -54,7 +54,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  summary: "The first bioinformatics-native AI agent skill library. Local-first, reproducible, built on OpenClaw."
+  summary: "Bioinformatics-native AI agent skill library. Local-first, reproducible, built on OpenClaw."
   dev_url: https://github.com/ClawBio/ClawBio
   doc_url: https://clawbio.github.io/ClawBio/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clawbio"
-description = "The first bioinformatics-native AI agent skill library. Local-first, reproducible, built on OpenClaw."
+description = "Bioinformatics-native AI agent skill library. Local-first, reproducible, built on OpenClaw."
 readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/tests/test_public_claims.py
+++ b/tests/test_public_claims.py
@@ -1,0 +1,140 @@
+"""Public claims must match the repository they describe.
+
+Every number a reader can quote (skill count, demo count, CLI count, release
+version) is derived here from its source of truth and compared against the
+files where it is repeated by hand. The plan that produced this gate found the
+README, CITATION.cff, .zenodo.json and llms.txt disagreeing with each other by
+up to 55 skills and two minor releases, and a "first" claim that no evidence
+supports. A stale public claim is a defect, so this test fails CI on drift.
+
+Sources of truth:
+  skill counts   skills/catalog.json (written by scripts/generate_catalog.py)
+  version        clawbio/__init__.py
+
+How to fix a failure: regenerate the catalogue (`python scripts/generate_catalog.py`)
+and copy the numbers it reports into the file named in the assertion; never
+hand-type a count. To bump the version, change clawbio/__init__.py first.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+CATALOG = ROOT / "skills" / "catalog.json"
+
+# Files that repeat the skill count by hand. Each `<number> skills` (or
+# `<number> Agent Skills`) in them must equal catalog.json's skill_count.
+COUNT_FILES = [
+    "README.md",
+    "llms.txt",
+    "CITATION.cff",
+    ".zenodo.json",
+    ".claude-plugin/plugin.json",
+    ".claude-plugin/marketplace.json",
+]
+
+# Files that state the current release. Each must carry the package version.
+VERSION_FILES = {
+    "README.md": r"The current release is \*\*v([0-9][0-9a-z.\-]*)\*\*",
+    "llms.txt": r"Current public release: `v([0-9][0-9a-z.\-]*)`",
+    "CITATION.cff": r"^version: ([0-9][0-9a-z.\-]*)$",
+    ".zenodo.json": r'"version": "([0-9][0-9a-z.\-]*)"',
+    ".claude-plugin/plugin.json": r'"version": "([0-9][0-9a-z.\-]*)"',
+    ".claude-plugin/marketplace.json": r'"version": "([0-9][0-9a-z.\-]*)"',
+}
+
+# A primacy claim the project cannot evidence. Scanned across every tracked
+# text file; the allowlist holds dated records of past talks and submissions,
+# which are history and are not rewritten.
+PRIMACY = re.compile(
+    r"\bfirst\s+bioinformatics[\s-]native\b|\bfirst\s+(?:AI\s+)?agent\s+skill\s+library\b",
+    re.IGNORECASE,
+)
+PRIMACY_ALLOWLIST_PREFIXES = (
+    "slides/",  # London Bioinformatics Meetup deck, February 2026, as delivered
+    "docs/dorahacks-buidl-submission.md",  # submission text as filed, 5 March 2026
+    "tests/test_public_claims.py",
+)
+TEXT_SUFFIXES = {".md", ".txt", ".toml", ".json", ".cff", ".html", ".py", ".yml", ".yaml", ".cfg", ".ini"}
+
+COUNT_PATTERN = re.compile(r"(?<![\d.,])(\d[\d,]*)\s+(?:Agent\s+)?skills\b", re.IGNORECASE)
+DEMO_PATTERN = re.compile(r"(\d+) with runnable demo data")
+CLI_PATTERN = re.compile(r"(\d+) (?:with a deterministic CLI entry point|run deterministically from the CLI)")
+
+
+def _catalog() -> dict:
+    return json.loads(CATALOG.read_text())
+
+
+def _package_version() -> str:
+    text = (ROOT / "clawbio" / "__init__.py").read_text()
+    match = re.search(r'^__version__\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    assert match, "clawbio/__init__.py has no __version__"
+    return match.group(1)
+
+
+def _tracked_text_files() -> list[Path]:
+    out = subprocess.run(
+        ["git", "ls-files", "-z"], cwd=ROOT, capture_output=True, check=True
+    ).stdout
+    paths = [ROOT / p for p in out.decode().split("\0") if p]
+    return [p for p in paths if p.suffix in TEXT_SUFFIXES and p.is_file()]
+
+
+def test_catalog_skill_count_matches_skill_entries():
+    cat = _catalog()
+    assert cat["skill_count"] == len(cat["skills"]), "catalog.json is internally inconsistent; regenerate it"
+
+
+@pytest.mark.parametrize("relpath", COUNT_FILES)
+def test_skill_counts_match_catalog(relpath: str):
+    expected = _catalog()["skill_count"]
+    text = (ROOT / relpath).read_text()
+    found = [(m.group(1), m.group(0)) for m in COUNT_PATTERN.finditer(text)]
+    assert found, f"{relpath} states no skill count; add one from catalog.json or drop it from COUNT_FILES"
+    wrong = [phrase for number, phrase in found if int(number.replace(",", "")) != expected]
+    assert not wrong, f"{relpath} disagrees with catalog.json skill_count={expected}: {wrong}"
+
+
+def test_demo_and_cli_counts_match_catalog():
+    skills = _catalog()["skills"]
+    demo = sum(1 for s in skills if s.get("has_demo"))
+    cli = sum(1 for s in skills if s.get("cli_alias"))
+    problems = []
+    for relpath in COUNT_FILES:
+        text = (ROOT / relpath).read_text()
+        for m in DEMO_PATTERN.finditer(text):
+            if int(m.group(1)) != demo:
+                problems.append(f"{relpath}: '{m.group(0)}' but catalog has_demo={demo}")
+        for m in CLI_PATTERN.finditer(text):
+            if int(m.group(1)) != cli:
+                problems.append(f"{relpath}: '{m.group(0)}' but catalog cli_alias={cli}")
+    assert not problems, problems
+
+
+@pytest.mark.parametrize("relpath,pattern", sorted(VERSION_FILES.items()))
+def test_stated_release_matches_package_version(relpath: str, pattern: str):
+    expected = _package_version()
+    text = (ROOT / relpath).read_text()
+    found = re.findall(pattern, text, re.MULTILINE)
+    assert found, f"{relpath} states no release version (pattern {pattern!r})"
+    wrong = sorted(set(v for v in found if v != expected))
+    assert not wrong, f"{relpath} states release {wrong}, package is {expected}"
+
+
+def test_no_primacy_claim_anywhere():
+    hits = []
+    for path in _tracked_text_files():
+        rel = path.relative_to(ROOT).as_posix()
+        if rel.startswith(PRIMACY_ALLOWLIST_PREFIXES):
+            continue
+        for lineno, line in enumerate(path.read_text(errors="ignore").splitlines(), 1):
+            if PRIMACY.search(line):
+                hits.append(f"{rel}:{lineno}: {line.strip()[:100]}")
+    assert not hits, "primacy claim found (the project does not evidence it):\n" + "\n".join(hits)

--- a/workshop-variant-interpretation.html
+++ b/workshop-variant-interpretation.html
@@ -186,7 +186,7 @@
   <div class="section-inner">
     <p class="section-label">Introduction</p>
     <h2 class="section-title">What is ClawBio?</h2>
-    <p class="section-sub">The first bioinformatics-native AI agent skill library. Curated, reproducible, open-source.</p>
+    <p class="section-sub">A bioinformatics-native AI agent skill library. Curated, reproducible, open-source.</p>
 
     <div class="slide-deck">
       <div class="slide" data-num="1">


### PR DESCRIPTION
Move M1 (integrity and governance sweep) from the September 2026 plan. Every claim below was checked against the live file or the GitHub API on 11 September 2026.

## Defects fixed, with evidence

**Stale public claims**

| Defect | Where | Evidence | Fix |
|--------|-------|----------|-----|
| "The first bioinformatics-native AI agent skill library" | README.md:4 and :697, pyproject.toml:7, marketplace.html:598, workshop-variant-interpretation.html:189, packaging/bioconda/meta.yaml:57 | Primacy is not evidenced anywhere in the repository | Reworded to "a bioinformatics-native AI agent skill library"; the gate now forbids the phrase |
| ClawHub badge "97 skills" | README.md:12 | clawhub.ai lists 3 ClawBio skills | Badge removed; the ClawHub link under Resources stays |
| Hand-typed counts disagreeing with the catalogue | README (91 with demo data), plugin.json and marketplace.json (50 CLI), CITATION.cff and .zenodo.json (42 skills, 687 tests), llms.txt (95 skills, 4,217 tests, 66 planned, "55 entries") | `python scripts/generate_catalog.py` regenerates to 97 skills with no diff; catalogue says 92 `has_demo`, 49 `cli_alias`, 29 MVP / 68 planned; `grep -rhoE '^[[:space:]]*def test_' --include='*.py' . \| wc -l` gives 4,730 | All set to the derived numbers |
| Stale release | README.md:689 (v0.7.0), llms.txt:11 and :28 (v0.5.0), both .claude-plugin manifests (0.7.0) | `clawbio/__init__.py` says 0.7.1, CHANGELOG dates it 2026-09-05 | All say 0.7.1 |
| Westminster affiliation | CITATION.cff:32, .zenodo.json:8 | Appointment ended 2026-07-31 | Removed; ORCID 0000-0002-5765-9827 only |

Note on the brief: the plan was written at c57fe78 with 96 skills. #410 (vcf-qc) landed since, so the catalogue is 97; the numbers here come from the regenerated catalogue, not the plan.

**The gate: `tests/test_public_claims.py`** (runs in the existing "Run repo-level tests" CI step)

- every `N skills` in README, llms.txt, CITATION.cff, .zenodo.json and both plugin manifests must equal `skill_count` in skills/catalog.json;
- `N with runnable demo data` and `N with a deterministic CLI entry point` must equal the catalogue's `has_demo` and `cli_alias` counts;
- the release stated in those six files must equal `__version__` in clawbio/__init__.py;
- no tracked text file may contain the primacy phrase, except `slides/` (the February 2026 talk as delivered) and `docs/dorahacks-buidl-submission.md` (the submission as filed on 5 March 2026), which are dated records.

Proof it fires, from the working tree with each fix reverted in turn and then restored:

```
=== RED PROOF 1: README version reverted to 0.7.0
E  AssertionError: README.md states release ['0.7.0'], package is 0.7.1
1 failed, 14 passed
=== RED PROOF 2: CITATION skill count reverted to 42
E  AssertionError: CITATION.cff disagrees with catalog.json skill_count=97: ['42 skills']
1 failed, 14 passed
=== RED PROOF 3: primacy restored in pyproject
E  AssertionError: primacy claim found (the project does not evidence it):
E    pyproject.toml:7: description = "The first bioinformatics-native AI agent skill library. ...
1 failed, 14 passed
=== RESTORED
15 passed
```

The gate also found one claim my own grep had missed (packaging/bioconda/meta.yaml, a `.yaml` file) on its first real run.

**Governance**

- `GOVERNANCE.md`: decision rights, who merges what, the daily PR agent's merge conditions as they exist in its tested code, how someone becomes a maintainer, dispute resolution, the thirty-day absence rule. Honest about scale: one lead maintainer, no steering committee or voting body.
- `MAINTAINERS.md`: read from `gh api repos/ClawBio/ClawBio/collaborators` and `gh api orgs/ClawBio/members` on 11 September 2026: manuelcorpas admin, jaymoore-research admin, camlloyd maintain, afonsoguerra read; org owner manuelcorpas, member afonsoguerra. States that a second maintainer is being sought. Names nobody as that second maintainer.
- `.github/CODEOWNERS`: review by @manuelcorpas on clawbio/, .github/, scripts/, pyproject.toml, uv.lock and the governance files. Binds only once branch protection requires code-owner review (see below).
- `.github/dependabot.yml`: weekly, `uv` and `github-actions`. Declared as `uv` rather than `pip` because CI runs `uv lock --check`; a pip-ecosystem update would edit pyproject.toml without the lockfile and fail that check on every PR it opened.
- `.github/workflows/codeql.yml`: python and actions, on PR, push to main and weekly; `github/codeql-action@4bd7200e` (v4.38.0), checkout pinned to the SHA ci.yml already uses.
- `pip-audit` job in ci.yml: report-only, mirroring the existing `uv audit` job. On the current lockfile `pip-audit --strict` reports 55 findings across gitpython 3.1.50, pyasn1 0.6.3 and setuptools 82.0.1, so a blocking gate would be born red, which is how `scientific-audit` came to carry `\|\| true` (#342). The job asserts the tool produced a report; promote to a gate by removing `\|\| true` once main is clean. No new action was needed (uvx), so nothing unpinned was added.

## Tests

- `tests/test_public_claims.py`: 15 passed.
- CI-equivalent set (tests/, bot security tests and the twelve skill suites ci.yml names): 1,294 passed, 23 failed, 89.9s locally. All 23 failures are in `skills/wgs-prs/tests` (untouched here): `Nextflow not found` and `gwas_prs.py exited with code 1` on this machine, which has no nextflow. Main's CI at 04856b0, the commit this branch is based on, runs the same wgs-prs suite and is green, so they are local-environment failures, not regressions, and are not fixed here.
- `uv lock --check`: clean.
- Pre-existing, not fixed here: a bare `uv run pytest` from the repo root (pytest.ini `testpaths`) aborts at collection with `Plugin already registered under a different name` because `skills/gwas-catalog-region-fetch/tests/conftest.py` and `skills/eqtl-catalogue-region-fetch/tests/conftest.py` both import as `tests.conftest` under `--import-mode=importlib`. Reproduced on an untouched clone of main. CI never runs the suite that way, so it is not red in CI, but the root `pytest` invocation the README implies does not work.

## Not done, and why

- **Branch protection on main.** A repository setting, not a file. Recommended: require the CI `test`, `lockfile-check` and `skill-lint` jobs, require code-owner review, block force pushes; leave `scientific-audit` out of the required set (external suite pinned to a commit, informative only, DEC-2026-099). CODEOWNERS is inert until this is switched on.
- **biostochastics/clawbio_bench**: not forked, not repointed; the ci.yml pin at 49a0f11 is untouched.
- **Skill science, tier fields, catalogue schema**: untouched. The catalogue was regenerated and produced no diff.
- **index.html and benchmarks.html** still say "91 with runnable demo data" and "10 of 95 skills audited". index.html is rewritten by the site-stats automation, so gating or editing it here would race that job; the leaderboard's disposition is an open plan item (finding 7). Not in the gate.
- **packaging/bioconda/meta.yaml** pins version 0.5.2; only its summary line changed here. The recipe is M4's.
- **SECURITY.md "latest minor only"** support window: the plan's interface 6 wants two minors; not in this PR's brief.
- **Test counts are not gated.** They change with every contribution and would turn community PRs red over a number nobody relies on; they were corrected to the derived value and llms.txt documents the derivation.
- **A second organisation owner account with a hardware key**: an account action, noted as planned in MAINTAINERS.md.
- **slides/ and docs/dorahacks-buidl-submission.md** keep the "first" wording as dated records of a talk and a submission; they are allowlisted in the gate with the reason beside them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation, metadata, and CI/governance automation; no runtime skill or package API changes beyond corrected public wording and new non-blocking audit jobs.
> 
> **Overview**
> This PR is an **integrity and governance sweep (M1)** that fixes stale public metadata and adds enforcement plus repo hygiene.
> 
> **Public claims:** README, `llms.txt`, `CITATION.cff`, `.zenodo.json`, Claude plugin manifests, `pyproject.toml`, and related pages are aligned to catalogue-derived numbers (97 skills, 92 with demo data, 49 CLI-deterministic skills, **v0.7.1**). Unsubstantiated **"first bioinformatics-native"** wording is removed; the misleading ClawHub skills badge is dropped; Westminster affiliation is removed from citation metadata.
> 
> **New CI gate:** `tests/test_public_claims.py` fails if hand-written skill/demo/CLI counts or stated release versions drift from `skills/catalog.json` and `clawbio/__init__.py`, and scans tracked text for primacy phrases (with allowlists for historical slides/submissions).
> 
> **Governance:** Adds `GOVERNANCE.md` (roles, merge rules, daily PR agent policy), `MAINTAINERS.md` (API-sourced permissions), and `.github/CODEOWNERS` for core paths (effective once branch protection requires owner review).
> 
> **Security / deps automation:** Weekly Dependabot for **uv** (not pip) and GitHub Actions; new **CodeQL** workflow (Python + Actions); report-only **pip-audit** job in CI alongside existing `uv audit`, with a guard so a broken audit step still fails the job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6ce0ff7ca038337f4ef1adb8e718762e63fb51f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->