### PR TITLE
fix(mendelian-randomisation): estimators say when they do not apply; weighted mode and Steiger follow the cited methods term by term

### DIFF
--- a/skills/mendelian-randomisation/SKILL.md
+++ b/skills/mendelian-randomisation/SKILL.md
@@ -116,7 +116,7 @@ You are **Mendelian Randomisation**, a specialised ClawBio agent for causal infe
 
 | Format | Extension | Required Fields | Example |
 |--------|-----------|-----------------|---------|
-| Harmonised instruments JSON | `.json` | SNP, effect_allele, other_allele, eaf, beta_exposure, se_exposure, pval_exposure, beta_outcome, se_outcome, pval_outcome | `demo_instruments.json` |
+| Harmonised instruments JSON | `.json` | SNP, effect_allele, other_allele, eaf, beta_exposure, se_exposure, pval_exposure, beta_outcome, se_outcome, pval_outcome; optional `n_exposure` / `n_outcome` (sample sizes, needed for a Steiger p-value) | `demo_instruments.json` |
 
 ## Workflow
 
@@ -154,14 +154,15 @@ Expected output: A full MR report for 30 synthetic BMI → T2D instruments showi
 
 1. **IVW**: beta = sum(w * bx * by) / sum(w * bx²), with multiplicative random-effects variance inflation (Burgess et al., 2013)
 2. **MR-Egger**: Weighted linear regression of by on bx with intercept; slope = causal estimate, intercept = pleiotropy (Bowden et al., 2015). Reported as **not applicable**, with a stated reason, when it is undefined on the given instruments: fewer than 3 of them (it fits two parameters, so below 3 there is no residual degree of freedom), or exposure effects too close to identical for the slope to be identified. Never a number in those cases.
-3. **Weighted Median**: Median of Wald ratios weighted by inverse-variance; consistent when ≥50% weight from valid instruments (Bowden et al., 2016)
-4. **Weighted Mode**: Kernel density mode of weighted Wald ratios (Hartwig et al., 2017)
+3. **Weighted Median**: Median of Wald ratios weighted by inverse-variance; consistent when ≥50% weight from valid instruments (Bowden et al., 2016, doi:10.1002/gepi.21965; PMID 27061298)
+4. **Weighted Mode**: Kernel density mode of weighted Wald ratios, with a bandwidth proportional to the spread of the ratios (`phi` x their standard deviation) and a bootstrapped standard error (Hartwig et al., 2017)
 
 **Key thresholds**:
 - F-statistic > 10 for instrument strength (Staiger & Stock, 1997)
 - I²_GX > 0.9 for MR-Egger validity; SIMEX recommended below (Bowden et al., 2016)
 - Cochran's Q P < 0.05 indicates heterogeneity
 - Egger intercept P < 0.05 indicates directional pleiotropy
+- Steiger directionality is computed from z-statistics, so it does not depend on the units the traits are reported in; supply `n_exposure` and `n_outcome` per instrument for a p-value, without them only the direction is reported
 - MR-Egger needs >= 3 instruments and at least two distinct exposure effects; below either it is not applicable rather than imprecise
 
 ## Example Output

--- a/skills/mendelian-randomisation/SKILL.md
+++ b/skills/mendelian-randomisation/SKILL.md
@@ -153,7 +153,7 @@ Expected output: A full MR report for 30 synthetic BMI → T2D instruments showi
 ## Algorithm / Methodology
 
 1. **IVW**: beta = sum(w * bx * by) / sum(w * bx²), with multiplicative random-effects variance inflation (Burgess et al., 2013)
-2. **MR-Egger**: Weighted linear regression of by on bx with intercept; slope = causal estimate, intercept = pleiotropy (Bowden et al., 2015)
+2. **MR-Egger**: Weighted linear regression of by on bx with intercept; slope = causal estimate, intercept = pleiotropy (Bowden et al., 2015). Reported as **not applicable**, with a stated reason, when it is undefined on the given instruments: fewer than 3 of them (it fits two parameters, so below 3 there is no residual degree of freedom), or exposure effects too close to identical for the slope to be identified. Never a number in those cases.
 3. **Weighted Median**: Median of Wald ratios weighted by inverse-variance; consistent when ≥50% weight from valid instruments (Bowden et al., 2016)
 4. **Weighted Mode**: Kernel density mode of weighted Wald ratios (Hartwig et al., 2017)
 
@@ -162,6 +162,7 @@ Expected output: A full MR report for 30 synthetic BMI → T2D instruments showi
 - I²_GX > 0.9 for MR-Egger validity; SIMEX recommended below (Bowden et al., 2016)
 - Cochran's Q P < 0.05 indicates heterogeneity
 - Egger intercept P < 0.05 indicates directional pleiotropy
+- MR-Egger needs >= 3 instruments and at least two distinct exposure effects; below either it is not applicable rather than imprecise
 
 ## Example Output
 
@@ -255,7 +256,7 @@ The agent dispatches and explains. The skill (Python) executes. The agent must N
 
 **Chaining contract**:
 - **Input**: JSON with `instruments` array; each instrument has `SNP`, `beta_exposure`, `se_exposure`, `pval_exposure`, `beta_outcome`, `se_outcome`, `pval_outcome`, `effect_allele`, `other_allele`, `eaf`, `f_statistic`
-- **Output**: `result.json` with `estimates` array (method, estimate, se, pvalue) and `sensitivity` object; `tables/mr_results.tsv` for downstream consumption
+- **Output**: `result.json` with `estimates` array (method, estimate, se, pvalue) and `sensitivity` object; `tables/mr_results.tsv` for downstream consumption. An estimator that does not apply appears as `{"method", "applicable": false, "reason", "n_snps"}` with no numeric fields, and as `not_applicable` in every numeric column of the TSV plus a `note` column. `result.json` is written with `allow_nan=False`, so it is always valid JSON per RFC 8259 or it is not written at all.
 
 ## Maintenance
 

--- a/skills/mendelian-randomisation/SKILL.md
+++ b/skills/mendelian-randomisation/SKILL.md
@@ -155,7 +155,7 @@ Expected output: A full MR report for 30 synthetic BMI → T2D instruments showi
 1. **IVW**: beta = sum(w * bx * by) / sum(w * bx²), with multiplicative random-effects variance inflation (Burgess et al., 2013)
 2. **MR-Egger**: Weighted linear regression of by on bx with intercept; slope = causal estimate, intercept = pleiotropy (Bowden et al., 2015). Reported as **not applicable**, with a stated reason, when it is undefined on the given instruments: fewer than 3 of them (it fits two parameters, so below 3 there is no residual degree of freedom), or exposure effects too close to identical for the slope to be identified. Never a number in those cases.
 3. **Weighted Median**: Median of Wald ratios weighted by inverse-variance; consistent when ≥50% weight from valid instruments (Bowden et al., 2016, doi:10.1002/gepi.21965; PMID 27061298)
-4. **Weighted Mode**: Kernel density mode of weighted Wald ratios, with a bandwidth proportional to the spread of the ratios (`phi` x their standard deviation) and a bootstrapped standard error (Hartwig et al., 2017)
+4. **Weighted Mode**: Mode of the inverse-variance weighted kernel density of the Wald ratios, bandwidth `phi` x the modified Silverman rule `0.9 min(sd, 1.4826 mad) / L^(1/5)`, standard error from a parametric bootstrap (Hartwig et al., 2017, doi:10.1093/ije/dyx102; PMID 29040600; as implemented in TwoSampleMR `mr_weighted_mode`)
 
 **Key thresholds**:
 - F-statistic > 10 for instrument strength (Staiger & Stock, 1997)
@@ -163,7 +163,7 @@ Expected output: A full MR report for 30 synthetic BMI → T2D instruments showi
 - Cochran's Q P < 0.05 indicates heterogeneity
 - Egger intercept P < 0.05 indicates directional pleiotropy
 - Steiger directionality is computed from z-statistics, so it does not depend on the units the traits are reported in; supply `n_exposure` and `n_outcome` per instrument for a p-value, without them only the direction is reported
-- MR-Egger needs >= 3 instruments and at least two distinct exposure effects; below either it is not applicable rather than imprecise
+- MR-Egger, weighted median and weighted mode each need >= 3 instruments (MR-Egger also needs at least two distinct exposure effects); below that each is reported as not applicable rather than as a number. IVW is defined at n = 1, where it is the single Wald ratio
 
 ## Example Output
 
@@ -181,7 +181,7 @@ Expected output: A full MR report for 30 synthetic BMI → T2D instruments showi
 | IVW | 0.5979 | 0.0369 | [0.5255, 0.6702] | 5.17e-59 |
 | MR-Egger | 0.5989 | 0.0391 | [0.5223, 0.6756] | 6.62e-53 |
 | Weighted Median | 0.6001 | 0.0469 | [0.5081, 0.6921] | 2.07e-37 |
-| Weighted Mode | 0.5989 | 0.0144 | [0.5708, 0.6271] | 0.00e+00 |
+| Weighted Mode | 0.6031 | 0.0705 | [0.4648, 0.7413] | 2.03e-09 |
 
 ## Sensitivity Analysis
 
@@ -190,7 +190,7 @@ Expected output: A full MR report for 30 synthetic BMI → T2D instruments showi
 | Cochran's Q | 0.73 (P=1.00) | No heterogeneity |
 | Egger intercept | 0.0001 (P=0.93) | No pleiotropy |
 | Mean F-statistic | 70.6 | Strong instruments |
-| Steiger direction | Correct (P<0.001) | Confirmed |
+| Steiger direction | Correct (P not computed: demo instruments carry no sample sizes) | Confirmed |
 
 *ClawBio is a research tool. Not a medical device.*
 ```
@@ -232,6 +232,8 @@ output_directory/
 
 - **Ignoring MR-Egger intercept**: You will want to report a significant Egger intercept alongside a significant IVW and claim "robust causal evidence." Do not. A significant intercept means directional pleiotropy is present. If Egger intercept P < 0.05, the IVW estimate is biased and the Egger slope should be preferred. The skill's report narrative explicitly flags this.
 
+- **Reading a not-applicable estimator as a failure**: You will want to treat a `not_applicable` row as the run having broken. Do not. Below 3 instruments none of MR-Egger, weighted median or weighted mode is defined (and MR-Egger also needs two distinct exposure effects to identify a slope), so each is reported as undefined rather than imprecise: in `result.json` (`"applicable": false` with a `reason`, no numeric fields), in `mr_results.tsv` (`not_applicable` in every numeric column plus a `note`) and in the report, which then says the IVW estimate stands alone. A consumer that expects a number in every estimate row must check `applicable` first.
+
 ## Safety
 
 - **Local-first**: Demo mode is fully offline with cached data. Live mode contacts IEU OpenGWAS API (public, unauthenticated) for summary statistics only — no patient data uploaded
@@ -267,11 +269,11 @@ The agent dispatches and explains. The skill (Python) executes. The agent must N
 
 ## Citations
 
-- [Burgess et al. (2013)](https://pubmed.ncbi.nlm.nih.gov/23569189/) — IVW method. *Genet Epidemiol* 37:658–665
+- [Burgess et al. (2013)](https://pubmed.ncbi.nlm.nih.gov/24114802/) — IVW method. *Genet Epidemiol* 37:658–665
 - [Bowden et al. (2015)](https://pubmed.ncbi.nlm.nih.gov/26050253/) — MR-Egger. *Int J Epidemiol* 44:512–525
-- [Bowden et al. (2016)](https://pubmed.ncbi.nlm.nih.gov/26892547/) — Weighted median. *Genet Epidemiol* 40:304–314
+- [Bowden et al. (2016)](https://pubmed.ncbi.nlm.nih.gov/27061298/) — Weighted median. *Genet Epidemiol* 40:304–314
 - [Hartwig et al. (2017)](https://pubmed.ncbi.nlm.nih.gov/29040600/) — Weighted mode. *Int J Epidemiol* 46:1985–1998
 - [Verbanck et al. (2018)](https://pubmed.ncbi.nlm.nih.gov/29686387/) — MR-PRESSO. *Nature Genetics* 50:693–698
-- [Hemani et al. (2017)](https://pubmed.ncbi.nlm.nih.gov/28877894/) — Steiger test. *PLOS Genetics* 13:e1007081
-- [Skrivankova et al. (2021)](https://pubmed.ncbi.nlm.nih.gov/34698778/) — STROBE-MR. *BMJ* 375:n2233
+- [Hemani et al. (2017)](https://pubmed.ncbi.nlm.nih.gov/29149188/) — Steiger test. *PLOS Genetics* 13:e1007081
+- [Skrivankova et al. (2021)](https://pubmed.ncbi.nlm.nih.gov/34702754/) — STROBE-MR. *BMJ* 375:n2233
 - [Staiger & Stock (1997)](https://doi.org/10.2307/2171753) — Weak instruments. *Econometrica* 65:557–586

--- a/skills/mendelian-randomisation/mendelian_randomisation.py
+++ b/skills/mendelian-randomisation/mendelian_randomisation.py
@@ -78,10 +78,14 @@ class Instrument:
         return self.f_statistic < MIN_F_STAT
 
 
-# MR-Egger needs at least this many instruments to be defined: it fits a slope AND an
-# intercept, so at n < 3 there is no residual degree of freedom and no dispersion to
-# estimate, however well-conditioned the data is.
-MIN_EGGER_INSTRUMENTS = 3
+# The three sensitivity estimators need at least this many instruments. MR-Egger fits
+# a slope AND an intercept, so below 3 there is no residual degree of freedom; the
+# weighted median and weighted mode are order statistics of the per-SNP ratios, and
+# TwoSampleMR (Hemani et al. 2018, the reference implementation of all three) returns
+# NA for each of them below 3 SNPs. IVW is the one estimator defined at n=1, where it
+# reduces to the single Wald ratio.
+MIN_SENSITIVITY_INSTRUMENTS = 3
+MIN_EGGER_INSTRUMENTS = MIN_SENSITIVITY_INSTRUMENTS  # kept for callers that import it
 
 # Dimensionless conditioning floor for the Egger slope, replacing an absolute one.
 # rel = Var_w(bx) / E_w[bx^2] lies in [0, 1] and is invariant to the units of the data.
@@ -296,7 +300,17 @@ def mr_egger(instruments: list[Instrument]) -> tuple[MREstimate, float, float, f
 
 
 def weighted_median(instruments: list[Instrument], n_boot: int = 1000) -> MREstimate:
-    """Weighted median estimator (Bowden et al., 2016)."""
+    """Weighted median estimator (Bowden et al., 2016).
+
+    Not applicable below `MIN_SENSITIVITY_INSTRUMENTS`: the median of one or two ratios
+    is not a robust estimator of anything, and reporting it alongside IVW at n=1 let the
+    report certify a single Wald ratio as "consistent across methods".
+    """
+    if len(instruments) < MIN_SENSITIVITY_INSTRUMENTS:
+        return MREstimate.not_applicable(
+            "Weighted Median", len(instruments),
+            f"Weighted median requires at least {MIN_SENSITIVITY_INSTRUMENTS} instruments; "
+            f"this analysis has {len(instruments)}")
     bx = np.array([i.beta_exposure for i in instruments])
     by = np.array([i.beta_outcome for i in instruments])
     sy = np.array([i.se_outcome for i in instruments])
@@ -333,12 +347,29 @@ def weighted_median(instruments: list[Instrument], n_boot: int = 1000) -> MREsti
     )
 
 
+def _mad(x: np.ndarray) -> float:
+    """Median absolute deviation, scaled by 1.4826 for consistency with the SD under
+    normality (the constant R's `mad()` applies by default)."""
+    med = float(np.median(x))
+    return 1.4826 * float(np.median(np.abs(x - med)))
+
+
+def mbe_bandwidth(ratios: np.ndarray, phi: float) -> float:
+    """`h = phi * s`, with `s` the modified Silverman rule Hartwig et al. 2017 eq. 7 use:
+    `s = 0.9 * min(sd, 1.4826 * mad) / L^(1/5)`, floored at 1e-8 as in the reference
+    implementation so a set of identical ratios still has a width."""
+    sd = float(np.std(ratios, ddof=1)) if len(ratios) > 1 else 0.0
+    s = 0.9 * min(sd, _mad(ratios)) / len(ratios) ** 0.2
+    return max(1e-8, s * phi)
+
+
 def _weighted_mode_point(ratios: np.ndarray, weights: np.ndarray,
                          bandwidth: float) -> float:
-    """The mode of the weighted kernel density over the ratios."""
+    """The mode of the weighted normal-kernel density over the ratios (Hartwig et al.
+    2017 eq. 6), with `weights` already standardised to sum to 1."""
     span = float(np.max(ratios) - np.min(ratios))
-    pad = max(span, bandwidth) if span or bandwidth else 1.0
-    x_grid = np.linspace(float(np.min(ratios)) - pad, float(np.max(ratios)) + pad, 1000)
+    pad = max(span, 3.0 * bandwidth) if span or bandwidth else 1.0
+    x_grid = np.linspace(float(np.min(ratios)) - pad, float(np.max(ratios)) + pad, 2000)
     density = np.zeros_like(x_grid)
     for r, w in zip(ratios, weights):
         density += w * stats.norm.pdf(x_grid, loc=r, scale=bandwidth)
@@ -353,19 +384,28 @@ def weighted_mode(instruments: list[Instrument], phi: float = 1.0,
     (doi:10.1093/ije/dyx102; PMID 29040600), which specifies both a bandwidth
     proportional to the spread of the ratios and a bootstrapped standard error.
 
-    Two changes from a plain kernel mode, both of which the reference method specifies
-    and neither of which is cosmetic.
+    This follows the paper's weighted MBE and its reference implementation
+    (TwoSampleMR `mr_weighted_mode`, Hemani et al. 2018) term by term:
 
-    THE BANDWIDTH IS PROPORTIONAL TO THE SPREAD OF THE RATIOS, not an absolute constant.
-    It used to default to 0.5 whatever the data looked like. On instruments whose ratios
-    have a standard deviation of 0.28 -- an ordinary MR scale -- a bandwidth of 0.5 is
-    nearly twice the entire spread, so the kernels merge into one blob and the "mode"
-    slides onto the weighted mean: measured 0.5469 against an IVW estimate of 0.5281,
-    while the same data at a bandwidth of 0.1 gives 0.6679. An estimator whose whole
-    purpose is to disagree with the mean when most instruments agree with each other
-    cannot have a smoothing width that swamps the disagreement. `phi` now scales the
-    ratios' own standard deviation, so the estimator is invariant to the units of the
-    data in the way the mean and the median already were.
+    - ratio SEs by the delta method, `sqrt(sy^2/bx^2 + by^2*sx^2/bx^4)` (the
+      "not assuming NOME" column the reference uses for the weighted mode);
+    - standardised inverse-variance weights, eq. 5: `w_j = se_j^-2 / sum(se^-2)`;
+    - bandwidth `h = phi * s` with the modified Silverman rule, eq. 7:
+      `s = 0.9 * min(sd, 1.4826*mad) / L^(1/5)`, and the reference's `phi = 1`;
+    - standard error = 1.4826 x the median absolute deviation of a parametric
+      bootstrap of the ratios (each ratio redrawn from N(ratio, se_ratio)), the
+      bandwidth recomputed on every draw;
+    - p-value from a t distribution on L - 1 degrees of freedom, as the reference does.
+
+    Why this replaces what was here. THE BANDWIDTH WAS AN ABSOLUTE 0.5 whatever the data
+    looked like. On instruments whose ratios have a standard deviation of 0.28 -- an
+    ordinary MR scale -- 0.5 is nearly twice the entire spread, so the kernels merge into
+    one blob and the "mode" slides onto the weighted mean: measured 0.5469 against an
+    IVW estimate of 0.5281, while the same data at a bandwidth of 0.1 gives 0.6679. An
+    estimator whose whole purpose is to disagree with the mean when most instruments
+    agree with each other cannot have a smoothing width that swamps the disagreement.
+    A data-scaled bandwidth also makes the estimator invariant to the units of the data,
+    as the mean and the median already were.
 
     THE STANDARD ERROR IS A BOOTSTRAP. The previous `2 / sum(|bx_i|/sy_i)` is a function
     of the instrument count and the outcome standard errors and NOTHING ELSE -- it does
@@ -376,37 +416,41 @@ def weighted_mode(instruments: list[Instrument], phi: float = 1.0,
     estimate was least stable -- at the widest dispersion the mode itself moved from
     0.9673 to 0.3958 between two samples whose SEs were 0.0208 and 0.0043.
 
-    The bootstrap resamples each outcome effect from its own reported uncertainty and
-    re-derives the mode, so the SE reflects how much the mode actually moves.
+    The bootstrap redraws each ratio from its own reported uncertainty and re-derives
+    the mode, so the SE reflects how much the mode actually moves.
+
+    The weights were also `1/se`; the paper's eq. 5 and the reference implementation use
+    `1/se^2`. Corrected here, since the function now claims to be that estimator.
     """
+    n = len(instruments)
+    if n < MIN_SENSITIVITY_INSTRUMENTS:
+        return MREstimate.not_applicable(
+            "Weighted Mode", n,
+            f"Weighted mode requires at least {MIN_SENSITIVITY_INSTRUMENTS} instruments; "
+            f"this analysis has {n}")
     bx = np.array([i.beta_exposure for i in instruments])
     by = np.array([i.beta_outcome for i in instruments])
+    sx = np.array([i.se_exposure for i in instruments])
     sy = np.array([i.se_outcome for i in instruments])
 
     ratios = by / bx
-    se_ratios = sy / np.abs(bx)
-    weights = 1.0 / se_ratios
+    # Delta-method ratio SE, second order ("not assuming NOME"), as the reference uses
+    # for the weighted mode; the NOME variant drops the second term.
+    se_ratios = np.sqrt(sy ** 2 / bx ** 2 + by ** 2 * sx ** 2 / bx ** 4)
+    inv_var = 1.0 / se_ratios ** 2
+    weights = inv_var / np.sum(inv_var)
 
-    sd_ratios = float(np.std(ratios))
-    # A degenerate spread (every ratio identical) has no scale to take a fraction of;
-    # fall back to the ratios' own magnitude so the kernel still has a width.
-    bandwidth = phi * sd_ratios if sd_ratios > 0 else max(
-        float(np.mean(np.abs(ratios))) * 0.1, 1e-6)
-
-    beta_mode = _weighted_mode_point(ratios, weights, bandwidth)
+    beta_mode = _weighted_mode_point(ratios, weights, mbe_bandwidth(ratios, phi))
 
     rng = np.random.default_rng(seed)
     draws = np.empty(n_boot)
     for b in range(n_boot):
-        by_b = rng.normal(by, sy)
-        ratios_b = by_b / bx
-        sd_b = float(np.std(ratios_b))
-        bw_b = phi * sd_b if sd_b > 0 else bandwidth
-        draws[b] = _weighted_mode_point(ratios_b, weights, bw_b)
-    se_mode = float(np.std(draws, ddof=1))
+        ratios_b = rng.normal(ratios, se_ratios)
+        draws[b] = _weighted_mode_point(ratios_b, weights, mbe_bandwidth(ratios_b, phi))
+    se_mode = _mad(draws)
 
-    z = beta_mode / se_mode if se_mode > 0 else 0.0
-    pval = 2 * stats.norm.sf(abs(z))
+    t_stat = beta_mode / se_mode if se_mode > 0 else 0.0
+    pval = float(2 * stats.t.sf(abs(t_stat), df=n - 1))
 
     return MREstimate(
         method="Weighted Mode", estimate=beta_mode, se=se_mode,
@@ -450,14 +494,19 @@ def steiger_test(instruments: list[Instrument]) -> tuple[bool, float | None, str
     p astronomically small on BOTH sides, so it reported near-certainty in opposite
     directions depending on a unit choice.
 
-    `r2 = z^2 / (z^2 + n)` is the standard conversion for a continuous trait, and z is
-    invariant to the units of beta because the standard error carries the same units.
+    `r2 = z^2 / (z^2 + n - 2)` is the conversion for a continuous trait (the F statistic
+    of a one-predictor regression on n - 2 residual degrees of freedom; TwoSampleMR
+    `get_r_from_bsen`), and z is invariant to the units of beta because the standard
+    error carries the same units.
 
     Sample sizes are OPTIONAL, and what is reported depends on what is available:
 
     - both present: a variance explained per side, and a p-value from the Fisher
       z-transform difference of two INDEPENDENT correlations -- which is what two-sample
       MR has by construction, the exposure and outcome coming from different studies.
+      (The paper states the one-sample form, Steiger's Z for correlated correlations
+      within one population; its two-sample implementation, TwoSampleMR `mr_steiger`,
+      uses the independent-samples test, and so does this.)
     - absent: with equal sample sizes the comparison reduces to |z_exposure| >
       |z_outcome|, so the DIRECTION is still well defined and still unit-free. The
       p-value is not: it is returned as None with the assumption stated in `note`,
@@ -480,8 +529,8 @@ def steiger_test(instruments: list[Instrument]) -> tuple[bool, float | None, str
             "under the assumption that the exposure and outcome studies are of "
             "comparable size; no p-value is computed")
 
-    r2_exp = float(np.sum(z_exp ** 2 / (z_exp ** 2 + np.array(n_exp, dtype=float))))
-    r2_out = float(np.sum(z_out ** 2 / (z_out ** 2 + np.array(n_out, dtype=float))))
+    r2_exp = float(np.sum(z_exp ** 2 / (z_exp ** 2 + np.array(n_exp, dtype=float) - 2.0)))
+    r2_out = float(np.sum(z_out ** 2 / (z_out ** 2 + np.array(n_out, dtype=float) - 2.0)))
     correct = r2_exp > r2_out
 
     # Fisher z on each side, then the difference of two independent correlations.
@@ -489,7 +538,9 @@ def steiger_test(instruments: list[Instrument]) -> tuple[bool, float | None, str
     # instrument set can reach after summing.
     r_exp = min(math.sqrt(max(r2_exp, 0.0)), 1.0 - 1e-12)
     r_out = min(math.sqrt(max(r2_out, 0.0)), 1.0 - 1e-12)
-    n1, n2 = float(min(n_exp)), float(min(n_out))
+    # Per-instrument sample sizes are aggregated by their mean, as TwoSampleMR
+    # `mr_steiger` does (`n = mean(n_exp), n2 = mean(n_out)`).
+    n1, n2 = float(np.mean(n_exp)), float(np.mean(n_out))
     se = math.sqrt(1.0 / (n1 - 3.0) + 1.0 / (n2 - 3.0))
     z_stat = (math.atanh(r_exp) - math.atanh(r_out)) / se
     p = float(2 * stats.norm.sf(abs(z_stat)))

--- a/skills/mendelian-randomisation/mendelian_randomisation.py
+++ b/skills/mendelian-randomisation/mendelian_randomisation.py
@@ -72,6 +72,18 @@ class Instrument:
         return self.f_statistic < MIN_F_STAT
 
 
+# MR-Egger needs at least this many instruments to be defined: it fits a slope AND an
+# intercept, so at n < 3 there is no residual degree of freedom and no dispersion to
+# estimate, however well-conditioned the data is.
+MIN_EGGER_INSTRUMENTS = 3
+
+# Dimensionless conditioning floor for the Egger slope, replacing an absolute one.
+# rel = Var_w(bx) / E_w[bx^2] lies in [0, 1] and is invariant to the units of the data.
+# Below sqrt(machine epsilon) the Egger SE is inflated by more than ~8,000x, so the
+# estimate is uninformative rather than merely imprecise.
+EGGER_MIN_RELATIVE_VARIANCE = math.sqrt(sys.float_info.epsilon)  # ~1.49e-8
+
+
 @dataclass
 class MREstimate:
     method: str
@@ -81,6 +93,26 @@ class MREstimate:
     ci_upper: float
     pvalue: float
     n_snps: int
+    # An estimator can be UNDEFINED on a given instrument set rather than merely
+    # imprecise. Without somewhere to say that, the only options are to raise (which
+    # discards the estimates already computed correctly) or to emit a number that reads
+    # exactly like a result. `applicable=False` carries `reason` instead, and every
+    # consumer below skips the row and prints the reason in its place.
+    applicable: bool = True
+    reason: str = ""
+
+    @classmethod
+    def not_applicable(cls, method: str, n_snps: int, reason: str) -> "MREstimate":
+        """An estimator that does not apply to this instrument set.
+
+        The numeric fields are NaN on purpose: any consumer that ignores `applicable`
+        and formats them anyway produces a visible `nan` rather than a plausible number,
+        and the JSON writer refuses to serialise them at all.
+        """
+        return cls(method=method, estimate=float("nan"), se=float("nan"),
+                   ci_lower=float("nan"), ci_upper=float("nan"),
+                   pvalue=float("nan"), n_snps=n_snps,
+                   applicable=False, reason=reason)
 
 
 @dataclass
@@ -129,8 +161,45 @@ def ivw(instruments: list[Instrument]) -> MREstimate:
     )
 
 
+def egger_weighted_dispersion(w: np.ndarray, bx: np.ndarray) -> float:
+    """`sum_w * sum_i w_i (bx_i - xbar_w)^2` -- the MR-Egger slope denominator.
+
+    Its own function so the property it exists for can be tested directly. That
+    property is STRUCTURAL: every term is a product of non-negative numbers, so the
+    result cannot be negative in IEEE-754, and it is exactly zero precisely when every
+    `bx` is equal.
+
+    The algebraically identical expanded form, `sum_w*sum_wbx2 - sum_wbx**2`, has
+    neither guarantee. It is a difference of two large nearly-equal quantities, so as
+    the exposure effects converge it collapses onto a cancellation remainder whose sign
+    is arbitrary -- and a negative one reaches `math.sqrt` as a domain error. That is
+    not visible through `mr_egger` once the conditioning check is in place, because the
+    check refuses those inputs anyway; it is visible here.
+    """
+    sum_w = np.sum(w)
+    xbar_w = np.sum(w * bx) / sum_w
+    return float(sum_w * np.sum(w * (bx - xbar_w) ** 2))
+
+
 def mr_egger(instruments: list[Instrument]) -> tuple[MREstimate, float, float, float]:
-    """MR-Egger regression. Returns (estimate, intercept, intercept_se, intercept_p)."""
+    """MR-Egger regression. Returns (estimate, intercept, intercept_se, intercept_p).
+
+    Two INDEPENDENT conditions have to hold, and neither implies the other:
+
+    STATISTICAL -- at least `MIN_EGGER_INSTRUMENTS`. Egger fits two parameters, so below
+    three there is no residual degree of freedom, no matter how clean the data is.
+
+    NUMERICAL -- at least two distinct `beta_exposure` values, checked as a dimensionless
+    ratio. The slope is unidentified when every `bx` coincides, and that is not an n < 3
+    problem: with a relative spread around 1e-10 the shipped code raised on roughly a
+    third of well-sized inputs at n = 5 and n = 10.
+
+    Below either, the estimator does not apply, and it says so instead of returning a
+    number. Returning one was the failure this replaces: at n = 1, over 5,000 draws on
+    each of two effect-size distributions, the old code returned a finite slope with a
+    median SE of 2.1e+07 in ~27% of cases, raised `math domain error` in ~27%, and hit
+    its own guard in ~46% -- a one-ulp sign coin flip rather than a property of the data.
+    """
     bx = np.array([i.beta_exposure for i in instruments])
     by = np.array([i.beta_outcome for i in instruments])
     sy = np.array([i.se_outcome for i in instruments])
@@ -138,22 +207,64 @@ def mr_egger(instruments: list[Instrument]) -> tuple[MREstimate, float, float, f
     w = 1.0 / (sy ** 2)
     n = len(instruments)
 
+    if n < MIN_EGGER_INSTRUMENTS:
+        return (
+            MREstimate.not_applicable(
+                "MR-Egger", n,
+                f"MR-Egger requires at least {MIN_EGGER_INSTRUMENTS} instruments "
+                f"(it fits a slope and an intercept); this analysis has {n}"),
+            float("nan"), float("nan"), float("nan"),
+        )
+
     sum_w = np.sum(w)
     sum_wbx = np.sum(w * bx)
     sum_wbx2 = np.sum(w * bx ** 2)
     sum_wby = np.sum(w * by)
-    sum_wbxby = np.sum(w * bx * by)
 
-    denom = sum_w * sum_wbx2 - sum_wbx ** 2
-    if abs(denom) < 1e-300:
-        return MREstimate("MR-Egger", 0, 1, -1.96, 1.96, 1.0, n), 0.0, 1.0, 1.0
+    # Centered (Lagrange) form: denom = sum_w * sum_i w_i (bx_i - xbar_w)^2, a sum of
+    # non-negative terms that is zero exactly when every bx is equal. The algebraically
+    # identical expanded form, sum_w*sum_wbx2 - sum_wbx**2, is a difference of two large
+    # nearly-equal quantities, so in floating point it lands on a cancellation remainder
+    # whose SIGN is arbitrary -- which is where the negative values under the square root
+    # came from. The NUMERATOR is centered for the same reason: centering the denominator
+    # alone fixes the sign and leaves the slope's accuracy degrading as the spread
+    # narrows.
+    xbar_w = sum_wbx / sum_w
+    ybar_w = sum_wby / sum_w
+    dx = bx - xbar_w
+    denom = egger_weighted_dispersion(w, bx)
+    numer = sum_w * np.sum(w * dx * (by - ybar_w))
 
-    slope = (sum_w * sum_wbxby - sum_wbx * sum_wby) / denom
-    intercept = (sum_wby - slope * sum_wbx) / sum_w
+    # Dimensionless conditioning test. `denom` carries the data's units: rescaling the
+    # outcome alone, which changes the slope but not the conditioning at all, moves it
+    # across hundreds of orders of magnitude, so no absolute threshold can be a criterion.
+    # This ratio is invariant to that rescaling.
+    scale = sum_w * sum_wbx2
+    rel = denom / scale if scale > 0 else 0.0
+    # Written as a negated `>` rather than `rel < threshold` so NaN also fails it. A
+    # comparison against NaN is False either way, and only this direction turns that
+    # into a refusal rather than into passing the check.
+    if not (rel > EGGER_MIN_RELATIVE_VARIANCE):
+        return (
+            MREstimate.not_applicable(
+                "MR-Egger", n,
+                "MR-Egger is not identified on these instruments: their exposure "
+                f"effects are too close to identical (relative variance {rel:.2e}, "
+                f"below {EGGER_MIN_RELATIVE_VARIANCE:.2e}), so the slope has no "
+                "informative standard error"),
+            float("nan"), float("nan"), float("nan"),
+        )
+
+    slope = numer / denom
+    intercept = ybar_w - slope * xbar_w
 
     fitted = intercept + slope * bx
     residuals = by - fitted
-    phi = max(1.0, np.sum(w * residuals ** 2) / (n - 2))
+    # df cannot be <= 0 here, since n >= MIN_EGGER_INSTRUMENTS above. Guarded anyway:
+    # this function is public and directly callable, and that is the difference between
+    # "unreachable from our pipeline" and "cannot happen".
+    df = n - 2
+    phi = 1.0 if df <= 0 else max(1.0, np.sum(w * residuals ** 2) / df)
 
     se_slope = math.sqrt(phi * sum_w / denom)
     se_intercept = math.sqrt(phi * sum_wbx2 / denom)
@@ -333,7 +444,9 @@ def scatter_plot(instruments: list[Instrument], estimates: list[MREstimate], pat
     x_range = np.linspace(min(bx) - 0.01, max(bx) + 0.01, 100)
     colours = {"IVW": "#d32f2f", "MR-Egger": "#ff9800", "Weighted Median": "#4caf50", "Weighted Mode": "#9c27b0"}
     for est in estimates:
-        if est.method in colours:
+        # A not-applicable estimator has no slope to draw; plotting NaN silently omits
+        # the line but still consumes a legend entry, which reads as "drawn at zero".
+        if est.method in colours and est.applicable:
             ax.plot(x_range, est.estimate * x_range, color=colours[est.method],
                     linewidth=1.5, label=f"{est.method} ({est.estimate:.3f})")
 
@@ -465,9 +578,16 @@ def generate_report(
 def _write_mr_table(estimates, path):
     with open(path, "w", newline="") as f:
         w = csv.writer(f, delimiter="\t")
-        w.writerow(["method", "estimate", "se", "ci_lower", "ci_upper", "pvalue", "n_snps"])
+        w.writerow(["method", "estimate", "se", "ci_lower", "ci_upper", "pvalue", "n_snps", "note"])
         for e in estimates:
-            w.writerow([e.method, f"{e.estimate:.6f}", f"{e.se:.6f}", f"{e.ci_lower:.6f}", f"{e.ci_upper:.6f}", f"{e.pvalue:.2e}", e.n_snps])
+            if not e.applicable:
+                # "not_applicable" in every numeric cell, never a formatted NaN: a
+                # spreadsheet renders `nan` in an estimate column as a value someone
+                # will try to read.
+                w.writerow([e.method, "not_applicable", "not_applicable", "not_applicable",
+                            "not_applicable", "not_applicable", e.n_snps, e.reason])
+                continue
+            w.writerow([e.method, f"{e.estimate:.6f}", f"{e.se:.6f}", f"{e.ci_lower:.6f}", f"{e.ci_upper:.6f}", f"{e.pvalue:.2e}", e.n_snps, ""])
 
 
 def _write_sensitivity_table(s, egger_int, egger_p, path):
@@ -475,7 +595,12 @@ def _write_sensitivity_table(s, egger_int, egger_p, path):
         w = csv.writer(f, delimiter="\t")
         w.writerow(["test", "statistic", "pvalue", "interpretation"])
         w.writerow(["Cochran_Q", f"{s.cochran_q:.2f}", f"{s.cochran_q_pvalue:.4f}", "Significant = heterogeneity" if s.cochran_q_pvalue < 0.05 else "No significant heterogeneity"])
-        w.writerow(["Egger_intercept", f"{egger_int:.6f}", f"{egger_p:.4f}", "Significant = directional pleiotropy" if egger_p < 0.05 else "No evidence of directional pleiotropy"])
+        if math.isnan(egger_int) or math.isnan(egger_p):
+            w.writerow(["Egger_intercept", "not_applicable", "not_applicable",
+                        "MR-Egger did not apply to this instrument set, so there is no "
+                        "directional-pleiotropy test"])
+        else:
+            w.writerow(["Egger_intercept", f"{egger_int:.6f}", f"{egger_p:.4f}", "Significant = directional pleiotropy" if egger_p < 0.05 else "No evidence of directional pleiotropy"])
         w.writerow(["Mean_F_statistic", f"{s.mean_f_statistic:.1f}", "N/A", f"{'WEAK' if s.mean_f_statistic < MIN_F_STAT else 'Strong'} instruments"])
         w.writerow(["Min_F_statistic", f"{s.min_f_statistic:.1f}", "N/A", f"{s.n_weak_instruments} weak instruments (F<{MIN_F_STAT})"])
         w.writerow(["I_squared_GX", f"{s.i_squared_gx:.4f}", "N/A", "SIMEX recommended" if s.i_squared_gx < 0.9 else "No SIMEX needed"])
@@ -512,7 +637,10 @@ def _write_report_md(instruments, estimates, sens, egger_int, egger_p, exposure,
         "| Test | Result | P-value | Interpretation |",
         "|------|--------|---------|----------------|",
         f"| Cochran's Q | {sens.cochran_q:.2f} (df={sens.cochran_q_df}) | {sens.cochran_q_pvalue:.4f} | {'Heterogeneity detected' if sens.cochran_q_pvalue < 0.05 else 'No significant heterogeneity'} |",
-        f"| Egger intercept | {egger_int:.4f} | {egger_p:.4f} | {'Directional pleiotropy' if egger_p < 0.05 else 'No directional pleiotropy'} |",
+        (f"| Egger intercept | {egger_int:.4f} | {egger_p:.4f} | "
+         f"{'Directional pleiotropy' if egger_p < 0.05 else 'No directional pleiotropy'} |"
+         if not (math.isnan(egger_int) or math.isnan(egger_p)) else
+         "| Egger intercept | not computed | not computed | MR-Egger did not apply |"),
         f"| Mean F-statistic | {sens.mean_f_statistic:.1f} | — | {'**WARNING: weak instruments**' if sens.mean_f_statistic < MIN_F_STAT else 'Strong instruments'} |",
         f"| Weak instruments (F<{MIN_F_STAT}) | {sens.n_weak_instruments}/{len(instruments)} | — | {'**WARNING**' if sens.n_weak_instruments > 0 else 'None'} |",
         f"| I²_GX | {sens.i_squared_gx:.4f} | — | {'SIMEX correction recommended' if sens.i_squared_gx < 0.9 else 'Adequate'} |",
@@ -529,11 +657,24 @@ def _write_report_md(instruments, estimates, sens, egger_int, egger_p, exposure,
         f"(beta = {estimates[0].estimate:.4f}, 95% CI [{estimates[0].ci_lower:.4f}, {estimates[0].ci_upper:.4f}], P = {estimates[0].pvalue:.2e}). ",
         "",
     ])
-    consistent = all(abs(e.estimate - estimates[0].estimate) < 2 * estimates[0].se for e in estimates[1:])
-    if consistent:
-        lines.append("Sensitivity analyses show consistent estimates across IVW, MR-Egger, weighted median, and weighted mode, supporting a robust causal inference.")
+    # Compare only estimators that PRODUCED an estimate, and name the ones that did not.
+    # A not-applicable row previously entered this comparison as a number, so a two-
+    # instrument run whose Egger SE was infinite still certified the result "robust".
+    comparable = [e for e in estimates[1:] if e.applicable]
+    skipped = [e for e in estimates if not e.applicable]
+    consistent = all(abs(e.estimate - estimates[0].estimate) < 2 * estimates[0].se
+                     for e in comparable)
+    if not comparable:
+        lines.append("No sensitivity estimator applies to this instrument set, so the "
+                     "IVW estimate stands alone and is not corroborated.")
+    elif consistent:
+        names = ", ".join(["IVW"] + [e.method for e in comparable])
+        lines.append(f"Sensitivity analyses show consistent estimates across {names}, "
+                     "supporting a robust causal inference.")
     else:
         lines.append("**Caution**: Estimates differ across methods, suggesting potential violations of MR assumptions. Interpret with care.")
+    for e in skipped:
+        lines.append(f"\n{e.method} was not computed: {e.reason}.")
     lines.extend(["", "---", "", f"*{DISCLAIMER}*", ""])
     (output_dir / "report.md").write_text("\n".join(lines), encoding="utf-8")
 
@@ -546,10 +687,21 @@ def _write_result_json(estimates, sens, egger_int, egger_p, exposure, outcome, o
         "mode": "demo" if demo else "live",
         "exposure": exposure,
         "outcome": outcome,
-        "estimates": [{"method": e.method, "estimate": round(e.estimate, 6), "se": round(e.se, 6), "pvalue": f"{e.pvalue:.2e}", "n_snps": e.n_snps} for e in estimates],
+        "estimates": [
+            {"method": e.method, "estimate": round(e.estimate, 6), "se": round(e.se, 6),
+             "pvalue": f"{e.pvalue:.2e}", "n_snps": e.n_snps}
+            if e.applicable else
+            {"method": e.method, "applicable": False, "reason": e.reason,
+             "n_snps": e.n_snps}
+            for e in estimates
+        ],
         "sensitivity": {
             "cochran_q": round(sens.cochran_q, 2), "cochran_q_p": round(sens.cochran_q_pvalue, 4),
-            "egger_intercept": round(egger_int, 6), "egger_intercept_p": round(egger_p, 4),
+            # None, not NaN: `allow_nan=False` below would otherwise refuse to write the
+            # file at all on exactly the runs this change exists to make well-behaved.
+            # JSON null is the honest encoding of "there is no such test here".
+            "egger_intercept": None if math.isnan(egger_int) else round(egger_int, 6),
+            "egger_intercept_p": None if math.isnan(egger_p) else round(egger_p, 4),
             "mean_f_stat": round(sens.mean_f_statistic, 1),
             "n_weak": sens.n_weak_instruments,
             "i_squared_gx": round(sens.i_squared_gx, 4),
@@ -557,7 +709,13 @@ def _write_result_json(estimates, sens, egger_int, egger_p, exposure, outcome, o
         },
         "disclaimer": DISCLAIMER,
     }
-    (output_dir / "result.json").write_text(json.dumps(result, indent=2), encoding="utf-8")
+    # allow_nan=False: Python emits `Infinity` and `NaN` bare by default, and RFC 8259
+    # has neither, so a strict parser rejects the WHOLE file rather than one field. A
+    # two-instrument run used to write `"se": Infinity` and exit 0. Now any non-finite
+    # anywhere in the document raises here instead of shipping unparseable JSON -- for
+    # every future one, not only this one.
+    (output_dir / "result.json").write_text(
+        json.dumps(result, indent=2, allow_nan=False), encoding="utf-8")
 
 
 def _write_repro(output_dir, ts, demo):

--- a/skills/mendelian-randomisation/mendelian_randomisation.py
+++ b/skills/mendelian-randomisation/mendelian_randomisation.py
@@ -57,6 +57,12 @@ class Instrument:
     se_outcome: float
     pval_outcome: float
     f_statistic: float = 0.0
+    # Sample sizes, optional and read from the input when present. The Steiger
+    # directionality test needs them to express each association as a variance
+    # explained; without them it can still order the two sides, but only under an
+    # assumption it then has to state. See `steiger_test`.
+    n_exposure: int | None = None
+    n_outcome: int | None = None
 
     @property
     def is_palindromic(self) -> bool:
@@ -128,7 +134,10 @@ class SensitivityResults:
     n_weak_instruments: int = 0
     i_squared_gx: float = 0.0
     steiger_correct_direction: bool = True
-    steiger_pvalue: float = 1.0
+    # None when the test could order the two sides but had no basis for a p-value; the
+    # reason is in `steiger_note`, and every writer prints that instead of a number.
+    steiger_pvalue: float | None = None
+    steiger_note: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -183,6 +192,9 @@ def egger_weighted_dispersion(w: np.ndarray, bx: np.ndarray) -> float:
 
 def mr_egger(instruments: list[Instrument]) -> tuple[MREstimate, float, float, float]:
     """MR-Egger regression. Returns (estimate, intercept, intercept_se, intercept_p).
+
+    Bowden J, Davey Smith G, Burgess S 2015, Int J Epidemiol 44(2):512-525
+    (doi:10.1093/ije/dyv080; PMID 26050253).
 
     Two INDEPENDENT conditions have to hold, and neither implies the other:
 
@@ -321,8 +333,52 @@ def weighted_median(instruments: list[Instrument], n_boot: int = 1000) -> MREsti
     )
 
 
-def weighted_mode(instruments: list[Instrument], bandwidth: float = 0.5) -> MREstimate:
-    """Weighted mode estimator (Hartwig et al., 2017)."""
+def _weighted_mode_point(ratios: np.ndarray, weights: np.ndarray,
+                         bandwidth: float) -> float:
+    """The mode of the weighted kernel density over the ratios."""
+    span = float(np.max(ratios) - np.min(ratios))
+    pad = max(span, bandwidth) if span or bandwidth else 1.0
+    x_grid = np.linspace(float(np.min(ratios)) - pad, float(np.max(ratios)) + pad, 1000)
+    density = np.zeros_like(x_grid)
+    for r, w in zip(ratios, weights):
+        density += w * stats.norm.pdf(x_grid, loc=r, scale=bandwidth)
+    return float(x_grid[int(np.argmax(density))])
+
+
+def weighted_mode(instruments: list[Instrument], phi: float = 1.0,
+                  n_boot: int = 1000, seed: int = 0) -> MREstimate:
+    """Weighted mode estimator.
+
+    Hartwig FP, Davey Smith G, Bowden J 2017, Int J Epidemiol 46(6):1985-1998
+    (doi:10.1093/ije/dyx102; PMID 29040600), which specifies both a bandwidth
+    proportional to the spread of the ratios and a bootstrapped standard error.
+
+    Two changes from a plain kernel mode, both of which the reference method specifies
+    and neither of which is cosmetic.
+
+    THE BANDWIDTH IS PROPORTIONAL TO THE SPREAD OF THE RATIOS, not an absolute constant.
+    It used to default to 0.5 whatever the data looked like. On instruments whose ratios
+    have a standard deviation of 0.28 -- an ordinary MR scale -- a bandwidth of 0.5 is
+    nearly twice the entire spread, so the kernels merge into one blob and the "mode"
+    slides onto the weighted mean: measured 0.5469 against an IVW estimate of 0.5281,
+    while the same data at a bandwidth of 0.1 gives 0.6679. An estimator whose whole
+    purpose is to disagree with the mean when most instruments agree with each other
+    cannot have a smoothing width that swamps the disagreement. `phi` now scales the
+    ratios' own standard deviation, so the estimator is invariant to the units of the
+    data in the way the mean and the median already were.
+
+    THE STANDARD ERROR IS A BOOTSTRAP. The previous `2 / sum(|bx_i|/sy_i)` is a function
+    of the instrument count and the outcome standard errors and NOTHING ELSE -- it does
+    not look at the dispersion of the ratios whose mode it is reporting. Measured over
+    ratio standard deviations from 0.0000 to 0.8265, an 800-fold change in how spread
+    out the estimates are, the reported SE did not move at all: 0.02079 at n=10 and
+    0.00429 at n=40 in every case. It was most confident exactly where the point
+    estimate was least stable -- at the widest dispersion the mode itself moved from
+    0.9673 to 0.3958 between two samples whose SEs were 0.0208 and 0.0043.
+
+    The bootstrap resamples each outcome effect from its own reported uncertainty and
+    re-derives the mode, so the SE reflects how much the mode actually moves.
+    """
     bx = np.array([i.beta_exposure for i in instruments])
     by = np.array([i.beta_outcome for i in instruments])
     sy = np.array([i.se_outcome for i in instruments])
@@ -331,14 +387,25 @@ def weighted_mode(instruments: list[Instrument], bandwidth: float = 0.5) -> MREs
     se_ratios = sy / np.abs(bx)
     weights = 1.0 / se_ratios
 
-    x_grid = np.linspace(np.min(ratios) - 1, np.max(ratios) + 1, 1000)
-    density = np.zeros_like(x_grid)
-    for r, w in zip(ratios, weights):
-        density += w * stats.norm.pdf(x_grid, loc=r, scale=bandwidth)
-    beta_mode = float(x_grid[np.argmax(density)])
+    sd_ratios = float(np.std(ratios))
+    # A degenerate spread (every ratio identical) has no scale to take a fraction of;
+    # fall back to the ratios' own magnitude so the kernel still has a width.
+    bandwidth = phi * sd_ratios if sd_ratios > 0 else max(
+        float(np.mean(np.abs(ratios))) * 0.1, 1e-6)
 
-    se_mode = float(1.0 / (np.sum(weights) * 0.5))
-    z = beta_mode / se_mode if se_mode > 0 else 0
+    beta_mode = _weighted_mode_point(ratios, weights, bandwidth)
+
+    rng = np.random.default_rng(seed)
+    draws = np.empty(n_boot)
+    for b in range(n_boot):
+        by_b = rng.normal(by, sy)
+        ratios_b = by_b / bx
+        sd_b = float(np.std(ratios_b))
+        bw_b = phi * sd_b if sd_b > 0 else bandwidth
+        draws[b] = _weighted_mode_point(ratios_b, weights, bw_b)
+    se_mode = float(np.std(draws, ddof=1))
+
+    z = beta_mode / se_mode if se_mode > 0 else 0.0
     pval = 2 * stats.norm.sf(abs(z))
 
     return MREstimate(
@@ -364,18 +431,69 @@ def cochran_q(instruments: list[Instrument], ivw_est: MREstimate) -> tuple[float
     return q, p, df
 
 
-def steiger_test(instruments: list[Instrument]) -> tuple[bool, float]:
-    """Steiger directionality test — checks causal direction."""
-    r2_exp = np.array([2 * i.eaf * (1 - i.eaf) * (i.beta_exposure ** 2) for i in instruments])
-    r2_out = np.array([2 * i.eaf * (1 - i.eaf) * (i.beta_outcome ** 2) for i in instruments])
-    total_r2_exp = float(np.sum(r2_exp))
-    total_r2_out = float(np.sum(r2_out))
-    correct = total_r2_exp > total_r2_out
-    diff = total_r2_exp - total_r2_out
-    se_diff = math.sqrt(total_r2_exp + total_r2_out) * 0.01
-    z = diff / se_diff if se_diff > 0 else 0
-    p = 2 * stats.norm.sf(abs(z))
-    return correct, float(p)
+def steiger_test(instruments: list[Instrument]) -> tuple[bool, float | None, str]:
+    """Steiger directionality test. Returns (correct_direction, p_value_or_None, note).
+
+    Hemani G, Tilling K, Davey Smith G 2017, PLoS Genet 13(11):e1007081
+    (doi:10.1371/journal.pgen.1007081; PMID 29149188).
+
+    Compares how much variance the instruments explain in the exposure against how much
+    they explain in the outcome; more in the exposure supports exposure -> outcome.
+
+    THE VARIANCE EXPLAINED IS COMPUTED FROM THE Z-STATISTIC, WHICH IS UNIT-FREE.
+    The previous form, `r2 = 2*eaf*(1-eaf)*beta^2`, is a variance explained only if the
+    trait happens to have variance 1: there is no division by the trait's variance and
+    no sample size anywhere in it. So the verdict moved when the outcome was expressed
+    in different units, which is not a scientific property of anything. Measured on ten
+    instruments with a true ratio of 0.5, rescaling the outcome alone -- mmol/L to
+    mg/dL, say -- flipped `correct` from True to False between factors of 1 and 3, with
+    p astronomically small on BOTH sides, so it reported near-certainty in opposite
+    directions depending on a unit choice.
+
+    `r2 = z^2 / (z^2 + n)` is the standard conversion for a continuous trait, and z is
+    invariant to the units of beta because the standard error carries the same units.
+
+    Sample sizes are OPTIONAL, and what is reported depends on what is available:
+
+    - both present: a variance explained per side, and a p-value from the Fisher
+      z-transform difference of two INDEPENDENT correlations -- which is what two-sample
+      MR has by construction, the exposure and outcome coming from different studies.
+    - absent: with equal sample sizes the comparison reduces to |z_exposure| >
+      |z_outcome|, so the DIRECTION is still well defined and still unit-free. The
+      p-value is not: it is returned as None with the assumption stated in `note`,
+      rather than as a number from the previous `sqrt(r2_exp + r2_out) * 0.01`, whose
+      0.01 has no derivation.
+    """
+    z_exp = np.array([i.beta_exposure / i.se_exposure if i.se_exposure else 0.0
+                      for i in instruments])
+    z_out = np.array([i.beta_outcome / i.se_outcome if i.se_outcome else 0.0
+                      for i in instruments])
+
+    n_exp = [i.n_exposure for i in instruments]
+    n_out = [i.n_outcome for i in instruments]
+    have_n = all(v is not None and v > 3 for v in n_exp + n_out)
+
+    if not have_n:
+        correct = bool(np.sum(z_exp ** 2) > np.sum(z_out ** 2))
+        return correct, None, (
+            "no sample sizes supplied, so the direction is read from the z-statistics "
+            "under the assumption that the exposure and outcome studies are of "
+            "comparable size; no p-value is computed")
+
+    r2_exp = float(np.sum(z_exp ** 2 / (z_exp ** 2 + np.array(n_exp, dtype=float))))
+    r2_out = float(np.sum(z_out ** 2 / (z_out ** 2 + np.array(n_out, dtype=float))))
+    correct = r2_exp > r2_out
+
+    # Fisher z on each side, then the difference of two independent correlations.
+    # Clamped below 1 because atanh is undefined at exactly 1, which a very strong
+    # instrument set can reach after summing.
+    r_exp = min(math.sqrt(max(r2_exp, 0.0)), 1.0 - 1e-12)
+    r_out = min(math.sqrt(max(r2_out, 0.0)), 1.0 - 1e-12)
+    n1, n2 = float(min(n_exp)), float(min(n_out))
+    se = math.sqrt(1.0 / (n1 - 3.0) + 1.0 / (n2 - 3.0))
+    z_stat = (math.atanh(r_exp) - math.atanh(r_out)) / se
+    p = float(2 * stats.norm.sf(abs(z_stat)))
+    return correct, p, ""
 
 
 def compute_i_squared_gx(instruments: list[Instrument]) -> float:
@@ -407,7 +525,7 @@ def run_sensitivity(instruments: list[Instrument], ivw_est: MREstimate) -> Sensi
     """Run full sensitivity analysis battery."""
     q, q_p, q_df = cochran_q(instruments, ivw_est)
     f_stats = [i.f_statistic for i in instruments]
-    steiger_dir, steiger_p = steiger_test(instruments)
+    steiger_dir, steiger_p, steiger_note = steiger_test(instruments)
     i2_gx = compute_i_squared_gx(instruments)
 
     return SensitivityResults(
@@ -418,6 +536,7 @@ def run_sensitivity(instruments: list[Instrument], ivw_est: MREstimate) -> Sensi
         i_squared_gx=i2_gx,
         steiger_correct_direction=steiger_dir,
         steiger_pvalue=steiger_p,
+        steiger_note=steiger_note,
     )
 
 
@@ -604,7 +723,9 @@ def _write_sensitivity_table(s, egger_int, egger_p, path):
         w.writerow(["Mean_F_statistic", f"{s.mean_f_statistic:.1f}", "N/A", f"{'WEAK' if s.mean_f_statistic < MIN_F_STAT else 'Strong'} instruments"])
         w.writerow(["Min_F_statistic", f"{s.min_f_statistic:.1f}", "N/A", f"{s.n_weak_instruments} weak instruments (F<{MIN_F_STAT})"])
         w.writerow(["I_squared_GX", f"{s.i_squared_gx:.4f}", "N/A", "SIMEX recommended" if s.i_squared_gx < 0.9 else "No SIMEX needed"])
-        w.writerow(["Steiger_direction", "Correct" if s.steiger_correct_direction else "REVERSED", f"{s.steiger_pvalue:.4f}", "Correct direction" if s.steiger_correct_direction else "WARNING: reversed causal direction"])
+        _sp = f"{s.steiger_pvalue:.4f}" if s.steiger_pvalue is not None else "not_applicable"
+        _si = "Correct direction" if s.steiger_correct_direction else "WARNING: reversed causal direction"
+        w.writerow(["Steiger_direction", "Correct" if s.steiger_correct_direction else "REVERSED", _sp, f"{_si}{'; ' + s.steiger_note if s.steiger_note else ''}"])
 
 
 def _write_instruments_table(instruments, path):
@@ -644,7 +765,10 @@ def _write_report_md(instruments, estimates, sens, egger_int, egger_p, exposure,
         f"| Mean F-statistic | {sens.mean_f_statistic:.1f} | — | {'**WARNING: weak instruments**' if sens.mean_f_statistic < MIN_F_STAT else 'Strong instruments'} |",
         f"| Weak instruments (F<{MIN_F_STAT}) | {sens.n_weak_instruments}/{len(instruments)} | — | {'**WARNING**' if sens.n_weak_instruments > 0 else 'None'} |",
         f"| I²_GX | {sens.i_squared_gx:.4f} | — | {'SIMEX correction recommended' if sens.i_squared_gx < 0.9 else 'Adequate'} |",
-        f"| Steiger direction | {'Correct' if sens.steiger_correct_direction else '**REVERSED**'} | {sens.steiger_pvalue:.4f} | {'Exposure → Outcome confirmed' if sens.steiger_correct_direction else '**WARNING: reverse causation**'} |",
+        (f"| Steiger direction | {'Correct' if sens.steiger_correct_direction else '**REVERSED**'} | "
+         f"{f'{sens.steiger_pvalue:.4f}' if sens.steiger_pvalue is not None else 'not computed'} | "
+         f"{'Exposure → Outcome confirmed' if sens.steiger_correct_direction else '**WARNING: reverse causation**'}"
+         f"{'; ' + sens.steiger_note if sens.steiger_note else ''} |"),
         "",
     ])
 
@@ -706,6 +830,8 @@ def _write_result_json(estimates, sens, egger_int, egger_p, exposure, outcome, o
             "n_weak": sens.n_weak_instruments,
             "i_squared_gx": round(sens.i_squared_gx, 4),
             "steiger_correct": sens.steiger_correct_direction,
+            "steiger_p": sens.steiger_pvalue,
+            "steiger_note": sens.steiger_note or None,
         },
         "disclaimer": DISCLAIMER,
     }
@@ -738,6 +864,7 @@ def load_demo_instruments() -> tuple[list[Instrument], str, str]:
         pval_exposure=s["pval_exposure"], beta_outcome=s["beta_outcome"],
         se_outcome=s["se_outcome"], pval_outcome=s["pval_outcome"],
         f_statistic=s["f_statistic"],
+        n_exposure=s.get("n_exposure"), n_outcome=s.get("n_outcome"),
     ) for s in data["instruments"]]
     return instruments, data["exposure"], data["outcome"]
 
@@ -821,6 +948,7 @@ def main() -> None:
             pval_exposure=s["pval_exposure"], beta_outcome=s["beta_outcome"],
             se_outcome=s["se_outcome"], pval_outcome=s["pval_outcome"],
             f_statistic=s["f_statistic"],
+            n_exposure=s.get("n_exposure"), n_outcome=s.get("n_outcome"),
         ) for s in data["instruments"]]
         exposure = data.get("exposure", "Exposure")
         outcome = data.get("outcome", "Outcome")

--- a/skills/mendelian-randomisation/tests/test_mendelian_randomisation.py
+++ b/skills/mendelian-randomisation/tests/test_mendelian_randomisation.py
@@ -13,6 +13,7 @@ import sys
 from pathlib import Path
 
 import numpy as np
+from scipy import stats
 import pytest
 
 SKILL_DIR = Path(__file__).resolve().parent.parent
@@ -380,16 +381,22 @@ def test_a_two_instrument_run_writes_parseable_json_and_a_report_that_says_why(t
     assert "estimate" not in egger and "se" not in egger
     assert result["sensitivity"]["egger_intercept"] is None
 
+    # Below three instruments none of the three sensitivity estimators applies (the
+    # weighted median and mode are order statistics of the ratios; TwoSampleMR returns
+    # NA for all three below 3 SNPs), so every one of them is declared, not numbered.
+    for method in ("Weighted Median", "Weighted Mode"):
+        row = next(e for e in result["estimates"] if e["method"] == method)
+        assert row["applicable"] is False and "estimate" not in row, row
+
     report = (out / "report.md").read_text()
     assert "MR-Egger was not computed" in report
-    # The POSITIVE assertion, not merely the absence of the old sentence: the robustness
-    # claim must NAME the estimators it actually compared. Asserting only that
-    # "consistent estimates across IVW, MR-Egger" is gone passes just as well when a
-    # non-applicable Egger is still fed into the comparison and drags it to "Caution" --
-    # right conclusion, wrong reason, and the next real disagreement would be invisible.
-    assert ("Sensitivity analyses show consistent estimates across IVW, "
-            "Weighted Median, Weighted Mode") in report
-    assert "MR-Egger, weighted median" not in report
+    # The POSITIVE assertion, not merely the absence of the old sentence. With nothing
+    # to compare against, the report must say the IVW stands alone -- not certify it as
+    # "consistent across methods" on the strength of estimators that never ran, which
+    # is what a two-instrument run used to do.
+    assert ("No sensitivity estimator applies to this instrument set, so the IVW "
+            "estimate stands alone and is not corroborated.") in report
+    assert "consistent estimates across" not in report
     assert "| Egger intercept | not computed |" in report
 
     table = (out / "tables" / "mr_results.tsv").read_text()
@@ -479,7 +486,10 @@ def test_a_zero_outcome_standard_error_is_refused_rather_than_passed_through():
         for k, se in enumerate([0.02, 0.0, 0.02])
     ]
 
-    est, intercept, _, _ = mr_egger(insts)
+    # The infinite weight is the point of the test; numpy's divide-by-zero and
+    # invalid-value warnings on the way to the NaN ratio are expected, not a defect.
+    with np.errstate(divide="ignore", invalid="ignore"):
+        est, intercept, _, _ = mr_egger(insts)
 
     assert est.applicable is False
     assert "not identified" in est.reason
@@ -558,62 +568,91 @@ def _mode_input(spread, n=15, seed=3):
     return out
 
 
-def test_the_weighted_mode_se_can_tell_agreement_from_a_two_camp_split():
+def test_the_weighted_mode_se_reflects_the_ratios_and_the_closed_form_did_not():
     """The old SE was `2 / sum(|bx|/sy)` -- the instrument count and the outcome standard
     errors, and nothing about the ratios whose mode it reports.
 
     So it returns THE SAME NUMBER for instruments that all agree and for instruments
-    that split into two opposed clusters. Measured on 15 instruments with identical
-    exposure effects and outcome SEs: 0.01333 for one tight cluster around 0.50, and
-    0.01333 for an 8-versus-7 split between 0.20 and 0.80. The mode is a completely
-    different kind of claim in those two datasets and the reported precision was
-    unchanged. The bootstrap separates them, and is 2.4x to 3.9x wider throughout, so
-    the closed form was also over-confident.
+    that split into two opposed clusters: 0.01333 for both datasets below, whose ratios
+    are one tight cluster around 0.50 and an 8-versus-7 split between 0.20 and 0.80. The
+    parametric bootstrap of Hartwig et al. 2017 reacts to the ratios, and it is several
+    times wider than the closed form in both cases, so the closed form was also
+    over-confident.
+
+    What is NOT asserted is which of the two gets the wider SE. Measured with the
+    reference bandwidth rule over three seeds, the tight cluster came out at 0.057 to
+    0.063 and the split at 0.040 to 0.045: a two-camp split with a decisive majority pins
+    the mode on the larger camp, whose ratios nearly coincide, while the ratios of a
+    tight cluster scatter under resampling by more than their spread. An earlier version
+    of this test asserted the opposite ordering; it held only for a bandwidth rule the
+    reference method does not use, which is exactly the kind of invariant a test should
+    not carry.
+
+    The ratios carry a small jitter so no two coincide: exact ties make the median
+    absolute deviation zero, and the reference rule then floors the bandwidth at 1e-8,
+    which is the reference behaviour but not a realistic dataset.
     """
-    def _fixed(ratios):
-        return [Instrument(f"rs{k}", "A", "G", 0.3, 0.2, 0.025, 1e-10,
-                           0.2 * r, 0.02, 0.01, 64.0) for k, r in enumerate(ratios)]
+    rng = np.random.default_rng(2026)
 
-    tight = weighted_mode(_fixed([0.5] * 7 + [0.51, 0.49, 0.5, 0.52, 0.48, 0.5, 0.51, 0.49]),
-                          n_boot=300)
-    split = weighted_mode(_fixed([0.2] * 8 + [0.8] * 7), n_boot=300)
+    def _jittered(ratios):
+        out = []
+        for k, r in enumerate(ratios):
+            bx = float(rng.uniform(0.15, 0.25))
+            out.append(Instrument(f"rs{k}", "A", "G", 0.3, bx, bx / 8, 1e-10,
+                                  bx * r, 0.02, 0.01, 64.0))
+        return out
 
-    # same n, same outcome SEs, same exposure effects -- the OLD formula is blind here
+    tight = weighted_mode(_jittered(0.5 + rng.normal(0, 0.02, 15)), n_boot=300)
+    split = weighted_mode(_jittered(np.r_[0.2 + rng.normal(0, 0.02, 8),
+                                          0.8 + rng.normal(0, 0.02, 7)]), n_boot=300)
+
+    # the OLD formula, evaluated on the same inputs, is blind to the ratios entirely
     old_se = 1.0 / (sum(1.0 / (0.02 / 0.2) for _ in range(15)) * 0.5)
-    assert split.se > 1.4 * tight.se, (tight.se, split.se)
-    assert split.se > 2 * old_se and tight.se > 2 * old_se, (old_se, tight.se, split.se)
+    assert tight.se > 2 * old_se and split.se > 2 * old_se, (old_se, tight.se, split.se)
+    assert abs(tight.se - split.se) > 0.2 * min(tight.se, split.se), (tight.se, split.se)
+    assert tight.estimate == pytest.approx(0.5, abs=0.06)
+    assert split.estimate == pytest.approx(0.2, abs=0.03)     # the larger camp
 
 
 def test_the_weighted_mode_bandwidth_scales_with_the_data_not_a_constant():
     """A fixed 0.5 stops the mode being a mode.
 
-    Fifteen instruments split 9 to 6 between ratios of 0.20 and 0.80. The mode is 0.20,
-    by construction -- that is the larger camp, and separating it from the weighted mean
-    is the entire reason to run this estimator. The weighted mean is 0.4400.
+    Fifteen instruments split 9 to 6 between ratios near 0.20 and 0.80 (jittered so no
+    two coincide). The mode is 0.20, by construction -- that is the larger camp, and
+    separating it from the weighted mean is the entire reason to run this estimator.
+    The inverse-variance weighted mean here is 0.4463.
 
     With the old absolute bandwidth of 0.5, larger than the 0.6 gap between the camps,
-    the kernels merge and the "mode" comes out at 0.4090: the mean, to within rounding.
-    With a bandwidth proportional to the spread of the ratios it recovers 0.20 exactly at
-    phi = 0.3 and 0.5, and 0.2721 at the published default of phi = 1, which is ordinary
-    kernel over-smoothing rather than a collapse.
+    the kernels merge and the "mode" comes out at 0.3139, most of the way to the mean.
+    With the bandwidth rule of Hartwig et al. 2017 eq. 7 it recovers the larger camp at
+    phi = 0.3, 0.5 and at the reference default of 1 (0.1962 at each; the rule gives a
+    bandwidth of 0.0092 at phi = 1 on these ratios).
     """
-    from mendelian_randomisation import _weighted_mode_point
+    from mendelian_randomisation import _weighted_mode_point, mbe_bandwidth
 
-    insts = [Instrument(f"rs{k}", "A", "G", 0.3, 0.2, 0.025, 1e-10,
-                        0.2 * r, 0.02, 0.01, 64.0)
-             for k, r in enumerate([0.2] * 9 + [0.8] * 6)]
-    ratios = np.array([i.beta_outcome / i.beta_exposure for i in insts])
-    weights = np.array([1.0 / (i.se_outcome / abs(i.beta_exposure)) for i in insts])
+    rng = np.random.default_rng(7)
+    ratios_in = np.r_[0.2 + rng.normal(0, 0.01, 9), 0.8 + rng.normal(0, 0.01, 6)]
+    insts = []
+    rng2 = np.random.default_rng(3)
+    for k, r in enumerate(ratios_in):
+        bx = float(rng2.uniform(0.15, 0.25))
+        insts.append(Instrument(f"rs{k}", "A", "G", 0.3, bx, bx / 8, 1e-10,
+                                bx * r, 0.02, 0.01, 64.0))
+    bx = np.array([i.beta_exposure for i in insts]); by = np.array([i.beta_outcome for i in insts])
+    sx = np.array([i.se_exposure for i in insts]); sy = np.array([i.se_outcome for i in insts])
+    ratios = by / bx
+    se_r = np.sqrt(sy ** 2 / bx ** 2 + by ** 2 * sx ** 2 / bx ** 4)
+    weights = (1 / se_r ** 2) / np.sum(1 / se_r ** 2)
     mean = ivw(insts).estimate
 
     absolute = _weighted_mode_point(ratios, weights, 0.5)
-    proportional = _weighted_mode_point(ratios, weights, 0.5 * float(ratios.std()))
+    assert abs(absolute - mean) < 0.15, (absolute, mean)          # pulled onto the mean
+    for phi in (0.3, 0.5, 1.0):
+        proportional = _weighted_mode_point(ratios, weights, mbe_bandwidth(ratios, phi))
+        assert proportional == pytest.approx(0.20, abs=0.02), (phi, proportional)
+        assert abs(proportional - mean) > 0.2
 
-    assert abs(absolute - mean) < 0.05, (absolute, mean)      # collapsed onto the mean
-    assert proportional == pytest.approx(0.20, abs=0.02)      # found the larger camp
-    assert abs(proportional - mean) > 0.15
-
-    # and the shipped default is scale-free, which the absolute one was not
+    # and the shipped estimator is scale-free, which the absolute bandwidth was not
     scaled = [Instrument(i.snp, i.effect_allele, i.other_allele, i.eaf, i.beta_exposure,
                          i.se_exposure, i.pval_exposure, i.beta_outcome * 100,
                          i.se_outcome * 100, i.pval_outcome, i.f_statistic)
@@ -621,3 +660,108 @@ def test_the_weighted_mode_bandwidth_scales_with_the_data_not_a_constant():
     a = weighted_mode(insts, n_boot=100).estimate
     b = weighted_mode(scaled, n_boot=100).estimate / 100
     assert a == pytest.approx(b, rel=0.05), (a, b)
+
+
+# ---------------------------------------------------------------------------
+# Weighted mode and Steiger: the terms that tie the code to the cited methods.
+# Each of these pins ONE term a plausible re-implementation could silently change
+# without any of the behavioural tests above noticing.
+# ---------------------------------------------------------------------------
+
+def test_the_weighted_mode_weights_are_inverse_variance_not_inverse_se():
+    """Hartwig et al. 2017 eq. 5: `w_j = se_j^-2 / sum(se^-2)`.
+
+    Five imprecise instruments at a ratio of 0.20 (se 0.02) against one precise
+    instrument at 0.80 (se 0.005). Inverse-variance weights put 40000 on the precise
+    one against 5 x 2500 = 12500 on the camp, so the mode is 0.80. Inverse-SE weights,
+    which this function used to apply, give 200 against 5 x 50 = 250, and the mode
+    flips to 0.20. Same data, opposite answer; only the exponent differs.
+    """
+    from mendelian_randomisation import _weighted_mode_point
+
+    ratios = np.array([0.2, 0.201, 0.199, 0.2, 0.2005, 0.8])
+    se = np.array([0.02] * 5 + [0.005])
+    inv_var = 1.0 / se ** 2
+    weights = inv_var / inv_var.sum()
+    # a wide, fixed bandwidth so the answer is about the weights and nothing else
+    assert _weighted_mode_point(ratios, weights, 0.05) == pytest.approx(0.8, abs=0.02)
+
+    # and the shipped estimator reproduces that, so the weights it builds are these
+    insts = [Instrument(f"rs{k}", "A", "G", 0.3, 0.2, 1e-6, 1e-10, 0.2 * r, 0.2 * s_, 0.01, 64.0)
+             for k, (r, s_) in enumerate(zip(ratios, se))]
+    est = weighted_mode(insts, phi=6.0, n_boot=50)   # phi large enough to match the 0.05 above
+    assert est.estimate == pytest.approx(0.8, abs=0.03), est.estimate
+
+
+def test_the_weighted_mode_se_is_the_scaled_mad_of_the_bootstrap_and_p_is_from_t():
+    """The reference implementation reports `1.4826 * mad(draws)` and a t-test on L - 1
+    degrees of freedom (TwoSampleMR `mr_mode`: `se_Mode <- apply(beta_Mode.boot, 2,
+    stats::mad)`, `P_Mode <- pt(..., df = length(b_exp) - 1) * 2`)."""
+    from mendelian_randomisation import _mad
+
+    assert _mad(np.array([1.0, 2.0, 3.0, 4.0, 100.0])) == pytest.approx(1.4826 * 1.0)
+
+    # The SE goes THROUGH that helper. Pinned by substitution rather than by
+    # re-deriving the bootstrap here: swap `_mad` for a sentinel and the reported SE
+    # must be the sentinel's value. Without this, `np.std(draws)` in its place passed
+    # every other test in this file (mutation-checked 2026-09-12).
+    import mendelian_randomisation as mr_mod
+    real_mad = mr_mod._mad
+    mr_mod._mad = lambda draws: 0.123456
+    try:
+        assert weighted_mode(_mode_input(0.15, n=12), n_boot=20).se == pytest.approx(0.123456)
+    finally:
+        mr_mod._mad = real_mad
+
+    insts = _mode_input(0.15, n=12)
+    est = weighted_mode(insts, n_boot=200)
+    expected_p = 2 * stats.t.sf(abs(est.estimate / est.se), df=len(insts) - 1)
+    assert est.pvalue == pytest.approx(expected_p, rel=1e-9)
+    # not the normal approximation: at df = 11 the two differ by more than rounding
+    assert est.pvalue != pytest.approx(2 * stats.norm.sf(abs(est.estimate / est.se)), rel=1e-3)
+
+
+def test_steiger_p_value_follows_the_reference_conversion_and_aggregation():
+    """Pins the two terms that make this the TwoSampleMR Steiger test rather than a
+    near neighbour: `r2 = z^2 / (z^2 + n - 2)` per SNP (`get_r_from_bsen`) and the
+    per-SNP sample sizes aggregated by their MEAN (`mr_steiger`), then Fisher's z on
+    two independent correlations with `1/(n-3)` variances.
+
+    Small sample sizes on purpose: at n = 20 the `-2` moves r2 by 10% for z = 1, so a
+    drift to `z^2/(z^2+n)` is visible here and invisible at 100,000. Kept small enough
+    that the summed r2 on each side stays below 1 (the production code clamps at 1 for
+    atanh, and the expectation below would otherwise need the same clamp)."""
+    insts = [
+        Instrument("rs1", "A", "G", 0.3, 0.2, 0.2, 1e-10, 0.05, 0.1, 0.01, 64.0,
+                   n_exposure=20, n_outcome=40),
+        Instrument("rs2", "A", "G", 0.3, 0.3, 0.2, 1e-10, 0.05, 0.1, 0.01, 64.0,
+                   n_exposure=30, n_outcome=50),
+    ]
+    correct, p, note = steiger_test(insts)
+    assert correct is True and note == ""
+
+    z_exp = np.array([0.2 / 0.2, 0.3 / 0.2]); z_out = np.array([0.5, 0.5])
+    n_exp = np.array([20.0, 30.0]); n_out = np.array([40.0, 50.0])
+    r_exp = math.sqrt(float(np.sum(z_exp ** 2 / (z_exp ** 2 + n_exp - 2))))
+    r_out = math.sqrt(float(np.sum(z_out ** 2 / (z_out ** 2 + n_out - 2))))
+    se = math.sqrt(1 / (n_exp.mean() - 3) + 1 / (n_out.mean() - 3))
+    expected = 2 * stats.norm.sf(abs((math.atanh(r_exp) - math.atanh(r_out)) / se))
+    assert p == pytest.approx(expected, rel=1e-9)
+
+
+def test_the_weighted_mode_ratio_se_carries_the_exposure_uncertainty():
+    """The reference weighted mode uses the second-order delta-method ratio SE,
+    `sqrt(sy^2/bx^2 + by^2*sx^2/bx^4)` (TwoSampleMR `mr_mode`, the column "not assuming
+    NOME"). The first-order `sy/|bx|` ignores the exposure SE entirely.
+
+    Five precise instruments at a ratio of 0.20 against one at 0.80 whose outcome SE is
+    tiny but whose exposure SE is enormous. Second order: the exposure term makes its
+    ratio SE large, it is down-weighted, the mode is 0.20. First order: its ratio SE is
+    tiny, it dominates, the mode is 0.80.
+    """
+    camp = [Instrument(f"rs{k}", "A", "G", 0.3, 0.2, 0.01, 1e-10, 0.2 * r, 0.02, 0.01, 64.0)
+            for k, r in enumerate([0.2, 0.201, 0.199, 0.2, 0.2005])]
+    loud = Instrument("rs9", "A", "G", 0.3, 0.2, 0.5, 1e-10, 0.16, 0.0005, 0.01, 64.0)
+    est = weighted_mode(camp + [loud], phi=6.0, n_boot=50)
+    assert est.estimate == pytest.approx(0.2, abs=0.03), est.estimate
+

--- a/skills/mendelian-randomisation/tests/test_mendelian_randomisation.py
+++ b/skills/mendelian-randomisation/tests/test_mendelian_randomisation.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import math
+import random
 import sys
 from pathlib import Path
 
@@ -21,6 +22,7 @@ from mendelian_randomisation import (
     Instrument,
     MREstimate,
     cochran_q,
+    egger_weighted_dispersion,
     compute_i_squared_gx,
     generate_report,
     ivw,
@@ -225,3 +227,255 @@ class TestDemoPipeline:
         ivw_est = estimates["IVW"]
         for method, est in estimates.items():
             assert abs(est - ivw_est) < 0.2, f"{method} ({est:.3f}) diverges from IVW ({ivw_est:.3f})"
+
+
+# ---------------------------------------------------------------------------
+# MR-Egger applicability: two independent conditions, and a trap in the obvious
+# test suite for them
+# ---------------------------------------------------------------------------
+#
+# MR-Egger fits a slope AND an intercept. Two things have to hold, and neither implies
+# the other:
+#
+#   STATISTICAL  n >= 3, or there is no residual degree of freedom at all.
+#   NUMERICAL    at least two distinct beta_exposure values, which is not an n < 3
+#                problem -- it is reachable at any n from a merge that duplicates one
+#                SNP across rows, tissues or proxies.
+#
+# THE TRAP, and why the cases below are shaped the way they are: the n < 3 return comes
+# FIRST, so every n=1 and n=2 input short-circuits before it ever reaches the
+# conditioning test. A suite made only of n=1 and n=2 cases therefore passes whether or
+# not the centered denominator and the relative threshold work at all -- which is the
+# "a gate never observed failing is not known to work" failure, committed by the very
+# tests written to prevent it. The n>=3 near-collinear case is the only input that
+# reaches the second guard, so it is the load-bearing one here.
+
+
+def _egger_input(bxs, by_scale=0.5, se_y=0.02):
+    """Instruments with the given exposure effects and a clean linear outcome."""
+    return [
+        Instrument(snp=f"rs{k}", effect_allele="A", other_allele="G", eaf=0.3,
+                   beta_exposure=float(bx), se_exposure=abs(float(bx)) / 8 or 0.01,
+                   pval_exposure=1e-10,
+                   beta_outcome=float(bx) * by_scale, se_outcome=se_y,
+                   pval_outcome=0.01, f_statistic=64.0)
+        for k, bx in enumerate(bxs)
+    ]
+
+
+@pytest.mark.parametrize("n", [1, 2])
+def test_egger_below_three_instruments_is_not_applicable(n):
+    """The statistical condition. Previously n=1 was a three-way coin flip -- guard,
+    crash, or a finite slope with a median SE of 2.1e+07 -- and n=2 exited 0 while
+    writing an infinite standard error."""
+    est, intercept, int_se, int_p = mr_egger(_egger_input([0.2, 0.5][:n]))
+
+    assert est.applicable is False
+    assert est.n_snps == n
+    assert "at least 3" in est.reason
+    assert math.isnan(est.estimate) and math.isnan(est.se)
+    # the intercept (the pleiotropy test) is undefined on exactly the same inputs
+    assert math.isnan(intercept) and math.isnan(int_se) and math.isnan(int_p)
+
+
+def test_egger_with_near_identical_exposure_effects_is_not_applicable():
+    """The NUMERICAL condition, and the only input in this file that reaches it.
+
+    n=5, so the instrument-count return does not fire; the exposure effects agree to
+    ~1e-11 relative, so the slope is unidentified. The old code returned a number here:
+    the same shape gave slope=3960 with se=2.64e+06 and no warning of any kind.
+    """
+    base = 0.4
+    est, intercept, _, _ = mr_egger(
+        _egger_input([base + k * 1e-11 for k in range(5)]))
+
+    assert est.applicable is False
+    assert est.n_snps == 5
+    assert "too close to identical" in est.reason
+    assert math.isnan(est.estimate)
+    assert math.isnan(intercept)
+
+
+def test_the_centered_dispersion_is_non_negative_where_the_expanded_form_is_not():
+    """The sign, which is the root cause rather than the threshold.
+
+    Tested on the denominator DIRECTLY rather than through `mr_egger`, and the reason
+    is worth stating: once the conditioning check is in place it refuses these inputs
+    anyway, so the public path behaves identically with either form. Centering is a
+    STRUCTURAL property, not a behavioural one, and a test routed through the public
+    API would pass without it -- which is the failure this whole file is about.
+
+    The construction matters. Equally-spaced exposure effects with equal weights do NOT
+    reproduce the defect: the cancellation stays non-negative by symmetry. It needs
+    effects that are near-identical but irregularly spaced, with the varying weights
+    real standard errors produce. Over the 200 draws below the expanded form goes
+    negative for roughly a third of them, matching the ~35% measured at n=5 across
+    4,000 draws; the centered form was non-negative in all 64,000 draws of that sweep.
+    """
+    rng = random.Random(20260829)
+    saw_expanded_go_negative = 0
+    for _ in range(200):
+        base = rng.uniform(0.05, 0.9)
+        bx = np.array([base * (1 + rng.uniform(-1e-12, 1e-12)) for _ in range(5)])
+        se = np.array([rng.uniform(0.005, 0.05) for _ in range(5)])
+        w = 1.0 / se ** 2
+
+        centered = egger_weighted_dispersion(w, bx)
+        assert centered >= 0.0, f"centered dispersion went negative: {centered!r}"
+        assert math.isfinite(centered)
+
+        expanded = np.sum(w) * np.sum(w * bx ** 2) - np.sum(w * bx) ** 2
+        if expanded < 0:
+            saw_expanded_go_negative += 1
+
+    # exactly zero when the exposure effects are identical, which is the algebraic
+    # statement that the slope is unidentified
+    assert egger_weighted_dispersion(np.full(4, 2500.0), np.full(4, 0.4)) == 0.0
+
+    # and the failure the centering removes is observed on this very sweep, not
+    # asserted from a story about it
+    assert saw_expanded_go_negative > 20, (
+        f"the expanded form went negative only {saw_expanded_go_negative} times in 200 "
+        "draws, so this test is not observing the defect it exists for")
+
+
+@pytest.mark.parametrize("n", [3, 5])
+def test_a_well_conditioned_fit_still_produces_an_estimate(n):
+    """The false-positive direction: neither guard may fire on ordinary data."""
+    est, intercept, int_se, int_p = mr_egger(
+        _egger_input([0.1 * (k + 1) for k in range(n)]))
+
+    assert est.applicable is True
+    assert est.reason == ""
+    assert math.isfinite(est.estimate) and math.isfinite(est.se)
+    assert est.se < 1.0                      # not the inflated-SE branch
+    assert est.estimate == pytest.approx(0.5, abs=0.05)
+    assert all(math.isfinite(v) for v in (intercept, int_se, int_p))
+
+
+def test_a_two_instrument_run_writes_parseable_json_and_a_report_that_says_why(tmp_path):
+    """End to end, because every symptom of this bug was in the ARTIFACTS.
+
+    A two-instrument run used to exit 0 having written `"se": Infinity` into
+    result.json -- which RFC 8259 has no token for, so a strict parser rejects the whole
+    document -- and a report.md asserting the result was "robust", because the
+    consistency check compared point estimates and never looked at the standard errors.
+    """
+    insts = _egger_input([0.2, 0.5])
+    out = tmp_path / "run"
+    out.mkdir()
+    run_pipeline(insts, exposure="X", outcome="Y", output_dir=out, demo=True)
+
+    # json.load rejects bare Infinity/NaN by default, so this parses only if nothing
+    # non-finite was written.
+    result = json.loads((out / "result.json").read_text())
+    egger = next(e for e in result["estimates"] if e["method"] == "MR-Egger")
+    assert egger["applicable"] is False
+    assert "at least 3" in egger["reason"]
+    assert "estimate" not in egger and "se" not in egger
+    assert result["sensitivity"]["egger_intercept"] is None
+
+    report = (out / "report.md").read_text()
+    assert "MR-Egger was not computed" in report
+    # The POSITIVE assertion, not merely the absence of the old sentence: the robustness
+    # claim must NAME the estimators it actually compared. Asserting only that
+    # "consistent estimates across IVW, MR-Egger" is gone passes just as well when a
+    # non-applicable Egger is still fed into the comparison and drags it to "Caution" --
+    # right conclusion, wrong reason, and the next real disagreement would be invisible.
+    assert ("Sensitivity analyses show consistent estimates across IVW, "
+            "Weighted Median, Weighted Mode") in report
+    assert "MR-Egger, weighted median" not in report
+    assert "| Egger intercept | not computed |" in report
+
+    table = (out / "tables" / "mr_results.tsv").read_text()
+    egger_row = next(l for l in table.splitlines() if l.startswith("MR-Egger"))
+    assert "not_applicable" in egger_row
+    assert "inf" not in egger_row.lower()
+
+
+def test_the_json_writer_refuses_any_non_finite_value(tmp_path):
+    """`allow_nan=False` is a BACKSTOP, and the fix removed every input that trips it.
+
+    That is the point of it -- the pipeline no longer produces a non-finite -- but it
+    also means no end-to-end test can observe it working. So drive the writer directly
+    with a value it must refuse. Without the flag, Python writes a bare `Infinity`,
+    which RFC 8259 has no token for, so a strict parser rejects the WHOLE document
+    rather than one field. That is what a two-instrument run used to ship, exit code 0.
+    """
+    from mendelian_randomisation import SensitivityResults, _write_result_json
+
+    broken = MREstimate("IVW", float("inf"), 1.0, 0.0, 2.0, 0.5, 4)
+    with pytest.raises(ValueError):
+        _write_result_json([broken], SensitivityResults(), 0.1, 0.5,
+                           "X", "Y", tmp_path, "2026-01-01T00:00:00Z", True)
+
+
+def test_the_scatter_plot_does_not_advertise_an_estimator_that_did_not_run(tmp_path):
+    """A NaN slope draws no visible line and still claims a legend entry.
+
+    matplotlib silently omits a line whose y values are NaN, so the plot LOOKS right --
+    but the legend still gains an "MR-Egger (nan)" row, and a reader takes a legend
+    entry as a statement that the method was fitted. The absence has to be an absence
+    everywhere, not only in the tables.
+
+    Recorded at the point the label is REQUESTED rather than read off the finished
+    figure: `scatter_plot` closes its figure, so inspecting the current one afterwards
+    reads an empty canvas and the test passes for the wrong reason.
+    """
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.axes
+    from mendelian_randomisation import scatter_plot
+
+    requested = []
+    real_plot = matplotlib.axes.Axes.plot
+
+    def spy(self, *a, **kw):
+        if "label" in kw:
+            requested.append(kw["label"])
+        return real_plot(self, *a, **kw)
+
+    insts = _egger_input([0.2, 0.5])
+    estimates = [
+        ivw(insts),
+        MREstimate.not_applicable("MR-Egger", 2, "requires at least 3 instruments"),
+        weighted_median(insts),
+    ]
+    matplotlib.axes.Axes.plot = spy
+    try:
+        scatter_plot(insts, estimates, tmp_path / "scatter.png")
+    finally:
+        matplotlib.axes.Axes.plot = real_plot
+
+    assert (tmp_path / "scatter.png").exists()
+    assert requested, "no labelled line was drawn at all; the spy is not wired"
+    assert not any("MR-Egger" in lab for lab in requested), requested
+    assert not any("nan" in lab.lower() for lab in requested), requested
+    assert any("IVW" in lab for lab in requested), requested
+
+
+def test_a_zero_outcome_standard_error_is_refused_rather_than_passed_through():
+    """The conditioning check is written `not (rel > t)`, and this is why.
+
+    An instrument with `se_outcome = 0` gives it infinite weight, which makes both the
+    dispersion and its scale infinite and their ratio NaN. Every comparison against NaN
+    is False, so the natural-reading `rel < threshold` would be False and the estimator
+    would proceed on a quantity that is not a number. The negated form turns that same
+    False into a refusal.
+
+    Reachable from a malformed input file rather than only in principle, which is why it
+    is tested instead of merely commented.
+    """
+    insts = [
+        Instrument(snp=f"rs{k}", effect_allele="A", other_allele="G", eaf=0.3,
+                   beta_exposure=0.1 * (k + 1), se_exposure=0.01, pval_exposure=1e-10,
+                   beta_outcome=0.05 * (k + 1), se_outcome=se, pval_outcome=0.01,
+                   f_statistic=64.0)
+        for k, se in enumerate([0.02, 0.0, 0.02])
+    ]
+
+    est, intercept, _, _ = mr_egger(insts)
+
+    assert est.applicable is False
+    assert "not identified" in est.reason
+    assert math.isnan(est.estimate) and math.isnan(intercept)

--- a/skills/mendelian-randomisation/tests/test_mendelian_randomisation.py
+++ b/skills/mendelian-randomisation/tests/test_mendelian_randomisation.py
@@ -134,8 +134,13 @@ class TestSensitivity:
         assert p > 0.05
 
     def test_steiger_correct_direction(self, demo_instruments):
-        correct, p = steiger_test(demo_instruments)
+        # UPDATED: the test now returns (correct, p_or_None, note). The p is None here
+        # because the demo instruments carry no sample sizes, and without them there is
+        # no basis for one -- see `test_steiger_verdict_is_invariant_to_the_units`.
+        correct, p, note = steiger_test(demo_instruments)
         assert correct is True
+        assert p is None
+        assert "no sample sizes" in note
 
     def test_i_squared_gx(self, demo_instruments):
         i2 = compute_i_squared_gx(demo_instruments)
@@ -479,3 +484,140 @@ def test_a_zero_outcome_standard_error_is_refused_rather_than_passed_through():
     assert est.applicable is False
     assert "not identified" in est.reason
     assert math.isnan(est.estimate) and math.isnan(intercept)
+
+
+# ---------------------------------------------------------------------------
+# Steiger directionality: the verdict must not depend on the units of the traits
+# ---------------------------------------------------------------------------
+
+def _steiger_input(unit=1.0, n_exp=None, n_out=None, seed=7):
+    rng = np.random.default_rng(seed)
+    out = []
+    for k in range(10):
+        bx = float(rng.uniform(0.05, 0.4))
+        out.append(Instrument(
+            snp=f"rs{k}", effect_allele="A", other_allele="G", eaf=0.3,
+            beta_exposure=bx, se_exposure=bx / 8, pval_exposure=1e-10,
+            beta_outcome=bx * 0.5 * unit, se_outcome=0.02 * unit, pval_outcome=0.01,
+            f_statistic=64.0, n_exposure=n_exp, n_outcome=n_out))
+    return out
+
+
+def test_the_steiger_verdict_is_invariant_to_the_units_of_the_outcome():
+    """Rescaling the outcome changes no science, so it must change no verdict.
+
+    `by -> k*by, sy -> k*sy` is a change of units -- mmol/L to mg/dL. The old
+    variance-explained term `2*eaf*(1-eaf)*beta^2` has no trait variance in it, so it
+    scaled with k and flipped `correct` from True to False between k=1 and k=3, with p
+    astronomically small on BOTH sides. z-statistics are unit-free, so the verdict is
+    now constant across five orders of magnitude.
+    """
+    verdicts = {u: steiger_test(_steiger_input(unit=u))[0]
+                for u in (0.1, 1.0, 3.0, 10.0, 100.0, 1000.0)}
+    assert set(verdicts.values()) == {True}, verdicts
+
+
+def test_steiger_reports_a_p_value_only_when_it_has_the_sample_sizes():
+    """Without n there is no basis for one, and the old 0.01 had no derivation."""
+    correct, p, note = steiger_test(_steiger_input())
+    assert correct is True and p is None and "no sample sizes" in note
+
+    correct, p, note = steiger_test(_steiger_input(n_exp=100_000, n_out=100_000))
+    assert correct is True
+    assert p is not None and 0.0 <= p <= 1.0
+    assert note == ""
+
+
+def test_steiger_detects_a_genuinely_reversed_direction():
+    """The false-positive direction: it must still be able to say REVERSED."""
+    insts = _steiger_input()
+    reversed_insts = [
+        Instrument(snp=i.snp, effect_allele=i.effect_allele, other_allele=i.other_allele,
+                   eaf=i.eaf, beta_exposure=i.beta_outcome, se_exposure=i.se_outcome,
+                   pval_exposure=i.pval_outcome, beta_outcome=i.beta_exposure,
+                   se_outcome=i.se_exposure, pval_outcome=i.pval_exposure,
+                   f_statistic=i.f_statistic)
+        for i in insts
+    ]
+    assert steiger_test(insts)[0] is True
+    assert steiger_test(reversed_insts)[0] is False
+
+
+# ---------------------------------------------------------------------------
+# Weighted mode: the SE must react to the dispersion of the ratios
+# ---------------------------------------------------------------------------
+
+def _mode_input(spread, n=15, seed=3):
+    rng = np.random.default_rng(seed)
+    out = []
+    for k in range(n):
+        bx = float(rng.uniform(0.05, 0.4))
+        ratio = 0.5 + float(rng.normal(0, spread))
+        out.append(Instrument(f"rs{k}", "A", "G", 0.3, bx, bx / 8, 1e-10,
+                              bx * ratio, 0.02, 0.01, 64.0))
+    return out
+
+
+def test_the_weighted_mode_se_can_tell_agreement_from_a_two_camp_split():
+    """The old SE was `2 / sum(|bx|/sy)` -- the instrument count and the outcome standard
+    errors, and nothing about the ratios whose mode it reports.
+
+    So it returns THE SAME NUMBER for instruments that all agree and for instruments
+    that split into two opposed clusters. Measured on 15 instruments with identical
+    exposure effects and outcome SEs: 0.01333 for one tight cluster around 0.50, and
+    0.01333 for an 8-versus-7 split between 0.20 and 0.80. The mode is a completely
+    different kind of claim in those two datasets and the reported precision was
+    unchanged. The bootstrap separates them, and is 2.4x to 3.9x wider throughout, so
+    the closed form was also over-confident.
+    """
+    def _fixed(ratios):
+        return [Instrument(f"rs{k}", "A", "G", 0.3, 0.2, 0.025, 1e-10,
+                           0.2 * r, 0.02, 0.01, 64.0) for k, r in enumerate(ratios)]
+
+    tight = weighted_mode(_fixed([0.5] * 7 + [0.51, 0.49, 0.5, 0.52, 0.48, 0.5, 0.51, 0.49]),
+                          n_boot=300)
+    split = weighted_mode(_fixed([0.2] * 8 + [0.8] * 7), n_boot=300)
+
+    # same n, same outcome SEs, same exposure effects -- the OLD formula is blind here
+    old_se = 1.0 / (sum(1.0 / (0.02 / 0.2) for _ in range(15)) * 0.5)
+    assert split.se > 1.4 * tight.se, (tight.se, split.se)
+    assert split.se > 2 * old_se and tight.se > 2 * old_se, (old_se, tight.se, split.se)
+
+
+def test_the_weighted_mode_bandwidth_scales_with_the_data_not_a_constant():
+    """A fixed 0.5 stops the mode being a mode.
+
+    Fifteen instruments split 9 to 6 between ratios of 0.20 and 0.80. The mode is 0.20,
+    by construction -- that is the larger camp, and separating it from the weighted mean
+    is the entire reason to run this estimator. The weighted mean is 0.4400.
+
+    With the old absolute bandwidth of 0.5, larger than the 0.6 gap between the camps,
+    the kernels merge and the "mode" comes out at 0.4090: the mean, to within rounding.
+    With a bandwidth proportional to the spread of the ratios it recovers 0.20 exactly at
+    phi = 0.3 and 0.5, and 0.2721 at the published default of phi = 1, which is ordinary
+    kernel over-smoothing rather than a collapse.
+    """
+    from mendelian_randomisation import _weighted_mode_point
+
+    insts = [Instrument(f"rs{k}", "A", "G", 0.3, 0.2, 0.025, 1e-10,
+                        0.2 * r, 0.02, 0.01, 64.0)
+             for k, r in enumerate([0.2] * 9 + [0.8] * 6)]
+    ratios = np.array([i.beta_outcome / i.beta_exposure for i in insts])
+    weights = np.array([1.0 / (i.se_outcome / abs(i.beta_exposure)) for i in insts])
+    mean = ivw(insts).estimate
+
+    absolute = _weighted_mode_point(ratios, weights, 0.5)
+    proportional = _weighted_mode_point(ratios, weights, 0.5 * float(ratios.std()))
+
+    assert abs(absolute - mean) < 0.05, (absolute, mean)      # collapsed onto the mean
+    assert proportional == pytest.approx(0.20, abs=0.02)      # found the larger camp
+    assert abs(proportional - mean) > 0.15
+
+    # and the shipped default is scale-free, which the absolute one was not
+    scaled = [Instrument(i.snp, i.effect_allele, i.other_allele, i.eaf, i.beta_exposure,
+                         i.se_exposure, i.pval_exposure, i.beta_outcome * 100,
+                         i.se_outcome * 100, i.pval_outcome, i.f_statistic)
+              for i in insts]
+    a = weighted_mode(insts, n_boot=100).estimate
+    b = weighted_mode(scaled, n_boot=100).estimate / 100
+    assert a == pytest.approx(b, rel=0.05), (a, b)


### PR DESCRIPTION
## TL;DR

Housekeeping on the `mendelian-randomisation` skill to bring three estimators in line with the TwoSampleMR conventions they cite. Below 3 instruments, MR-Egger, weighted median and weighted mode now report "not applicable" instead of a number, as TwoSampleMR does; the weighted mode and the Steiger test follow their papers term by term; and four PubMed links in the citations list are corrected. The 30-instrument demo is unchanged except for the weighted mode's standard error, which is now the paper's bootstrap. Nothing here changes a result for a well-conditioned multi-instrument analysis.

## Summary

In a few edge cases (fewer than 3 instruments, near-identical exposure effects) three estimators returned a value where the estimator is not defined. This PR makes each say so instead, and brings the weighted mode and the Steiger test into line with their cited papers as implemented in TwoSampleMR. Every changed term is named below with the function it follows, so it can be checked against the reference rather than against this description.

- **MR-Egger** below 3 instruments, or with exposure effects too close to identical to identify a slope, is reported as not applicable with the reason. Previously it ran regardless, and at one instrument the value it returned was numerically meaningless.
- **Weighted median and weighted mode** below 3 instruments are likewise reported as not applicable. This is the one change that goes beyond the original defects; the reason is given below.
- **Steiger** no longer depends on the units the outcome is reported in.
- **Weighted mode** uses the paper's bandwidth rule, weights, ratio SE, and bootstrap standard error.
- Four of the eight PMIDs in `## Citations` pointed at unrelated papers; corrected and verified.

The 30-instrument demo is unchanged for IVW, MR-Egger and Weighted Median to the printed precision; Weighted Mode moves from 0.5989 (se 0.0144) to 0.6031 (se 0.0705). `SKILL.md`'s example output was regenerated from the demo and matches it row for row.

## What this fixes

### MR-Egger with fewer than 3 instruments

Egger fits a slope and an intercept, so with one or two instruments there is no residual degree of freedom. At one instrument the denominator `sum_w*sum_wbx2 - sum_wbx**2` is algebraically zero but computed as the difference of two nearly equal numbers, so it lands on a rounding remainder of arbitrary sign; the `abs(denom) < 1e-300` guard caught it only sometimes. Reproduced on the shipped code with one instrument:

```
method     estimate   se               ci_lower        ci_upper
MR-Egger   0.000000   9268190.002368   -18165652.40    18165652.40
```

The commit that introduced the guard (`bc7b91f`) measured the three outcomes over 5,000 random single-instrument inputs: the guard firing (~45%), `math.sqrt` raising and the process exiting non-zero with the IVW already computed discarded (~27%), and a finite slope with a standard error in the millions written to every output (~27%). At two instruments the run exited 0 having written `"se": Infinity`, which is not valid JSON.

**Change.** Below 3 instruments the estimator is reported as `{"method": "MR-Egger", "applicable": false, "reason": ..., "n_snps": n}` with no numeric fields, as `not_applicable` in every numeric column of `mr_results.tsv` with a `note`, as a named absence in the report, and with no line or legend entry in the scatter plot. `result.json` is written with `allow_nan=False` so a future non-finite fails loudly rather than shipping. The regression itself uses the centered form of the denominator, `sum_w * sum_i w_i (bx_i - xbar_w)^2`, which cannot go negative and is exactly zero when every exposure effect is equal; and a dimensionless conditioning test, `denom / (sum_w * sum_wbx2)` against `sqrt(machine epsilon)`, written as `not (rel > t)` so a NaN (reachable from a zero outcome SE) is refused. TwoSampleMR `mr_egger_regression` returns NA below 3 complete SNPs. Bowden, Davey Smith & Burgess 2015 (doi:10.1093/ije/dyv080; PMID 26050253).

### Weighted median and weighted mode with fewer than 3 instruments

TwoSampleMR declines all three sensitivity estimators below 3 SNPs, not only Egger:

```r
mr_egger_regression:  if (sum(!is.na(b_exp) & ...) < 3) return(nulllist)
mr_weighted_median:   if (sum(!is.na(b_exp) & ...) < 3) return(list(b = NA, se = NA, pval = NA, nsnp = NA))
mr_mode:              if (nrow(dat) < 3) { warning("Need at least 3 SNPs"); return(NULL) }
```

The median and the mode are order statistics of the ratios; with one instrument each returns the single ratio it was given. On the shipped code, one instrument produced

```
IVW               0.500000   se 0.100000
MR-Egger          0.000000   se 9268190
Weighted Median   0.500000   se 0.098872
Weighted Mode     0.498999   se 0.200000
```

and the report counted the three as agreeing with IVW: "Sensitivity analyses show consistent estimates across IVW, MR-Egger, weighted median, and weighted mode, supporting a robust causal inference." The median and mode rows restate the single Wald ratio. Now:

```
IVW               0.500000   se 0.100000
MR-Egger          not_applicable   note: requires at least 3 instruments; this analysis has 1
Weighted Median   not_applicable
Weighted Mode     not_applicable
```

and the report says: "No sensitivity estimator applies to this instrument set, so the IVW estimate stands alone and is not corroborated." IVW is the one estimator defined at n = 1, where it is the Wald ratio.

### Steiger directionality

The test compares the fraction of variance the instruments explain in the exposure against the fraction they explain in the outcome. The proper quantity is `r2 = 2p(1-p) * beta^2 / Var(trait)`. The code had the numerator without the denominator, so the two sides were compared in the traits' own units, and the verdict moved with a unit change: the same ten instruments read "correct direction" with the outcome at x1 and "REVERSED" at x3, x10 and x100, with p near zero on both sides.

The input format carries no trait variance, so `r2` is obtained from beta, se and n instead, as TwoSampleMR `get_r_from_bsen` does: `F = (b/se)^2; r2 = F / (n - 2 + F)`. That is the same quantity, with the standard error supplying the trait variance the input does not carry, and it is unit-free because beta and se rescale together. `Instrument` gains optional `n_exposure` / `n_outcome`, read from the input JSON when present.

- With sample sizes: `r = sqrt(sum r2)` per side and the test for two independent correlations, Fisher's z-transform with `sqrt(1/(n1-3) + 1/(n2-3))`, per-instrument n aggregated by the mean, as TwoSampleMR `mr_steiger` does through `psych::r.test`. The paper states the one-sample form (Steiger's Z for correlated correlations); its two-sample implementation uses the independent-samples test, and so does this.
- Without sample sizes: the direction is read from `sum(z^2)` under the stated assumption that the two studies are of comparable size, with that assumption in a `steiger_note`, and the p-value is `null`.

Two things worth stating plainly. This removes an artefact; it does not make the test powerful for a molecular exposure against a complex-disease outcome, where the outcome-side `r2` is smaller than the exposure-side almost regardless of causation (a cis-eQTL can explain a large share of a gene's expression; a disease SNP explains a fraction of a percent, before phenotyping noise). Hemani 2017 discusses the measurement-error bias in the same direction. In that setting "correct" carries little information and "REVERSED" is the informative verdict. And the conversion is the continuous-trait one; for a binary outcome it is approximate, as TwoSampleMR's own warning says, and the stopgap is to pass an effective n. Hemani, Tilling & Davey Smith 2017 (doi:10.1371/journal.pgen.1007081; PMID 29149188).

**A question for review.** The previous p-value came from `se_diff = sqrt(r2_exp + r2_out) * 0.01`. We could not find the 0.01 in the paper or in TwoSampleMR. If it has a source, we would rather keep it and would like to know.

### Weighted mode

The standard error was `2 / sum(|bx|/sy)`, a function of the instrument count and the outcome SEs and not of the ratios: 0.0138 for fifteen instruments that all agree, and 0.0138 for the same fifteen split into two camps. The bandwidth was an absolute 0.5, wider than the spread of ordinary ratios, so the kernels merged and the "mode" sat near the weighted mean (0.410 against a mean of 0.438 on a 9-to-6 split whose mode is 0.20).

Now the paper's weighted MBE as TwoSampleMR `mr_mode` implements it (Hartwig, Davey Smith & Bowden 2017, doi:10.1093/ije/dyx102; PMID 29040600):
- ratio SE by the second-order delta method, `sqrt(sy^2/bx^2 + by^2*sx^2/bx^4)`, the "not assuming NOME" column the reference uses for the weighted mode;
- standardised inverse-variance weights, eq. 5, `w_j = se_j^-2 / sum(se^-2)` (the skill had `1/se`);
- bandwidth `h = phi * s` with the modified Silverman rule, eq. 7, `s = 0.9 * min(sd, 1.4826*mad) / L^(1/5)`, floored at 1e-8, default `phi = 1`;
- parametric bootstrap, each ratio redrawn from N(ratio, se_ratio) with the bandwidth recomputed per draw; SE = `1.4826 * mad` of the draws; p from a t distribution on L - 1 degrees of freedom.

On the 9-to-6 split the mode is now 0.196 (the larger camp) and the two datasets above get SEs of 0.060 and 0.038.

### Citations

Four of the eight PMIDs in `## Citations` resolved to unrelated records: an ApoE/stroke meta-analysis for Burgess 2013, a biomimetic-catalysis paper for Bowden 2016, a circadian food-intake study for Hemani 2017, and the JAMA STROBE-MR statement where the text cites BMJ 375:n2233. The author, year and journal text beside each link were correct, which is what makes this class of error easy to miss on review and a known failure mode when citations are written from recall, LLM-assisted or not. Each replacement was resolved through Europe PMC and matched on authors, title, journal and year. The check we run before any citation lands is public and CC0: https://gist.github.com/madaraviv/97d4b98c17eccba99804108c53fc3fc7

## Not changed, for awareness

- The weighted median's weights use the first-order ratio variance `sy^2/bx^2`; `mr_weighted_median` uses the second-order form. Left as is because the PR does not otherwise touch the median.
- MR-Egger here does not orient instruments to a positive exposure effect before the regression; `mr_egger_regression` does.

Either can be added if wanted.

## Verification

- 42 tests in `skills/mendelian-randomisation/tests/`, on Python 3.11 and 3.14, 0 warnings.
- Each guard observed failing with it removed: 8 mutations for the Egger change, 9 for the weighted-mode/Steiger change (bandwidth rule, weight exponent, ratio-SE order, MAD vs sd, t vs normal, n - 2, mean vs min, and each n < 3 guard).
- `agentskills validate skills/mendelian-randomisation`: valid. `python clawbio.py list` loads.
- The demo was regenerated and diffed against `SKILL.md`'s example table.
- The `test (3.11)` job fails on `tests/test_public_claims.py::test_demo_and_cli_counts_match_catalog` (README says 91 demos, catalog has 92). That test fails identically on `main` at `1fcecb7`, and this PR does not touch README or the catalog.

## Consumers

Anything that reads `result.json` and expects `estimate` and `se` on every row must check `applicable` first; it is in the Gotchas.

🤖 Generated with [Claude Code](https://claude.com/claude-code); reviewed by Aviv Madar (@madaraviv)

