### PR TITLE
fix(nutrigx): never strand-flip palindromic SNPs — homozygous reference was scored as homozygous risk

### DIFF
--- a/skills/nutrigx/extract_genotypes.py
+++ b/skills/nutrigx/extract_genotypes.py
@@ -70,8 +70,17 @@ def extract_snp_genotypes(genotype_table: dict, snp_panel: list) -> dict:
         # Try direct match first
         norm = raw_geno
         allele_matched = risk_allele in raw_geno
-        if not allele_matched:
-            # Try strand flip
+        if not allele_matched and not is_ambiguous(ref_allele, risk_allele):
+            # Try strand flip.
+            #
+            # Never for a palindromic (A/T or C/G) SNP. Flipping such a genotype
+            # yields the other allele of the same pair, so the flip always
+            # "succeeds" and silently turns homozygous reference into homozygous
+            # risk: at rs9939609 (FTO, ref T, risk A) a TT call - no risk alleles
+            # - became AA and scored 2. Strand cannot be resolved from the
+            # genotype alone for these SNPs, so the alleles are trusted as
+            # reported and the call falls through to the homozygous-reference
+            # branch below.
             flipped = flip_genotype(raw_geno)
             if risk_allele in flipped:
                 norm = flipped

--- a/skills/nutrigx/tests/test_nutrigx.py
+++ b/skills/nutrigx/tests/test_nutrigx.py
@@ -202,3 +202,37 @@ def test_rs4988235_gg_and_cc_are_non_persistent():
         assert result["call"]["risk_count"] == 2
         assert result["score"]["category"] == "Elevated"
         assert result["score"]["score"] == 10.0
+
+
+# ── Palindromic (A/T, C/G) SNPs must never be strand-flipped ──────────────────
+# Flipping a palindromic genotype yields the other allele of the same pair, so
+# the flip always succeeds and converts homozygous reference into homozygous
+# risk. At rs9939609 (FTO, ref T, risk A) a TT call -- no risk alleles -- was
+# normalised to AA and scored 2. Three panel entries are palindromic.
+
+def test_palindromic_snps_are_not_strand_flipped():
+    panel = load_panel()
+    palindromic = [
+        s for s in panel
+        if frozenset([s["ref_allele"], s["risk_allele"]]) in
+        (frozenset(["A", "T"]), frozenset(["C", "G"]))
+    ]
+    assert palindromic, "expected palindromic entries in the panel"
+
+    for snp in palindromic:
+        ref, risk = snp["ref_allele"], snp["risk_allele"]
+        for genotype, expected in ((ref * 2, 0), (ref + risk, 1), (risk * 2, 2)):
+            call = extract_snp_genotypes({snp["rsid"]: genotype}, panel)[snp["rsid"]]
+            assert call["status"] == "found", f"{snp['rsid']} {genotype}: {call['status']}"
+            assert call["risk_count"] == expected, (
+                f"{snp['rsid']} ({ref}/{risk}) {genotype}: risk_count "
+                f"{call['risk_count']}, expected {expected}"
+            )
+
+
+def test_non_palindromic_snps_still_strand_flip():
+    """rs4988235 is C/T against G/A, so flipping is unambiguous and still needed."""
+    panel = load_panel()
+    for genotype in ("CC", "GG"):          # the same call on opposite strands
+        call = extract_snp_genotypes({"rs4988235": genotype}, panel)["rs4988235"]
+        assert call["risk_count"] == 2, f"{genotype} should give 2 risk alleles"


### PR DESCRIPTION
## The bug

`extract_snp_genotypes` falls back to a strand flip when the risk allele is not found in the reported genotype:

```python
allele_matched = risk_allele in raw_geno
if not allele_matched:
    flipped = flip_genotype(raw_geno)
    if risk_allele in flipped:
        norm = flipped
        allele_matched = True
```

For a **palindromic** (A/T or C/G) SNP, flipping yields the other allele of the same pair — so the flip *always* succeeds, and a call with **zero** risk alleles becomes one with **two**.

At `rs9939609` (FTO, ref `T`, risk `A`), a `TT` call — no risk alleles — was normalised to `AA` and scored 2 of 2.

## Scope

Three panel entries are palindromic:

| SNP | Gene | ref/risk | Domain |
|---|---|---|---|
| `rs9939609` | FTO | T/A | carbohydrate |
| `rs12934922` | BCMO1 | A/T | vitamin A |
| `rs1801282` | PPARG | C/G | fat metabolism |

Before the fix, every homozygous-reference call at these three scored maximum risk:

```
rs12934922  BCMO1  A/T  hom-ref AA -> risk_count=2   *** INVERTED ***
rs9939609   FTO    T/A  hom-ref TT -> risk_count=2   *** INVERTED ***
rs1801282   PPARG  C/G  hom-ref CC -> risk_count=2   *** INVERTED ***
```

The A allele at `rs9939609` runs around 40% in European populations, so roughly **a third of users are `TT`** and every one was reported at maximum FTO risk. **Results for these three SNPs change in every report generated before this fix.**

## The fix

`is_ambiguous()` already exists in this module for exactly this case — **defined and never called**. It is now consulted. Palindromic SNPs skip the flip and fall through to the existing homozygous-reference branch, which already returns `status: "found"` with `risk_count: 0`.

Strand cannot be resolved from a genotype alone for these SNPs. Without allele-frequency context, trusting the alleles as reported is the only safe convention.

Flipping is **unchanged** for the other 25 SNPs, where it is unambiguous and necessary — `rs4988235` is C/T against G/A and still resolves on either strand.

## After

```
rs12934922  AA risk_count=0 | AT risk_count=1 | TT risk_count=2
rs9939609   TT risk_count=0 | TA risk_count=1 | AA risk_count=2
rs1801282   CC risk_count=0 | CG risk_count=1 | GG risk_count=2
rs4988235   GG risk_count=2   (non-palindromic flip still works)
```

## Testing

24 existing nutrigx tests pass, plus 2 new ones covering all three genotypes at each palindromic SNP and confirming legitimate flipping is unaffected.

## Context

Found while reviewing this skill for improvements to contribute back, having already opened #426, #427, #428 and #430. The same dead `is_ambiguous()` and the same inversion were present in [drdaviddelorenzo/nutrigenomics](https://github.com/drdaviddelorenzo/nutrigenomics), fixed there in 0.3.10.

Independent of the other PRs — it touches only `extract_genotypes.py` and the test file.

Optionally, calls could also carry a `strand_ambiguous` flag so a report can qualify these three SNPs; I left that out to keep the diff minimal, but happy to add it.