### PR TITLE
ci: widen the Dependabot cooldown to 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    # Dependabot already waits 3 days by default before proposing a version
+    # update. Widen that to a week: a compromised release is usually pulled
+    # within days of publication, and 3 sits at the edge of that window.
+    # Security updates bypass cooldown either way (zizmor: dependabot-cooldown).
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     groups:
       python-minor-and-patch:
@@ -18,4 +24,10 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    # Dependabot already waits 3 days by default before proposing a version
+    # update. Widen that to a week: a compromised release is usually pulled
+    # within days of publication, and 3 sits at the edge of that window.
+    # Security updates bypass cooldown either way (zizmor: dependabot-cooldown).
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- Sets an explicit 7-day `cooldown` on both the `uv` and `github-actions` Dependabot ecosystems in `.github/dependabot.yml`.
- Dependabot already waits 3 days by default before proposing a version update. A compromised release is usually pulled within days of publication, and 3 sits at the edge of that window, so this widens it to a week. Security updates bypass cooldown either way.
- Resolves the two `dependabot-cooldown` findings zizmor reports against `main`.

## Skill affected

None. CI configuration only (`.github/dependabot.yml`).

## Checklist

- [x] SKILL.md is present and complete (YAML frontmatter + methodology) — n/a, no skill touched
- [x] Tests included and passing (`pytest -v`) — n/a, no Python changed; verified with zizmor below
- [x] Demo data included for reviewers to test — n/a
- [x] No patient/sensitive data committed
- [x] Follows [CONTRIBUTING.md](../CONTRIBUTING.md) conventions

## Test output

```
$ uvx zizmor --no-progress --format plain .github/dependabot.yml
No findings to report. Good job!
```

Before this change, zizmor 1.30.1 reported on `main`:

```
warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates
 --> .github/dependabot.yml:7:5   (package-ecosystem: "uv")
warning[dependabot-cooldown]: insufficient cooldown in Dependabot updates
 --> .github/dependabot.yml:16:5  (package-ecosystem: "github-actions")
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
