### PR TITLE
fix(nutrigx): stream the AncestryDNA parser instead of loading the file into memory

### DIFF
--- a/skills/nutrigx/parse_input.py
+++ b/skills/nutrigx/parse_input.py
@@ -53,27 +53,23 @@ def parse_23andme(filepath: str) -> dict:
 
 
 def parse_ancestry(filepath: str) -> dict:
-    """Parse AncestryDNA raw data file. Returns {rsid: genotype}."""
+    """
+    Parse an AncestryDNA raw data file. Returns {rsid: genotype}.
+
+    The file is streamed. csv.DictReader accepts any iterable of strings, so
+    comment lines are filtered by a generator rather than by first building a
+    list of every line in the file: consumer genetic files are large, and
+    materialising one made memory use scale with input size.
+    """
     genotypes = {}
     with open(filepath, encoding="utf-8", errors="replace") as f:
-        reader = csv.DictReader(f, delimiter="\t")
-        # Handle comment lines
-        raw = f.read() if not hasattr(reader, 'fieldnames') else ""
-    
-    # Re-read skipping comments
-    lines = []
-    with open(filepath, encoding="utf-8", errors="replace") as f:
-        for line in f:
-            if not line.startswith("#"):
-                lines.append(line)
-    
-    reader = csv.DictReader(lines, delimiter="\t")
-    for row in reader:
-        rsid = row.get("rsid", "").strip()
-        allele1 = row.get("allele1", "").strip()
-        allele2 = row.get("allele2", "").strip()
-        if rsid.startswith("rs"):
-            genotypes[rsid] = allele1 + allele2
+        rows = (line for line in f if not line.startswith("#"))
+        for row in csv.DictReader(rows, delimiter="\t"):
+            rsid = row.get("rsid", "").strip()
+            allele1 = row.get("allele1", "").strip()
+            allele2 = row.get("allele2", "").strip()
+            if rsid.startswith("rs"):
+                genotypes[rsid] = allele1 + allele2
     return genotypes
 
 


### PR DESCRIPTION
## What

`parse_ancestry` read every line of the input into a list before parsing, so memory use scaled with the size of the genetic file. Consumer exports run to hundreds of thousands of rows, which makes this a denial-of-service risk on untrusted input and simply wasteful on trusted input.

`csv.DictReader` accepts any iterable of strings, so comment lines can be filtered by a generator and the file streamed.

`detect_format`, `parse_23andme` and `parse_vcf` already stream — this brings `parse_ancestry` into line with them.

## Dead code removed in the same function

```python
with open(filepath, encoding="utf-8", errors="replace") as f:
    reader = csv.DictReader(f, delimiter="\t")
    raw = f.read() if not hasattr(reader, 'fieldnames') else ""
```

`csv.DictReader` always has a `fieldnames` attribute, so this branch never ran, `raw` was always `""` and never used, and the file was opened a second time to do the real work.

## Testing

Output is unchanged: comment lines skipped, header respected, only `rs`-prefixed identifiers collected. 24 nutrigx tests pass.

## Context

Found via a security audit of [drdaviddelorenzo/nutrigenomics](https://github.com/drdaviddelorenzo/nutrigenomics), which shares this parser's ancestry. The same fix is applied there.