### PR TITLE
chore: correct the demo-data count in the README headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ uv run python clawbio.py run pharmgx --demo
 
 ## What ClawBio Does Today
 
-**97 skills (91 with runnable demo data) + 8,182 Galaxy tools + 4,820 tests + benchmark validation. Local-first by default. Reproducible. No guessing.**
+**97 skills (92 with runnable demo data) + 8,182 Galaxy tools + 4,820 tests + benchmark validation. Local-first by default. Reproducible. No guessing.**
 > **v0.5.0 released** (4 Apr 2026): Validation and Benchmark Infrastructure. AD ground truth benchmark, mock API server for offline testing, swappable fine-mapping pipeline (SuSiE vs ABF), 74 benchmark tests, red/green TDD mandate. [Release notes](https://github.com/ClawBio/ClawBio/releases/tag/v0.5.0). DOI: [10.5281/zenodo.19420648](https://doi.org/10.5281/zenodo.19420648).
 
 Snap a photo of a medication in Telegram. ClawBio identifies the drug from the packaging, queries your pharmacogenomic profile from [your own genome](docs/demo-genome.md), and returns a personalised dosage card — on your machine, in seconds:


### PR DESCRIPTION
## Why

`tests/test_public_claims.py::test_demo_and_cli_counts_match_catalog` is **failing on `main`**, so every open PR inherits a red `test (3.11 / 3.12 / 3.13)`:

```
AssertionError: ["README.md: '91 with runnable demo data' but catalog has_demo=92"]
```

`skills/catalog.json` has `has_demo=92`. The README states the figure twice — line 696 already says **92**, the headline on line 71 still says **91**. One occurrence was updated and the other missed.

## The change

One digit in the headline.

## Verification

- `tests/test_public_claims.py` — 15 passed
- full repo suite — **306 passed, 0 failed** (was 1 failed, 305 passed)

## Context

Found while opening #426, #427, #428 and #430 against nutrigx. I confirmed the failure reproduces on unmodified `upstream/main` and that none of those four branches introduces it — each shows the same single pre-existing failure and nothing else — so I have kept the fix out of them rather than bundling an unrelated README edit into a citations or parser PR.

If a catalog automation job is meant to keep this figure in step, this is presumably a case it missed rather than something to fix by hand each time.